### PR TITLE
feat(logging): add MetricsLayer tracing-to-metrics bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1298,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +1692,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -2514,6 +2542,7 @@ dependencies = [
 name = "strata-logging"
 version = "0.1.0"
 dependencies = [
+ "metrics",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ futures = "0.3"
 futures-util = "0.3"
 hex = { version = "0.4", features = ["serde"] }
 int-enum = "1"
+metrics = "0.24"
 musig2 = "0.1"
 num_enum = "0.7"
 opentelemetry = "0.26"

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 workspace = true
 
 [dependencies]
+metrics.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,6 +1,7 @@
 //! Logging subsystem with OpenTelemetry support.
 
 pub mod manager;
+pub mod metrics_layer;
 pub mod service;
 pub mod types;
 
@@ -9,6 +10,7 @@ mod tests;
 
 // Re-export main types and functions
 pub use manager::{finalize, init};
+pub use metrics_layer::MetricsLayer;
 pub use service::{LoggingInitConfig, init_logging_from_config};
 // Re-export tracing-appender types for convenience
 pub use tracing_appender::rolling::Rotation;

--- a/crates/logging/src/manager.rs
+++ b/crates/logging/src/manager.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::fmt::layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+use super::metrics_layer::MetricsLayer;
 use super::types::LoggerConfig;
 
 /// Global tracer provider for proper shutdown
@@ -104,11 +105,14 @@ pub fn init(config: LoggerConfig) {
         tracing_opentelemetry::layer().with_tracer(tt)
     });
 
+    let metrics_layer = config.enable_metrics_layer.then_some(MetricsLayer);
+
     // Register all layers - with() accepts Option<Layer> so this scales cleanly
     tracing_subscriber::registry()
         .with(stdout_sub)
         .with(file_layer)
         .with(otel_layer)
+        .with(metrics_layer)
         .init();
 
     info!(

--- a/crates/logging/src/metrics_layer.rs
+++ b/crates/logging/src/metrics_layer.rs
@@ -1,0 +1,101 @@
+//! Tracing layer that records span busy/idle time as `metrics` histograms.
+
+use std::time::{Duration, Instant};
+
+use tracing::Subscriber;
+use tracing::span::{Attributes, Id};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Per-span timing state tracked across enter/exit events.
+struct SpanTiming {
+    created_at: Instant,
+    busy: Duration,
+    last_entered: Instant,
+}
+
+/// A tracing [`Layer`] that records span busy/idle time as `metrics` histograms.
+///
+/// For every span that closes, two histograms are recorded (microseconds):
+///
+/// - `strata_span_busy_us{span="<name>"}` — time the span was actively executing.
+/// - `strata_span_idle_us{span="<name>"}` — wall time the span existed but was not executing.
+///
+/// The layer always emits these via the `metrics` facade. If no recorder is
+/// installed, the calls are cheap no-ops, but the per-span state is still
+/// allocated. Callers who never run with a recorder should install this layer
+/// conditionally (see [`LoggerConfig::enable_metrics_layer`][super::LoggerConfig]).
+///
+/// Timing assumes each span is entered and exited in balanced pairs, which is
+/// the contract `tracing` guarantees for correctly instrumented async code.
+#[derive(Debug)]
+pub struct MetricsLayer;
+
+impl<S> Layer<S> for MetricsLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let now = Instant::now();
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(SpanTiming {
+                created_at: now,
+                busy: Duration::ZERO,
+                last_entered: now,
+            });
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id)
+            && let Some(timing) = span.extensions_mut().get_mut::<SpanTiming>()
+        {
+            timing.last_entered = Instant::now();
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(id)
+            && let Some(timing) = span.extensions_mut().get_mut::<SpanTiming>()
+        {
+            timing.busy += timing.last_entered.elapsed();
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id)
+            && let Some(timing) = span.extensions().get::<SpanTiming>()
+        {
+            let total = timing.created_at.elapsed();
+            let busy = timing.busy;
+            let idle = total.saturating_sub(busy);
+            let name = span.name().to_string();
+
+            metrics::histogram!("strata_span_busy_us", "span" => name.clone())
+                .record(busy.as_micros() as f64);
+            metrics::histogram!("strata_span_idle_us", "span" => name)
+                .record(idle.as_micros() as f64);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::{info_span, subscriber};
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::registry;
+
+    use super::*;
+
+    /// Exercising the layer without a metrics recorder installed should not
+    /// panic — `metrics::histogram!` is a no-op in that case.
+    #[test]
+    fn records_without_panicking_when_no_recorder_is_installed() {
+        let subscriber = registry().with(MetricsLayer);
+        subscriber::with_default(subscriber, || {
+            let span = info_span!("test_span");
+            let _guard = span.enter();
+        });
+    }
+}

--- a/crates/logging/src/metrics_layer.rs
+++ b/crates/logging/src/metrics_layer.rs
@@ -19,8 +19,8 @@ struct SpanTiming {
 ///
 /// For every span that closes, two histograms are recorded (microseconds):
 ///
-/// - `strata_span_busy_us{span="<name>"}` — time the span was actively executing.
-/// - `strata_span_idle_us{span="<name>"}` — wall time the span existed but was not executing.
+/// - `strata_span_busy_us{span="<name>"}`: time the span was actively executing.
+/// - `strata_span_idle_us{span="<name>"}`: wall time the span existed but was not executing.
 ///
 /// The layer always emits these via the `metrics` facade. If no recorder is
 /// installed, the calls are cheap no-ops, but the per-span state is still
@@ -70,9 +70,9 @@ where
             let total = timing.created_at.elapsed();
             let busy = timing.busy;
             let idle = total.saturating_sub(busy);
-            let name = span.name().to_string();
+            let name: &'static str = span.name();
 
-            metrics::histogram!("strata_span_busy_us", "span" => name.clone())
+            metrics::histogram!("strata_span_busy_us", "span" => name)
                 .record(busy.as_micros() as f64);
             metrics::histogram!("strata_span_idle_us", "span" => name)
                 .record(idle.as_micros() as f64);
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
 
     /// Exercising the layer without a metrics recorder installed should not
-    /// panic — `metrics::histogram!` is a no-op in that case.
+    /// panic. `metrics::histogram!` is a no-op in that case.
     #[test]
     fn records_without_panicking_when_no_recorder_is_installed() {
         let subscriber = registry().with(MetricsLayer);

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -23,6 +23,11 @@ pub struct LoggingInitConfig<'a> {
     pub json_format: Option<bool>,
     /// Default log file prefix if not specified in config
     pub default_log_prefix: &'a str,
+    /// Enable the tracing-to-metrics bridge layer.
+    ///
+    /// Set to `true` only when a `metrics` recorder has been (or will be)
+    /// installed. See [`MetricsLayer`](super::MetricsLayer).
+    pub enable_metrics_layer: bool,
 }
 
 /// Initialize logging from configuration with all standard setup.
@@ -57,6 +62,8 @@ pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
     if let Some(json_format) = config.json_format {
         lconfig = lconfig.with_json_logging(json_format);
     }
+
+    lconfig = lconfig.with_metrics_layer(config.enable_metrics_layer);
 
     // Initialize logging
     init(lconfig);

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -128,6 +128,18 @@ fn test_trace_context_propagation() {
 }
 
 #[test]
+fn test_logger_config_metrics_layer_builder() {
+    let config = LoggerConfig::new("test-service".to_string());
+    assert!(!config.enable_metrics_layer);
+
+    let enabled = LoggerConfig::new("test-service".to_string()).with_metrics_layer(true);
+    assert!(enabled.enable_metrics_layer);
+
+    let disabled = enabled.with_metrics_layer(false);
+    assert!(!disabled.enable_metrics_layer);
+}
+
+#[test]
 fn test_logger_config_with_otlp_export_config() {
     let export_config = OtlpExportConfig {
         timeout: Duration::from_secs(5),

--- a/crates/logging/src/types.rs
+++ b/crates/logging/src/types.rs
@@ -152,6 +152,14 @@ pub struct LoggerConfig {
     pub file_logging_config: Option<FileLoggingConfig>,
     /// OTLP export configuration
     pub otlp_export_config: OtlpExportConfig,
+    /// Whether to install the tracing-to-metrics bridge layer.
+    ///
+    /// When `true`, a [`MetricsLayer`](super::MetricsLayer) is added to the
+    /// subscriber stack and records per-span busy/idle histograms via the
+    /// `metrics` facade. Only enable this when a `metrics` recorder is (or
+    /// will be) installed by the binary; otherwise the per-span state is
+    /// allocated for nothing.
+    pub enable_metrics_layer: bool,
 }
 
 impl LoggerConfig {
@@ -163,6 +171,7 @@ impl LoggerConfig {
             stdout_config: StdoutConfig::default(),
             file_logging_config: None,
             otlp_export_config: OtlpExportConfig::default(),
+            enable_metrics_layer: false,
         }
     }
 
@@ -210,6 +219,12 @@ impl LoggerConfig {
     /// Set OTLP export configuration
     pub fn with_otlp_export_config(mut self, config: OtlpExportConfig) -> Self {
         self.otlp_export_config = config;
+        self
+    }
+
+    /// Enable or disable the tracing-to-metrics bridge layer.
+    pub fn with_metrics_layer(mut self, enabled: bool) -> Self {
+        self.enable_metrics_layer = enabled;
         self
     }
 


### PR DESCRIPTION
## Summary

Adds `MetricsLayer`, a tracing layer that records span busy/idle time as `strata_span_busy_us` / `strata_span_idle_us` microsecond histograms via the `metrics` facade. Opt in via `LoggerConfig::with_metrics_layer(true)` or `LoggingInitConfig::enable_metrics_layer`. Off by default. Histogram calls are no-ops when no `metrics` recorder is installed, so the cost while enabled is one `SpanTiming` extension per span.

Needed by alpenlabs/alpen#1516, which wires this behind a Prometheus `/metrics` endpoint in `bin/strata`. That PR carries a duplicate `MetricsLayer` in `crates/common/src/logging/` today, to be deleted on rebase once this lands.

## Public API delta

- `pub struct MetricsLayer` in `crates/logging/src/metrics_layer.rs`, re-exported as `strata_logging::MetricsLayer`
- `LoggerConfig::enable_metrics_layer: bool` (defaults `false`) + builder `with_metrics_layer(bool) -> Self`
- `LoggingInitConfig::enable_metrics_layer: bool`

No existing signatures change.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)

## Notes to Reviewers

`metrics = "0.24"` added as workspace dep. Three lock entries added: `metrics v0.24.3`, `ahash v0.8.12`, `portable-atomic v1.13.1`.

AI Assistance Notice: AI used to mechanically port `MetricsLayer` from alpenlabs/alpen#1516 into upstream style and to draft this PR description.

## Related Issues

Blocks alpenlabs/alpen#1516.