### PR TITLE
Feat/allow other executors in service framework

### DIFF
--- a/crates/service/src/adapters/dumb_ticking.rs
+++ b/crates/service/src/adapters/dumb_ticking.rs
@@ -11,6 +11,7 @@ use tokio::time::{interval, Interval, MissedTickBehavior};
 use crate::{AsyncServiceInput, ServiceInput};
 
 /// Handle for stopping a service using a [`DumbTickingInput`].
+#[derive(Debug)]
 pub struct DumbTickHandle {
     stop_tx: oneshot::Sender<()>,
 }

--- a/crates/service/src/async_worker.rs
+++ b/crates/service/src/async_worker.rs
@@ -9,14 +9,14 @@ use tracing::*;
 use crate::instrumentation::{
     record_shutdown_result, OperationResult, ServiceInstrumentation, ShutdownReason,
 };
-use crate::{AsyncService, AsyncServiceInput, Response, ServiceState};
+use crate::{AsyncGuard, AsyncService, AsyncServiceInput, Response, ServiceState};
 
 /// Async worker task.
 pub(crate) async fn worker_task<S: AsyncService, I>(
     mut state: S::State,
     mut inp: I,
     status_tx: watch::Sender<S::Status>,
-    shutdown_guard: strata_tasks::ShutdownGuard,
+    shutdown_guard: impl AsyncGuard,
 ) -> anyhow::Result<()>
 where
     I: AsyncServiceInput<Msg = S::Msg>,

--- a/crates/service/src/builder.rs
+++ b/crates/service/src/builder.rs
@@ -5,8 +5,9 @@ use std::fmt::Debug;
 use tokio::sync::{mpsc, watch};
 
 use crate::{
-    async_worker, sync_worker, AsyncService, AsyncServiceInput, CommandHandle, Service,
-    ServiceInput, ServiceMonitor, ServiceMsg, SyncService, SyncServiceInput, TokioMpscInput,
+    async_worker, sync_worker, AsyncExecutor, AsyncService, AsyncServiceInput, CommandHandle,
+    Service, ServiceInput, ServiceMonitor, ServiceMsg, SyncExecutor, SyncService, SyncServiceInput,
+    TokioMpscInput,
 };
 
 /// Builder to help with constructing service workers.
@@ -53,7 +54,7 @@ where
     pub async fn launch_async(
         self,
         name: &'static str,
-        texec: &strata_tasks::TaskExecutor,
+        texec: &impl AsyncExecutor,
     ) -> anyhow::Result<ServiceMonitor<S::Status>> {
         // TODO convert to fallible results?
         let state = self.state.expect("service/builder: missing state");
@@ -63,7 +64,7 @@ where
         let (status_tx, status_rx) = watch::channel(init_status);
 
         let worker_fut_cls = move |g| async_worker::worker_task::<S, I>(state, inp, status_tx, g);
-        texec.spawn_critical_async_with_shutdown(name, worker_fut_cls);
+        texec.spawn_async(name, worker_fut_cls);
 
         Ok(ServiceMonitor::new(status_rx))
     }
@@ -77,7 +78,7 @@ where
     pub fn launch_sync(
         self,
         name: &'static str,
-        texec: &strata_tasks::TaskExecutor,
+        texec: &impl SyncExecutor,
     ) -> anyhow::Result<ServiceMonitor<S::Status>> {
         // TODO convert to fallible results?
         let state = self.state.expect("service/builder: missing state");
@@ -87,7 +88,7 @@ where
         let (status_tx, status_rx) = watch::channel(init_status);
 
         let worker_cls = move |g| sync_worker::worker_task::<S, I>(state, inp, status_tx, g);
-        texec.spawn_critical(name, worker_cls);
+        texec.spawn_sync(name, worker_cls);
 
         Ok(ServiceMonitor::new(status_rx))
     }

--- a/crates/service/src/executor.rs
+++ b/crates/service/src/executor.rs
@@ -74,3 +74,126 @@ impl AsyncExecutor for strata_tasks::TaskExecutor {
         self.spawn_critical_async_with_shutdown(name, async_func);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use serde::Serialize;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::{AsyncService, Response, ServiceBuilder, ServiceState, TokioMpscInput};
+
+    /// A minimal async guard backed by a shared flag.
+    struct MockGuard {
+        flag: Arc<AtomicBool>,
+    }
+
+    impl AsyncGuard for MockGuard {
+        async fn wait_for_shutdown(&self) {
+            // Poll until the flag is set.  In a real impl this would be
+            // notification-based; good enough for a test.
+            loop {
+                if self.flag.load(Ordering::Relaxed) {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+    }
+
+    /// A minimal async executor that spawns via `tokio::spawn`.
+    struct MockExecutor {
+        shutdown: Arc<AtomicBool>,
+    }
+
+    impl MockExecutor {
+        fn new() -> Self {
+            Self {
+                shutdown: Arc::new(AtomicBool::new(false)),
+            }
+        }
+
+        fn trigger_shutdown(&self) {
+            self.shutdown.store(true, Ordering::Relaxed);
+        }
+    }
+
+    impl AsyncExecutor for MockExecutor {
+        type ShutdownGuard = MockGuard;
+
+        fn spawn_async<F>(
+            &self,
+            _name: &'static str,
+            worker: impl FnOnce(Self::ShutdownGuard) -> F + Send + 'static,
+        ) where
+            F: Future<Output = anyhow::Result<()>> + Send + 'static,
+        {
+            let guard = MockGuard {
+                flag: self.shutdown.clone(),
+            };
+            tokio::spawn(worker(guard));
+        }
+    }
+
+    // ---- trivial service definition ----
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TestStatus;
+
+    struct TestState;
+
+    impl ServiceState for TestState {
+        fn name(&self) -> &str {
+            "test"
+        }
+    }
+
+    struct TestService;
+
+    impl crate::Service for TestService {
+        type State = TestState;
+        type Msg = u32;
+        type Status = TestStatus;
+
+        fn get_status(_s: &Self::State) -> Self::Status {
+            TestStatus
+        }
+    }
+
+    impl AsyncService for TestService {
+        async fn process_input(_state: &mut TestState, _input: u32) -> anyhow::Result<Response> {
+            Ok(Response::Continue)
+        }
+    }
+
+    /// Service framework works with a non-`strata_tasks` executor.
+    #[tokio::test]
+    async fn launch_async_with_mock_executor() {
+        let executor = MockExecutor::new();
+
+        let (tx, rx) = mpsc::channel(10);
+        let input = TokioMpscInput::new(rx);
+
+        let _monitor = ServiceBuilder::<TestService, _>::new()
+            .with_state(TestState)
+            .with_input(input)
+            .launch_async("test_svc", &executor)
+            .await
+            .unwrap();
+
+        // Send a message through the service.
+        tx.send(42).await.unwrap();
+
+        // Trigger shutdown and let the worker exit.
+        executor.trigger_shutdown();
+
+        // Drop the sender so the worker's input stream also ends.
+        drop(tx);
+
+        // Give the spawned task a moment to complete.
+        tokio::task::yield_now().await;
+    }
+}

--- a/crates/service/src/executor.rs
+++ b/crates/service/src/executor.rs
@@ -1,0 +1,76 @@
+//! Traits for service executors.
+use std::future::Future;
+
+/// Executor for synchronous workers.
+pub trait SyncExecutor {
+    /// To get shutdown signal notification.
+    type ShutdownGuard: SyncGuard + Send + 'static;
+
+    /// Spawn a sync worker task.
+    fn spawn_sync(
+        &self,
+        name: &'static str,
+        worker: impl FnOnce(Self::ShutdownGuard) -> anyhow::Result<()> + Send + 'static,
+    );
+}
+
+/// Executor for asynchronous workers.
+pub trait AsyncExecutor {
+    /// To get shutdown signal notification.
+    type ShutdownGuard: AsyncGuard + Send + 'static;
+
+    /// Spawn a future as a worker task.
+    fn spawn_async<F>(
+        &self,
+        name: &'static str,
+        worker: impl FnOnce(Self::ShutdownGuard) -> F + Send + 'static,
+    ) where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static;
+}
+
+/// Provide shutdown signal to a sync worker task.
+pub trait SyncGuard {
+    /// Check if shutdown signal has been sent.
+    fn should_shutdown(&self) -> bool;
+}
+
+/// Provide shutdown signal to an async worker task.
+pub trait AsyncGuard {
+    /// Returns a future that resolves when shutdown signal is sent.
+    fn wait_for_shutdown(&self) -> impl Future<Output = ()> + Send;
+}
+
+impl SyncGuard for strata_tasks::ShutdownGuard {
+    fn should_shutdown(&self) -> bool {
+        strata_tasks::ShutdownGuard::should_shutdown(self)
+    }
+}
+
+impl AsyncGuard for strata_tasks::ShutdownGuard {
+    fn wait_for_shutdown(&self) -> impl Future<Output = ()> {
+        strata_tasks::ShutdownGuard::wait_for_shutdown(self)
+    }
+}
+
+impl SyncExecutor for strata_tasks::TaskExecutor {
+    type ShutdownGuard = strata_tasks::ShutdownGuard;
+
+    fn spawn_sync(
+        &self,
+        name: &'static str,
+        func: impl FnOnce(Self::ShutdownGuard) -> anyhow::Result<()> + Send + 'static,
+    ) {
+        self.spawn_critical(name, func);
+    }
+}
+
+impl AsyncExecutor for strata_tasks::TaskExecutor {
+    type ShutdownGuard = strata_tasks::ShutdownGuard;
+
+    fn spawn_async<F>(&self, name: &'static str, async_func: impl FnOnce(Self::ShutdownGuard) -> F)
+    where
+        F: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        self.spawn_critical_async_with_shutdown(name, async_func);
+    }
+}

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -93,6 +93,7 @@ mod async_worker;
 mod builder;
 mod command;
 mod errors;
+mod executor;
 mod instrumentation;
 mod status;
 mod sync_worker;
@@ -102,6 +103,7 @@ pub use adapters::*;
 pub use builder::ServiceBuilder;
 pub use command::{CommandCompletionSender, CommandHandle};
 pub use errors::ServiceError;
+pub use executor::*;
 pub use instrumentation::{
     HistogramBuckets, InstrumentationBuilder, OperationResult, ServiceInstrumentation,
     ShutdownReason,

--- a/crates/service/src/sync_worker.rs
+++ b/crates/service/src/sync_worker.rs
@@ -8,13 +8,13 @@ use tracing::*;
 use crate::instrumentation::{
     record_shutdown_result, OperationResult, ServiceInstrumentation, ShutdownReason,
 };
-use crate::{Response, ServiceState, SyncService, SyncServiceInput};
+use crate::{Response, ServiceState, SyncGuard, SyncService, SyncServiceInput};
 
 pub(crate) fn worker_task<S: SyncService, I>(
     mut state: S::State,
     mut inp: I,
     status_tx: watch::Sender<S::Status>,
-    shutdown_guard: strata_tasks::ShutdownGuard,
+    shutdown_guard: impl SyncGuard,
 ) -> anyhow::Result<()>
 where
     I: SyncServiceInput<Msg = S::Msg>,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Adds `SyncExecutor`, `AsyncExecutor`, `SyncGuard` and `AsyncGuard` trait bounds for service framework executor. This allows executors other than `strata_tasks::TaskExecutor` to be used with the service framework. 
Adds implementation for `strata_tasks::TaskExecutor` so existing code using service framework with `strata_tasks` is not impacted by this change. 

Additional changes:
- [x] Add Debug impl to `DumbTickHandle`

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->
The main motivation for this PR is to be able to use service framework inside alpen-ee which uses reth's task executor.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
