### PR TITLE
feat!: improve predicate testing and parsing

### DIFF
--- a/crates/predicate/src/errors.rs
+++ b/crates/predicate/src/errors.rs
@@ -16,6 +16,10 @@ pub enum PredicateError {
     #[error("invalid predicate type {0}")]
     InvalidPredicateType(u8),
 
+    /// Missing predicate type identifier.
+    #[error("missing predicate type")]
+    MissingPredicateType,
+
     // === Parsing Errors ===
     /// Predicate condition parsing failed.
     #[error("predicate parsing failed for type {id}: {reason}")]

--- a/crates/predicate/src/type_ids.rs
+++ b/crates/predicate/src/type_ids.rs
@@ -86,3 +86,22 @@ impl fmt::Display for PredicateTypeId {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::PredicateTypeId;
+
+    #[test]
+    fn test_roundtrip() {
+        // Check that all expected type IDs are canonical
+        let valid_bytes = [0, 1, 10, 20];
+        for byte in valid_bytes {
+            let parsed = PredicateTypeId::try_from(byte).unwrap();
+            assert_eq!(parsed.as_u8(), byte);
+        }
+
+        // Check an arbitrary invalid type ID
+        let invalid_byte = 30;
+        assert!(PredicateTypeId::try_from(invalid_byte).is_err());
+    }
+}

--- a/crates/predicate/src/verifiers/sp1_groth16.rs
+++ b/crates/predicate/src/verifiers/sp1_groth16.rs
@@ -147,7 +147,7 @@ mod tests {
         let res = verifier.verify(&larger_predicate, &claim, &witness);
         assert_predicate_parsing_failed(res, PredicateTypeId::Sp1Groth16);
 
-        // Test with shorter predicate
+        // Test with shorter predicates
         let shorter_predicate = &predicate[..predicate.len() - 5];
         let res = verifier.verify(shorter_predicate, &claim, &witness);
         assert_predicate_parsing_failed(res, PredicateTypeId::Sp1Groth16);
@@ -169,14 +169,23 @@ mod tests {
         let (predicate, claim, mut witness) = load_predicate_claim_witness();
         let verifier = Sp1Groth16Verifier;
 
-        // Test with larger witness
+        // Test with larger witnesses
         let mut larger_witness = witness.clone();
         larger_witness.extend_from_slice(&[0u8; 10]);
         let res = verifier.verify(&predicate, &claim, &larger_witness);
         assert_witness_parsing_failed(res, PredicateTypeId::Sp1Groth16);
 
-        // Test with shorter witness
+        let mut larger_witness = witness.clone();
+        larger_witness.extend_from_slice(&[0u8; 1]);
+        let res = verifier.verify(&predicate, &claim, &larger_witness);
+        assert_witness_parsing_failed(res, PredicateTypeId::Sp1Groth16);
+
+        // Test with shorter witnesses
         let shorter_witness = &witness[..witness.len() - 5];
+        let res = verifier.verify(&predicate, &claim, shorter_witness);
+        assert_witness_parsing_failed(res, PredicateTypeId::Sp1Groth16);
+
+        let shorter_witness = &witness[1..];
         let res = verifier.verify(&predicate, &claim, shorter_witness);
         assert_witness_parsing_failed(res, PredicateTypeId::Sp1Groth16);
 
@@ -191,14 +200,23 @@ mod tests {
         let (predicate, mut claim, witness) = load_predicate_claim_witness();
         let verifier = Sp1Groth16Verifier;
 
-        // Test with larger claim
+        // Test with larger claims
         let mut larger_claim = claim.clone();
         larger_claim.extend_from_slice(&[0u8; 10]);
         let res = verifier.verify(&predicate, &larger_claim, &witness);
         assert_verification_failed(res, PredicateTypeId::Sp1Groth16);
 
-        // Test with shorter claim
+        let mut larger_claim = claim.clone();
+        larger_claim.extend_from_slice(&[0u8; 1]);
+        let res = verifier.verify(&predicate, &larger_claim, &witness);
+        assert_verification_failed(res, PredicateTypeId::Sp1Groth16);
+
+        // Test with shorter claims
         let shorter_claim = &claim[..claim.len() - 2];
+        let res = verifier.verify(&predicate, shorter_claim, &witness);
+        assert_verification_failed(res, PredicateTypeId::Sp1Groth16);
+
+        let shorter_claim = &claim[1..];
         let res = verifier.verify(&predicate, shorter_claim, &witness);
         assert_verification_failed(res, PredicateTypeId::Sp1Groth16);
 


### PR DESCRIPTION
## Description

Recent work in #15 introduces predicates. As noted in a review, there are a few places where testing and parsing can be improved.

In addition to adding and improving tests, this PR updates `PredicateKey` encoding in a breaking way, by making an empty encoding invalid. This makes `PredicateKey` encodings canonical and removes a possible edge case footgun.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

This PR does **not** address all comments from the corresponding #15 review. Notably, it does not yet add parser fuzzing, nor does it break out SP1 predicates by hash function type.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A
