### PR TITLE
feat(logging): make noisy-dep filter directives consumer-supplied

### DIFF
--- a/crates/logging/src/manager.rs
+++ b/crates/logging/src/manager.rs
@@ -1,5 +1,6 @@
 //! Logging initialization and shutdown management.
 
+use std::env;
 use std::sync::OnceLock;
 
 use metrics_exporter_otel::OpenTelemetryRecorder;
@@ -13,10 +14,10 @@ use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::*;
 use tracing_appender::rolling::RollingFileAppender;
-use tracing_subscriber::Layer;
 use tracing_subscriber::fmt::layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
 
 use super::metrics_layer::MetricsLayer;
 use super::types::LoggerConfig;
@@ -40,13 +41,15 @@ pub fn init(config: LoggerConfig) {
     // Set the global trace context propagator for distributed tracing
     set_text_map_propagator(TraceContextPropagator::new());
 
-    // Default filter suppresses verbose SP1 executor logs below WARN (so TRACE, INFO and DEBUG
-    // are filtered out).
-    // It still allows further override via RUST_LOG.
-    let filt = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(tracing::Level::INFO.into())
-        .from_env_lossy()
-        .add_directive("sp1_core_executor=warn".parse().unwrap());
+    // Build the filter from any consumer-supplied directives plus the value of
+    // `RUST_LOG`. Consumers are expected to pass directives such as
+    // `sp1_core_executor=warn` or `jsonrpsee_server::server=warn` themselves;
+    // this crate is intentionally agnostic about which dependencies are noisy.
+    // `RUST_LOG` still wins on conflicts because it is appended last.
+    let filt = build_env_filter(
+        &config.extra_filter_directives,
+        env::var(EnvFilter::DEFAULT_ENV).ok().as_deref(),
+    );
 
     // Configure stdout logging with JSON or compact format
     let stdout_sub = if config.stdout_config.json_format {
@@ -164,6 +167,29 @@ pub fn init(config: LoggerConfig) {
         deployment_environment = ?config.resource.deployment_environment,
         "logging initialized"
     );
+}
+
+fn build_env_filter(extra_directives: &[String], env_filter: Option<&str>) -> EnvFilter {
+    let extras = extra_directives
+        .iter()
+        .map(String::as_str)
+        .filter(|d| !d.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let directives = match (extras.is_empty(), env_filter) {
+        (true, Some(env)) if !env.trim().is_empty() => env.to_string(),
+        (true, _) => String::new(),
+        (false, Some(env)) if !env.trim().is_empty() => format!("{extras},{env}"),
+        (false, _) => extras,
+    };
+
+    let builder = EnvFilter::builder().with_default_directive(tracing::Level::INFO.into());
+    if directives.is_empty() {
+        builder.parse_lossy("")
+    } else {
+        builder.parse_lossy(directives)
+    }
 }
 
 /// Shuts down the logging subsystem, flushing pending spans and tearing down resources.

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -28,6 +28,12 @@ pub struct LoggingInitConfig<'a> {
     /// Set to `true` only when a `metrics` recorder has been (or will be)
     /// installed. See [`MetricsLayer`](super::MetricsLayer).
     pub enable_metrics_layer: bool,
+    /// Extra `EnvFilter` directives to merge before `RUST_LOG`.
+    ///
+    /// Forwarded to [`LoggerConfig::extra_filter_directives`]. Use this from
+    /// the binary to silence noisy dependencies (e.g.
+    /// `["sp1_core_executor=warn", "jsonrpsee_server::server=warn"]`).
+    pub extra_filter_directives: &'a [&'a str],
 }
 
 /// Initialize logging from configuration with all standard setup.
@@ -64,6 +70,11 @@ pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
     }
 
     lconfig = lconfig.with_metrics_layer(config.enable_metrics_layer);
+
+    if !config.extra_filter_directives.is_empty() {
+        lconfig =
+            lconfig.with_extra_filter_directives(config.extra_filter_directives.iter().copied());
+    }
 
     // Initialize logging
     init(lconfig);

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -140,6 +140,26 @@ fn test_logger_config_metrics_layer_builder() {
 }
 
 #[test]
+fn test_logger_config_extra_filter_directives_default_empty() {
+    let config = LoggerConfig::new("test-service".to_string());
+    assert!(config.extra_filter_directives.is_empty());
+}
+
+#[test]
+fn test_logger_config_with_extra_filter_directives() {
+    let config = LoggerConfig::new("test-service".to_string())
+        .with_extra_filter_directives(["sp1_core_executor=warn", "jsonrpsee_server::server=warn"]);
+
+    assert_eq!(
+        config.extra_filter_directives,
+        vec![
+            "sp1_core_executor=warn".to_string(),
+            "jsonrpsee_server::server=warn".to_string(),
+        ]
+    );
+}
+
+#[test]
 fn test_logger_config_with_otlp_export_config() {
     let export_config = OtlpExportConfig {
         timeout: Duration::from_secs(5),

--- a/crates/logging/src/types.rs
+++ b/crates/logging/src/types.rs
@@ -165,6 +165,14 @@ pub struct LoggerConfig {
     /// instrumentation library (the `otel.scope.name` attribute) on the
     /// emitted metrics. Defaults to `"strata"`.
     pub meter_name: String,
+    /// Extra `EnvFilter` directives applied before the value of `RUST_LOG`.
+    ///
+    /// Each entry is a directive in the same syntax as `RUST_LOG`
+    /// (e.g. `"sp1_core_executor=warn"`). They are joined with commas and
+    /// prepended to the env value, so the env still wins on conflicts.
+    /// Use this to suppress noisy dependencies from the consumer side rather
+    /// than hardcoding directives inside this crate.
+    pub extra_filter_directives: Vec<String>,
 }
 
 impl LoggerConfig {
@@ -178,6 +186,7 @@ impl LoggerConfig {
             otlp_export_config: OtlpExportConfig::default(),
             enable_metrics_layer: false,
             meter_name: "strata".to_string(),
+            extra_filter_directives: Vec::new(),
         }
     }
 
@@ -238,6 +247,19 @@ impl LoggerConfig {
     /// when installing the `metrics`-crate to OpenTelemetry bridge.
     pub fn with_meter_name(mut self, name: String) -> Self {
         self.meter_name = name;
+        self
+    }
+
+    /// Replace the set of extra `EnvFilter` directives.
+    ///
+    /// See [`Self::extra_filter_directives`] for the directive syntax and
+    /// precedence rules.
+    pub fn with_extra_filter_directives<I, S>(mut self, directives: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.extra_filter_directives = directives.into_iter().map(Into::into).collect();
         self
     }
 

--- a/crates/tasks/src/manager.rs
+++ b/crates/tasks/src/manager.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::fmt::{Display, Formatter};
+use std::fmt::{self, Display, Formatter};
 use std::future::Future;
 use std::panic::{self, AssertUnwindSafe};
 use std::pin::pin;
@@ -66,7 +66,7 @@ impl TaskError {
 }
 
 impl Display for TaskError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let task_name = &self.task_name;
         match &self.reason {
             FailureReason::Error(error) => {


### PR DESCRIPTION
## Description

Extracts `EnvFilter` construction into a dedicated `build_env_filter` helper and adds `LoggerConfig::extra_filter_directives` (plus a `with_extra_filter_directives` builder and a matching `LoggingInitConfig::extra_filter_directives` field) so binaries pass directives like `sp1_core_executor=warn` or `jsonrpsee_server::server=warn` themselves rather than having those hardcoded inside the crate.

`RUST_LOG` is still appended last and wins on conflicts.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Per review feedback on the previous revision: noisy-dependency suppression directives now belong to the consumer, not this crate. Downstream binaries that previously relied on the implicit `sp1_core_executor=warn` / `jsonrpsee_server::server=warn` defaults must now opt in by setting `extra_filter_directives` on `LoggerConfig` or `LoggingInitConfig`.

`LoggingInitConfig` gained a new required field (`extra_filter_directives: &[&str]`), so call sites need a small update (pass `&[]` to keep the previous behavior of "no extras").

Needs a new tag after merged.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3236