### PR TITLE
feat(service): make CommandHandle::new public

### DIFF
--- a/crates/service/src/command.rs
+++ b/crates/service/src/command.rs
@@ -19,8 +19,12 @@ pub struct CommandHandle<M> {
 }
 
 impl<M> CommandHandle<M> {
-    /// Constructs a new instance.
-    pub(crate) fn new(tx: mpsc::Sender<M>) -> Self {
+    /// Constructs a new instance from an mpsc sender.
+    ///
+    /// Use this when you need to create a command channel manually (e.g., to
+    /// combine with other inputs via `SelectInput`). For standard command
+    /// worker services, prefer `ServiceBuilder::create_command_handle()`.
+    pub fn new(tx: mpsc::Sender<M>) -> Self {
         Self { tx }
     }
 


### PR DESCRIPTION
Allows consumers to create command channels manually for combining with other inputs via SelectInput. Needed by PaaS to wire SelectInput<CommandInput, TickingInput> for tick-based retry.

## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
