### PR TITLE
merkle: cleanup and add `new_repeated`

### DIFF
--- a/crates/merkle/Cargo.toml
+++ b/crates/merkle/Cargo.toml
@@ -41,6 +41,7 @@ ssz = [
   "dep:tree_hash_derive",
   "dep:ssz_codegen",
 ]
+legacy_compact = []
 
 [[bench]]
 name = "mmr_comparison"

--- a/crates/merkle/benches/mmr_comparison.rs
+++ b/crates/merkle/benches/mmr_comparison.rs
@@ -2,12 +2,14 @@
 #![allow(missing_docs)]
 #![allow(unused_crate_dependencies)]
 
+#[cfg(not(feature = "legacy_compact"))]
+compile_error!("build this target with `--features legacy_compact`");
+
 // stupid linter issue
 use criterion as _;
 use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use sha2::{Digest, Sha256};
-use strata_merkle::mmr::CompactMmr64;
-use strata_merkle::{Mmr, Sha256Hasher};
+use strata_merkle::{CompactMmr64, Mmr, Sha256Hasher};
 
 type Hash32 = [u8; 32];
 

--- a/crates/merkle/src/codec_impl.rs
+++ b/crates/merkle/src/codec_impl.rs
@@ -51,7 +51,6 @@ mod tests {
     use strata_codec::{decode_buf_exact, encode_to_vec};
 
     use super::*;
-    use crate::Mmr;
 
     type H = [u8; 32];
 

--- a/crates/merkle/src/codec_impl.rs
+++ b/crates/merkle/src/codec_impl.rs
@@ -4,45 +4,7 @@
 use strata_codec::{Codec, CodecError, Decoder, Encoder, VarVec};
 
 use crate::hasher::MerkleHash;
-use crate::mmr::CompactMmr64;
 use crate::proof::{MerkleProof, RawMerkleProof};
-
-// CompactMmr64
-
-impl<H> Codec for CompactMmr64<H>
-where
-    H: MerkleHash + Codec,
-{
-    fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
-        let entries = u64::decode(dec)?;
-        let cap_log2 = u8::decode(dec)?;
-        // Number of roots equals popcount of entries (one per peak)
-        let roots_len = entries.count_ones() as usize;
-        let mut roots = Vec::with_capacity(roots_len);
-        for _ in 0..roots_len {
-            roots.push(H::decode(dec)?);
-        }
-        Ok(Self {
-            entries,
-            cap_log2,
-            roots,
-        })
-    }
-
-    fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
-        self.entries.encode(enc)?;
-        self.cap_log2.encode(enc)?;
-        // Validate roots length matches expected popcount to avoid misalignment
-        let expected = self.entries.count_ones() as usize;
-        if self.roots.len() != expected {
-            return Err(CodecError::MalformedField("CompactMmr64.roots"));
-        }
-        for h in &self.roots {
-            h.encode(enc)?;
-        }
-        Ok(())
-    }
-}
 
 // RawMerkleProof
 
@@ -78,28 +40,20 @@ where
 
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         self.inner.encode(enc)?;
-        self.index.encode(enc)
+        self.index.encode(enc)?;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
-    use sha2::Sha256;
     use strata_codec::{decode_buf_exact, encode_to_vec};
 
     use super::*;
     use crate::Mmr;
 
     type H = [u8; 32];
-    type Hasher = crate::Sha256Hasher;
-
-    fn make_hashes(n: usize) -> Vec<H> {
-        use sha2::Digest;
-        (0..n)
-            .map(|i| Sha256::digest(i.to_be_bytes()).into())
-            .collect()
-    }
 
     fn arb_hash() -> impl Strategy<Value = H> {
         any::<[u8; 32]>()
@@ -124,19 +78,6 @@ mod tests {
             let bytes = encode_to_vec(&proof).expect("serialize proof");
             let de: MerkleProof<H> = decode_buf_exact(&bytes).expect("deserialize proof");
             prop_assert_eq!(proof, de);
-        }
-
-        #[test]
-        fn roundtrip_compact_mmr(num_leaves in 1usize..=64) {
-            let mut mmr = CompactMmr64::<H>::new(8);
-            let leaves = make_hashes(num_leaves);
-            for h in leaves.iter() {
-                Mmr::<Hasher>::add_leaf(&mut mmr, *h).expect("add leaf");
-            }
-
-            let bytes = encode_to_vec(&mmr).expect("serialize compact");
-            let de: CompactMmr64<H> = decode_buf_exact(&bytes).expect("deserialize compact");
-            prop_assert_eq!(mmr, de);
         }
     }
 }

--- a/crates/merkle/src/ext.rs
+++ b/crates/merkle/src/ext.rs
@@ -311,7 +311,7 @@ mod tests {
 
     use super::*;
     use crate::Sha256Hasher;
-    use crate::mmr::CompactMmr64;
+    use crate::legacy_compact_mmr::CompactMmr64;
     use crate::proof::MerkleProof;
     use crate::traits::MmrState;
 

--- a/crates/merkle/src/ext.rs
+++ b/crates/merkle/src/ext.rs
@@ -12,6 +12,10 @@ use crate::traits::MmrState;
 /// are hashed. The blanket implementation provides the actual MMR algorithms that
 /// work with any state backend implementing [`MmrState`].
 pub trait Mmr<MH: MerkleHasher>: MmrState<MH::Hash> {
+    /// Creates a new instance with some arbitrary number of repeated leafs
+    /// pre-inserted.
+    fn new_repeated(leaf: MH::Hash, count: u64) -> Self;
+
     /// Returns if the MMR is empty.
     fn is_empty(&self) -> bool;
 
@@ -69,6 +73,32 @@ where
     MH: MerkleHasher,
     S: MmrState<MH::Hash>,
 {
+    fn new_repeated(leaf: MH::Hash, count: u64) -> Self {
+        let mut this = Self::new_empty();
+
+        let mut cur = leaf;
+        for i in 0..u64::BITS {
+            let shr = count >> i;
+
+            // If the bit is set then set the value.
+            if shr & 1 != 0 {
+                this.set_peak(i as u8, cur);
+            }
+
+            // If there's no more set bits then break so that we don't keep
+            // hashing uselessly.
+            if shr == 0 {
+                break;
+            }
+
+            // We hash on every iteration because we need to compute the root at
+            // each step *anyways*.
+            cur = MH::hash_node(cur, cur);
+        }
+
+        this
+    }
+
     fn is_empty(&self) -> bool {
         self.num_entries() == 0
     }
@@ -773,6 +803,33 @@ mod tests {
                 state_iter[i].0 > state_iter[i - 1].0,
                 "peak heights should be in ascending order"
             );
+        }
+    }
+
+    #[test]
+    fn test_new_repeated_matches_add_leaf() {
+        let leaf = make_hash(b"repeated_leaf");
+
+        let mut acc = CompactMmr64::<Hash32>::new(64);
+
+        for count in 0..=10000 {
+            let batch = <CompactMmr64<Hash32> as Mmr<Sha256Hasher>>::new_repeated(leaf, count);
+
+            assert_eq!(
+                acc.num_entries(),
+                batch.num_entries(),
+                "test: num_entries mismatch for count={count}"
+            );
+
+            assert!(
+                acc.iter_peaks()
+                    .zip(batch.iter_peaks())
+                    .all(|((h1, v1), (h2, v2))| h1 == h2 && v1 == v2),
+                "test: peaks mismatch for count={count}"
+            );
+
+            // Add the leaf at the end so it's there for the next iteration.
+            Mmr::<Sha256Hasher>::add_leaf(&mut acc, leaf).unwrap();
         }
     }
 

--- a/crates/merkle/src/hasher.rs
+++ b/crates/merkle/src/hasher.rs
@@ -41,7 +41,7 @@ impl<const LEN: usize> MerkleHash for [u8; LEN] {
     }
 
     fn eq_ct(a: &Self, b: &Self) -> bool {
-        // Attempt to constant-time comparison.  This is *really hard* to do in
+        // Attempt at constant-time comparison.  This is *really hard* to do in
         // Rust, because LLVM likes to obliterate unnecessary instructions.
         //
         // I could use some of the more advanced libraries for this, but this

--- a/crates/merkle/src/legacy_compact_mmr.rs
+++ b/crates/merkle/src/legacy_compact_mmr.rs
@@ -1,0 +1,191 @@
+use crate::hasher::*;
+use crate::proof::*;
+use crate::traits::*;
+
+/// Compact representation of the MMR that can hold upto 2**64 elements.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
+)]
+pub struct CompactMmr64<H: MerkleHash> {
+    pub(crate) entries: u64,
+    pub(crate) cap_log2: u8,
+    pub(crate) roots: Vec<H>,
+}
+
+impl<H: MerkleHash> CompactMmr64<H> {
+    /// Creates a new empty CompactMmr64 with the specified capacity.
+    ///
+    /// # Arguments
+    /// * `cap_log2` - The log2 of the maximum capacity (max 64).
+    pub fn new(cap_log2: u8) -> Self {
+        Self {
+            entries: 0,
+            cap_log2,
+            roots: Vec::new(),
+        }
+    }
+
+    /// Gets the number of entries inserted into the MMR.
+    pub fn num_entries(&self) -> u64 {
+        self.entries
+    }
+
+    /// Verifies a single proof for a leaf.
+    ///
+    /// This method delegates to the unified [`Mmr::verify`](crate::Mmr::verify)
+    /// trait method.
+    pub fn verify<MH>(&self, proof: &MerkleProof<H>, leaf: &H) -> bool
+    where
+        MH: MerkleHasher<Hash = H>,
+    {
+        crate::Mmr::<MH>::verify(self, proof, leaf)
+    }
+
+    /// Given a peak index, gets the index in the `roots` field
+    /// corresponding to it.
+    #[inline(always)]
+    fn get_packed_index(&self, peak_idx: u8) -> Option<usize> {
+        let bit_mask = 1u64 << peak_idx;
+
+        // Check if this peak is set.
+        if (self.entries & bit_mask) == 0 {
+            return None;
+        }
+
+        // Count how many set bits are BELOW peak_idx.
+        // Roots are stored in forward order (lowest height first), so the
+        // index equals the number of peaks below this one.
+        let bits_below = (self.entries & (bit_mask - 1)).count_ones() as usize;
+        Some(bits_below)
+    }
+}
+
+impl<H: MerkleHash> MmrState<H> for CompactMmr64<H> {
+    fn new_empty() -> Self {
+        Self {
+            // This interface doesn't define a capacity since generally we
+            // actually just want to resize as needed.
+            cap_log2: 64,
+            entries: 0,
+            roots: Vec::new(),
+        }
+    }
+
+    fn max_num_peaks(&self) -> u8 {
+        self.cap_log2
+    }
+
+    fn num_entries(&self) -> u64 {
+        self.entries
+    }
+
+    fn num_present_peaks(&self) -> u8 {
+        self.entries.count_ones() as u8
+    }
+
+    fn get_peak(&self, i: u8) -> Option<&H> {
+        let packed_idx = self.get_packed_index(i)?;
+        self.roots.get(packed_idx)
+    }
+
+    fn set_peak(&mut self, i: u8, val: H) -> bool {
+        // Check if index is within bounds.
+        if i >= self.cap_log2 {
+            return false;
+        }
+
+        let bit_mask = 1u64 << i;
+        let is_currently_set = (self.entries & bit_mask) != 0;
+
+        if H::is_zero(&val) {
+            // Unsetting the peak.
+            if !is_currently_set {
+                return false; // Already unset.
+            }
+
+            // Find and remove from roots.
+            if let Some(packed_idx) = self.get_packed_index(i)
+                && packed_idx < self.roots.len()
+            {
+                self.roots.remove(packed_idx);
+                self.entries &= !bit_mask; // Clear the bit.
+                return true;
+            }
+
+            false
+        } else {
+            // Setting the peak.
+            if is_currently_set {
+                // Update existing peak in place.
+                if let Some(packed_idx) = self.get_packed_index(i)
+                    && let Some(root) = self.roots.get_mut(packed_idx)
+                {
+                    *root = val;
+                    return true;
+                }
+
+                false
+            } else {
+                // Insert new peak at correct position (maintaining forward order).
+                // Count how many set bits are *below* index i to find insertion point.
+                let bits_below = (self.entries & ((1u64 << i) - 1)).count_ones() as usize;
+
+                if bits_below <= self.roots.len() {
+                    self.roots.insert(bits_below, val);
+                    self.entries |= bit_mask; // Set the bit
+                    return true;
+                }
+
+                false
+            }
+        }
+    }
+
+    fn iter_peaks<'a>(&'a self) -> impl Iterator<Item = (u8, &'a H)> + 'a {
+        CompactMmr64PeaksIter {
+            remaining: self.entries,
+            original: self.entries,
+            roots: &self.roots,
+        }
+    }
+}
+
+/// Iterator that yields (peak_index, &hash) pairs from lowest to highest peak index for
+/// CompactMmr64.
+struct CompactMmr64PeaksIter<'a, H> {
+    /// Remaining bits to process (gets bits cleared as we iterate).
+    remaining: u64,
+
+    /// Original entries value (needed to compute packed index).
+    original: u64,
+
+    /// Reference to the roots array.
+    roots: &'a Vec<H>,
+}
+
+impl<'a, H> Iterator for CompactMmr64PeaksIter<'a, H> {
+    type Item = (u8, &'a H);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+
+        // Find the index of the lowest set bit.
+        let peak_idx = self.remaining.trailing_zeros() as u8;
+
+        // Clear the lowest set bit.
+        self.remaining &= self.remaining - 1;
+
+        // Compute the packed index using bit manipulation.
+        // Roots are stored in forward order (lowest height first), so the
+        // index equals the number of peaks below this one.
+        let bit_mask = 1u64 << peak_idx;
+        let bits_below = (self.original & (bit_mask - 1)).count_ones() as usize;
+
+        self.roots.get(bits_below).map(|root| (peak_idx, root))
+    }
+}

--- a/crates/merkle/src/lib.rs
+++ b/crates/merkle/src/lib.rs
@@ -1,25 +1,4 @@
-//! Merkle primitives and data structures.
-//!
-//! # MMR (Merkle Mountain Range)
-//!
-//! The primary MMR implementation is [`CompactMmr64`] with the [`Mmr`] extension trait.
-//!
-//! ```rust,ignore
-//! use strata_merkle::{CompactMmr64, Sha256Hasher, Mmr};
-//!
-//! let mut mmr = CompactMmr64::<[u8; 32]>::new(64);
-//! Mmr::<Sha256Hasher>::add_leaf(&mut mmr, leaf)?;
-//! Mmr::<Sha256Hasher>::verify(&mmr, &proof, &leaf);
-//! ```
-//!
-//! For SSZ-compatible types, use `Mmr64B32` which implements
-//! the [`MmrState`] trait and works with the same `Mmr` extension methods.
-//!
-//! # Modules
-//!
-//! - `hasher`: common hash and hasher traits/impls
-//! - `mmr`: [`CompactMmr64`] - compact MMR representation
-//! - `tree`: generic binary Merkle tree with proofs
+//! Merkle tree and merkle mountain range primitives, traits, etc.
 #![expect(
     clippy::declare_interior_mutable_const,
     reason = "Constants with interior mutability are needed for MMR implementation"

--- a/crates/merkle/src/lib.rs
+++ b/crates/merkle/src/lib.rs
@@ -35,17 +35,26 @@ use criterion as _;
 
 #[cfg(feature = "codec")]
 mod codec_impl;
-pub mod error;
-pub mod hasher;
-pub mod mmr;
-pub mod proof;
-pub mod tree;
 
+#[cfg(any(test, feature = "legacy_compact"))]
+mod legacy_compact_mmr;
+
+mod error;
 mod ext;
+mod hasher;
+mod mmr;
+mod proof;
 mod traits;
+mod tree;
 
-pub use ext::Mmr;
-pub use traits::MmrState;
+pub use error::*;
+pub use ext::*;
+pub use hasher::*;
+#[cfg(any(test, feature = "legacy_compact"))]
+pub use legacy_compact_mmr::*;
+pub use proof::*;
+pub use traits::*;
+pub use tree::*;
 
 // Include SSZ-generated types
 #[cfg(feature = "ssz")]
@@ -60,7 +69,6 @@ mod ssz_generated {
     include!(concat!(env!("OUT_DIR"), "/generated_ssz.rs"));
 }
 
-use hasher::{DigestMerkleHasher, DigestMerkleHasherNoPrefix};
 use sha2::Sha256;
 
 /// Merkle hash impl for SHA-256 `Digest` impl.
@@ -71,13 +79,8 @@ pub type Sha256NoPrefixHasher = DigestMerkleHasherNoPrefix<Sha256, 32>;
 
 /// Compatibility alias for the primary hasher trait used across Merkle data structures.
 pub use hasher::MerkleHasher as StrataMerkle;
-// Common re-exports for ergonomic access at the crate root.
-pub use hasher::{MerkleHash, MerkleHasher};
-pub use mmr::CompactMmr64;
-pub use proof::{MerkleProof, ProofData, ProofDataMut, RawMerkleProof};
 // Re-export SSZ-generated concrete types (32-byte hash versions)
 #[cfg(feature = "ssz")]
 pub use ssz_generated::ssz::mmr::*;
 #[cfg(feature = "ssz")]
 pub use ssz_generated::ssz::proof::*;
-pub use tree::BinaryMerkleTree;

--- a/crates/merkle/src/mmr.rs
+++ b/crates/merkle/src/mmr.rs
@@ -204,7 +204,6 @@ mod tests {
         ssz_types::FixedBytes,
     };
 
-    use super::CompactMmr64;
     use crate::proof::MerkleProof;
     use crate::traits::MmrState;
     use crate::{CompactMmr64, Mmr, Sha256Hasher};

--- a/crates/merkle/src/mmr.rs
+++ b/crates/merkle/src/mmr.rs
@@ -1,198 +1,34 @@
 //! Merkle Mountain Range (MMR) accumulator and related types.
 
-use crate::hasher::{MerkleHash, MerkleHasher};
-use crate::proof::MerkleProof;
-use crate::traits::MmrState;
-
-/// Compact representation of the MMR that can hold upto 2**64 elements.
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(
-    feature = "borsh",
-    derive(borsh::BorshSerialize, borsh::BorshDeserialize)
-)]
-pub struct CompactMmr64<H: MerkleHash> {
-    pub(crate) entries: u64,
-    pub(crate) cap_log2: u8,
-    pub(crate) roots: Vec<H>,
-}
-
-impl<H: MerkleHash> CompactMmr64<H> {
-    /// Creates a new empty CompactMmr64 with the specified capacity.
-    ///
-    /// # Arguments
-    /// * `cap_log2` - The log2 of the maximum capacity (max 64).
-    pub fn new(cap_log2: u8) -> Self {
-        Self {
-            entries: 0,
-            cap_log2,
-            roots: Vec::new(),
-        }
-    }
-
-    /// Gets the number of entries inserted into the MMR.
-    pub fn num_entries(&self) -> u64 {
-        self.entries
-    }
-
-    /// Verifies a single proof for a leaf.
-    ///
-    /// This method delegates to the unified [`Mmr::verify`](crate::Mmr::verify)
-    /// trait method.
-    pub fn verify<MH>(&self, proof: &MerkleProof<H>, leaf: &H) -> bool
-    where
-        MH: MerkleHasher<Hash = H>,
-    {
-        crate::Mmr::<MH>::verify(self, proof, leaf)
-    }
-
-    /// Given a peak index, gets the index in the `roots` field
-    /// corresponding to it.
-    #[inline(always)]
-    fn get_packed_index(&self, peak_idx: u8) -> Option<usize> {
-        let bit_mask = 1u64 << peak_idx;
-
-        // Check if this peak is set.
-        if (self.entries & bit_mask) == 0 {
-            return None;
-        }
-
-        // Count how many set bits are BELOW peak_idx.
-        // Roots are stored in forward order (lowest height first), so the
-        // index equals the number of peaks below this one.
-        let bits_below = (self.entries & (bit_mask - 1)).count_ones() as usize;
-        Some(bits_below)
-    }
-}
-
-impl<H: MerkleHash> MmrState<H> for CompactMmr64<H> {
-    fn max_num_peaks(&self) -> u8 {
-        self.cap_log2
-    }
-
-    fn num_entries(&self) -> u64 {
-        self.entries
-    }
-
-    fn num_present_peaks(&self) -> u8 {
-        self.entries.count_ones() as u8
-    }
-
-    fn get_peak(&self, i: u8) -> Option<&H> {
-        let packed_idx = self.get_packed_index(i)?;
-        self.roots.get(packed_idx)
-    }
-
-    fn set_peak(&mut self, i: u8, val: H) -> bool {
-        // Check if index is within bounds.
-        if i >= self.cap_log2 {
-            return false;
-        }
-
-        let bit_mask = 1u64 << i;
-        let is_currently_set = (self.entries & bit_mask) != 0;
-
-        if H::is_zero(&val) {
-            // Unsetting the peak.
-            if !is_currently_set {
-                return false; // Already unset.
-            }
-
-            // Find and remove from roots.
-            if let Some(packed_idx) = self.get_packed_index(i)
-                && packed_idx < self.roots.len()
-            {
-                self.roots.remove(packed_idx);
-                self.entries &= !bit_mask; // Clear the bit.
-                return true;
-            }
-
-            false
-        } else {
-            // Setting the peak.
-            if is_currently_set {
-                // Update existing peak in place.
-                if let Some(packed_idx) = self.get_packed_index(i)
-                    && let Some(root) = self.roots.get_mut(packed_idx)
-                {
-                    *root = val;
-                    return true;
-                }
-
-                false
-            } else {
-                // Insert new peak at correct position (maintaining forward order).
-                // Count how many set bits are *below* index i to find insertion point.
-                let bits_below = (self.entries & ((1u64 << i) - 1)).count_ones() as usize;
-
-                if bits_below <= self.roots.len() {
-                    self.roots.insert(bits_below, val);
-                    self.entries |= bit_mask; // Set the bit
-                    return true;
-                }
-
-                false
-            }
-        }
-    }
-
-    fn iter_peaks<'a>(&'a self) -> impl Iterator<Item = (u8, &'a H)> + 'a {
-        CompactMmr64PeaksIter {
-            remaining: self.entries,
-            original: self.entries,
-            roots: &self.roots,
-        }
-    }
-}
-
-/// Iterator that yields (peak_index, &hash) pairs from lowest to highest peak index for
-/// CompactMmr64.
-struct CompactMmr64PeaksIter<'a, H> {
-    /// Remaining bits to process (gets bits cleared as we iterate).
-    remaining: u64,
-
-    /// Original entries value (needed to compute packed index).
-    original: u64,
-
-    /// Reference to the roots array.
-    roots: &'a Vec<H>,
-}
-
-impl<'a, H> Iterator for CompactMmr64PeaksIter<'a, H> {
-    type Item = (u8, &'a H);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        }
-
-        // Find the index of the lowest set bit.
-        let peak_idx = self.remaining.trailing_zeros() as u8;
-
-        // Clear the lowest set bit.
-        self.remaining &= self.remaining - 1;
-
-        // Compute the packed index using bit manipulation.
-        // Roots are stored in forward order (lowest height first), so the
-        // index equals the number of peaks below this one.
-        let bit_mask = 1u64 << peak_idx;
-        let bits_below = (self.original & (bit_mask - 1)).count_ones() as usize;
-
-        self.roots.get(bits_below).map(|root| (peak_idx, root))
-    }
-}
-
 #[cfg(feature = "ssz")]
 mod mmr64b32 {
     use ssz_types::{FixedBytes, VariableList};
 
-    use super::*;
-    use crate::{Mmr, Sha256Hasher};
+    #[cfg(feature = "legacy_compact")]
+    use crate::CompactMmr64;
+    use crate::ext::*;
+    use crate::hasher::*;
+    use crate::traits::*;
+    use crate::{MAX_MMR_PEAKS, Sha256Hasher};
 
     type Hash32 = <Sha256Hasher as MerkleHasher>::Hash;
 
     impl crate::Mmr64B32 {
+        /// Gets the number of entries inserted into the MMR.
+        pub fn num_entries(&self) -> u64 {
+            self.entries
+        }
+
+        /// Verifies a single proof for a leaf.
+        ///
+        /// This method delegates to the unified [`Mmr::verify`](crate::Mmr::verify)
+        /// trait method using Sha256Hasher as the merkle hasher implementation.
+        pub fn verify(&self, proof: &crate::MerkleProofB32, leaf: &[u8; 32]) -> bool {
+            Mmr::<Sha256Hasher>::verify(self, proof, leaf)
+        }
+
         /// Creates a concrete MMR from a generic CompactMmr64
+        #[cfg(feature = "legacy_compact")]
         pub fn from_generic(mmr: &CompactMmr64<Hash32>) -> Self {
             let roots: Vec<_> = mmr
                 .roots
@@ -206,6 +42,7 @@ mod mmr64b32 {
         }
 
         /// Converts to a generic CompactMmr64
+        #[cfg(feature = "legacy_compact")]
         pub fn to_generic(&self) -> CompactMmr64<Hash32> {
             CompactMmr64 {
                 entries: self.entries,
@@ -213,24 +50,18 @@ mod mmr64b32 {
                 roots: self.roots.iter().map(|fb| fb.0).collect(),
             }
         }
-
-        /// Gets the number of entries inserted into the MMR.
-        pub fn num_entries(&self) -> u64 {
-            self.entries
-        }
-
-        /// Verifies a single proof for a leaf.
-        ///
-        /// This method delegates to the unified [`Mmr::verify`](crate::Mmr::verify)
-        /// trait method using Sha256Hasher as the merkle hasher implementation.
-        pub fn verify(&self, proof: &crate::MerkleProofB32, leaf: &[u8; 32]) -> bool {
-            Mmr::<Sha256Hasher>::verify(self, proof, leaf)
-        }
     }
 
     impl MmrState<Hash32> for crate::Mmr64B32 {
+        fn new_empty() -> Self {
+            Self {
+                entries: 0,
+                roots: VariableList::empty(),
+            }
+        }
+
         fn max_num_peaks(&self) -> u8 {
-            64
+            MAX_MMR_PEAKS as u8
         }
 
         fn num_entries(&self) -> u64 {
@@ -376,7 +207,7 @@ mod tests {
     use super::CompactMmr64;
     use crate::proof::MerkleProof;
     use crate::traits::MmrState;
-    use crate::{Mmr, Sha256Hasher};
+    use crate::{CompactMmr64, Mmr, Sha256Hasher};
 
     type Hash32 = [u8; 32];
 

--- a/crates/merkle/src/proof.rs
+++ b/crates/merkle/src/proof.rs
@@ -524,9 +524,7 @@ mod proofb32 {
 mod tests {
     #[cfg(feature = "ssz")]
     use {
-        crate::{
-            MerkleProof, MerkleProofB32, Mmr, RawMerkleProofB32, Sha256Hasher, mmr::CompactMmr64,
-        },
+        crate::{CompactMmr64, MerkleProof, MerkleProofB32, Mmr, RawMerkleProofB32, Sha256Hasher},
         sha2::{Digest, Sha256},
         ssz::{Decode, Encode},
         ssz_types::FixedBytes,

--- a/crates/merkle/src/traits.rs
+++ b/crates/merkle/src/traits.rs
@@ -4,6 +4,9 @@ use crate::hasher::MerkleHash;
 
 /// Abstracts over an MMR accumulator's state.
 pub trait MmrState<H: MerkleHash> {
+    /// Creates a new empty MMR state instance.
+    fn new_empty() -> Self;
+
     /// Gets the maximum number of peaks we can store.
     fn max_num_peaks(&self) -> u8;
 

--- a/crates/merkle/src/tree.rs
+++ b/crates/merkle/src/tree.rs
@@ -4,7 +4,7 @@
 //! functionality: construct from leaves, generate inclusion proofs, and verify
 //! those proofs.
 use crate::error::MerkleError;
-use crate::hasher::{MerkleHash, MerkleHasher};
+use crate::hasher::*;
 use crate::proof::MerkleProof;
 
 /// Simple binary Merkle tree backed by a flattened node array.

--- a/crates/merkle/ssz/proof.ssz
+++ b/crates/merkle/ssz/proof.ssz
@@ -15,7 +15,7 @@ class RawMerkleProofB32(Container):
 ### If the MMR or tree that produced this proof is updated, then this proof has
 ### to be updated as well.
 class MerkleProofB32(Container):
-    ### Sibling hashes required for proof.
-    inner: RawMerkleProofB32
     ### Index of the element for which this proof is for.
     index: uint64
+    ### Sibling hashes required for proof.
+    inner: RawMerkleProofB32


### PR DESCRIPTION
## Description

This PR does three things:

* make `CompactMmr64` only available if the new `legacy_compact` feature is enabled, we should only be using the SSZ version everywhere now, doing some reorganization in the process
* STR-2783: adds a `new_repeated` fn to create efficiently create MMR instances containing lots of repeated elements, with an exhaustive test
* makes everything be exported at the crate root and hides the modules themselves

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
