### PR TITLE
chore(deps): bump const-hex to 1.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ bincode = "1.3"
 bitcoin = { version = "0.32.6" }
 bitcoin-bosd = { version = "0.9.0", default-features = false }
 borsh = { version = "1.5.0", features = ["derive"] }
-const-hex = "1.14"
+const-hex = "1.18"
 digest = "0.10"
 futures = "0.3"
 futures-util = "0.3"

--- a/crates/identifiers/Cargo.toml
+++ b/crates/identifiers/Cargo.toml
@@ -16,7 +16,7 @@ tree_hash = { workspace = true, optional = true }
 
 arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, optional = true }
-const-hex = "1.14"
+const-hex.workspace = true
 hex.workspace = true
 int-enum.workspace = true
 paste = { workspace = true, optional = true }


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
`strata-identifiers` uses `const_hex::display` (in crates/identifiers/src/acct.rs), but we were declaring `const-hex = "1.14".`

That caused lockfile-sensitive builds:

* In some environments, Cargo resolved a newer `const-hex` and everything compiled.
* In others (including downstream workspaces with older lock state), it resolved to 1.14.x, where display is not available, causing compile failures.

This PR makes the dependency requirement explicit and consistent:

* Root workspace: const-hex bumped from 1.14 to 1.18
* crates/identifiers: switched from direct const-hex = "1.14" to const-hex.workspace = true


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [X] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [X] I have performed a self-review of my code.
- [X] I have commented my code where necessary.
- [X] I have updated the documentation if needed.
- [X] My changes do not introduce new warnings.
- [X] I have added tests that prove my changes are effective or that my feature works.
- [X] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
