### PR TITLE
feat(crypto): add ZeroizableBuf32 zeroizable 32-byte key buffer

### DIFF
--- a/crates/crypto/src/keys/zeroizable.rs
+++ b/crates/crypto/src/keys/zeroizable.rs
@@ -104,6 +104,35 @@ impl Zeroize for ZeroizableKeypair {
 
 impl ZeroizeOnDrop for ZeroizableKeypair {}
 
+/// A zeroizable on [`Drop`] wrapper around a 32-byte key buffer.
+///
+/// Holds raw secret key bytes and guarantees they are securely erased when the
+/// value is dropped. Does not implement [`Copy`] so key material cannot be
+/// silently duplicated via assignment.
+#[derive(Clone, PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
+#[expect(
+    missing_debug_implementations,
+    reason = "Debug implementation would expose sensitive key material"
+)]
+pub struct ZeroizedBuf32([u8; 32]);
+
+impl ZeroizedBuf32 {
+    /// Creates a new [`ZeroizedBuf32`] from a 32-byte array.
+    ///
+    /// Takes ownership of `bytes` since it is zeroized on drop.
+    pub fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl Deref for ZeroizedBuf32 {
+    type Target = [u8; 32];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -213,6 +242,50 @@ mod tests {
         }
 
         // Check if zeroization occurred
+        assert!(was_zeroized.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn test_zeroizable_buf32_deref() {
+        let bytes = [0x42u8; 32];
+        let key = ZeroizedBuf32::new(bytes);
+        assert_eq!(*key, bytes);
+    }
+
+    #[test]
+    fn test_zeroizable_buf32_zeroize() {
+        let mut key = ZeroizedBuf32::new([0x42u8; 32]);
+        key.zeroize();
+        // zeroize crate fills with 0x00 (volatile writes of zero)
+        assert_eq!(*key, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_zeroize_on_drop_buf32() {
+        struct TestWrapper {
+            inner: ZeroizedBuf32,
+            flag: Arc<AtomicBool>,
+        }
+
+        impl Drop for TestWrapper {
+            fn drop(&mut self) {
+                let bytes = *self.inner;
+                // Flag is true when bytes are NOT yet zeroized at this point
+                // (inner drops after this, triggering zeroization)
+                self.flag.store(bytes != [0u8; 32], Ordering::Relaxed);
+            }
+        }
+
+        let was_zeroized = Arc::new(AtomicBool::new(false));
+        let was_zeroized_clone = Arc::clone(&was_zeroized);
+
+        {
+            let _ = TestWrapper {
+                inner: ZeroizedBuf32::new([0x42u8; 32]),
+                flag: was_zeroized_clone,
+            };
+        }
+
         assert!(was_zeroized.load(Ordering::Relaxed));
     }
 }


### PR DESCRIPTION
## Description
- Adds `ZeroizedBuf32` to the `strata-crypto` zeroizable module: a newtype over `[u8; 32]` with `Zeroize + ZeroizeOnDrop` via derive macros, no `Copy`
- Includes tests for deref, manual zeroize, and zeroize-on-drop behavior

## Test plan

- [x] `cargo test -p strata-crypto`

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
The implementation was already reviewed as part of the alpen branch — this PR extracts it into `strata-common` where it belongs alongside the existing `ZeroizableXpriv` and `ZeroizableKeypair` types.

Reviewed commits in [alpenlabs/strata](https://github.com/alpenlabs/strata):
- [b3910ffdd](https://github.com/alpenlabs/strata/commit/b3910ffdd75eb0e5719f4df8dd89f383a9da298b) — initial introduction as `ZeroizableBuf32`
- [e47ba24d8](https://github.com/alpenlabs/strata/commit/e47ba24d81cf1ac60f974af1f19e5c4c29550419) — renamed to `ZeroizedBuf32`, switched to derive macros (matches this PR exactly)
## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
