### PR TITLE
Propagate service errors to task executor

### DIFF
--- a/crates/service/src/async_worker.rs
+++ b/crates/service/src/async_worker.rs
@@ -93,7 +93,10 @@ where
 
     info!(service.name = %service_name, "service stopped");
 
-    Ok(())
+    match err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 async fn worker_task_inner<S: AsyncService, I>(
@@ -186,4 +189,94 @@ async fn handle_shutdown<S: AsyncService>(
         instrumentation,
         shutdown_reason,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+    use tokio::sync::watch;
+
+    use super::*;
+    use crate::{AsyncGuard, VecInput};
+
+    /// Guard that never fires shutdown.
+    struct NeverShutdown;
+
+    impl AsyncGuard for NeverShutdown {
+        async fn wait_for_shutdown(&self) {
+            std::future::pending().await
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TestStatus;
+
+    struct TestState;
+
+    impl ServiceState for TestState {
+        fn name(&self) -> &str {
+            "test-async"
+        }
+    }
+
+    struct FailingService;
+
+    impl crate::Service for FailingService {
+        type State = TestState;
+        type Msg = u32;
+        type Status = TestStatus;
+
+        fn get_status(_s: &Self::State) -> Self::Status {
+            TestStatus
+        }
+    }
+
+    impl AsyncService for FailingService {
+        async fn process_input(_state: &mut TestState, _input: u32) -> anyhow::Result<Response> {
+            anyhow::bail!("async process error")
+        }
+    }
+
+    struct OkService;
+
+    impl crate::Service for OkService {
+        type State = TestState;
+        type Msg = u32;
+        type Status = TestStatus;
+
+        fn get_status(_s: &Self::State) -> Self::Status {
+            TestStatus
+        }
+    }
+
+    impl AsyncService for OkService {
+        async fn process_input(_state: &mut TestState, _input: u32) -> anyhow::Result<Response> {
+            Ok(Response::Continue)
+        }
+    }
+
+    #[tokio::test]
+    async fn worker_task_propagates_inner_error() {
+        let inp = VecInput::from_iter([1u32]);
+        let (status_tx, _status_rx) = watch::channel(TestStatus);
+
+        let result =
+            worker_task::<FailingService, _>(TestState, inp, status_tx, NeverShutdown).await;
+
+        let err = result.expect_err("worker_task should return Err on process_input failure");
+        assert!(
+            err.to_string().contains("async process error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_task_returns_ok_on_complete_without_error() {
+        let inp = VecInput::from_iter([1u32, 2, 3]);
+        let (status_tx, _status_rx) = watch::channel(TestStatus);
+
+        let result = worker_task::<OkService, _>(TestState, inp, status_tx, NeverShutdown).await;
+
+        result.expect("worker_task should return Ok when all inputs succeed");
+    }
 }

--- a/crates/service/src/sync_worker.rs
+++ b/crates/service/src/sync_worker.rs
@@ -125,7 +125,10 @@ where
 
     info!(service.name = %service_name, "service stopped");
 
-    Ok(())
+    match err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
 }
 
 /// Handles service shutdown cleanup and instrumentation.
@@ -160,4 +163,93 @@ fn handle_shutdown<S: SyncService>(
         instrumentation,
         shutdown_reason,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+    use tokio::sync::watch;
+
+    use super::*;
+    use crate::{SyncGuard, VecInput};
+
+    /// Guard that never signals shutdown.
+    struct NeverShutdown;
+
+    impl SyncGuard for NeverShutdown {
+        fn should_shutdown(&self) -> bool {
+            false
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize)]
+    struct TestStatus;
+
+    struct TestState;
+
+    impl ServiceState for TestState {
+        fn name(&self) -> &str {
+            "test-sync"
+        }
+    }
+
+    struct FailingService;
+
+    impl crate::Service for FailingService {
+        type State = TestState;
+        type Msg = u32;
+        type Status = TestStatus;
+
+        fn get_status(_s: &Self::State) -> Self::Status {
+            TestStatus
+        }
+    }
+
+    impl SyncService for FailingService {
+        fn process_input(_state: &mut TestState, _input: u32) -> anyhow::Result<Response> {
+            anyhow::bail!("sync process error")
+        }
+    }
+
+    struct OkService;
+
+    impl crate::Service for OkService {
+        type State = TestState;
+        type Msg = u32;
+        type Status = TestStatus;
+
+        fn get_status(_s: &Self::State) -> Self::Status {
+            TestStatus
+        }
+    }
+
+    impl SyncService for OkService {
+        fn process_input(_state: &mut TestState, _input: u32) -> anyhow::Result<Response> {
+            Ok(Response::Continue)
+        }
+    }
+
+    #[test]
+    fn worker_task_propagates_inner_error() {
+        let inp = VecInput::from_iter([1u32]);
+        let (status_tx, _status_rx) = watch::channel(TestStatus);
+
+        let result = worker_task::<FailingService, _>(TestState, inp, status_tx, NeverShutdown);
+
+        let err = result.expect_err("worker_task should return Err on process_input failure");
+        assert!(
+            err.to_string().contains("sync process error"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn worker_task_returns_ok_on_complete_without_error() {
+        let inp = VecInput::from_iter([1u32, 2, 3]);
+        let (status_tx, _status_rx) = watch::channel(TestStatus);
+
+        let result = worker_task::<OkService, _>(TestState, inp, status_tx, NeverShutdown);
+
+        result.expect("worker_task should return Ok when all inputs succeed");
+    }
 }


### PR DESCRIPTION
## Description
Propagate worker_task inner errors instead of swallowing them

Previously both async and sync worker_task functions discarded the error from process_input and always returned Ok(()). This meant TaskExecutor never received the error and couldn't trigger shutdown.

related: alpenlabs/alpen#1678
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

https://github.com/alpenlabs/alpen/pull/1678#discussion_r3201896080
<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->