### PR TITLE
feat(metrics): add process metrics initializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4124,7 +4125,7 @@ version = "0.3.0-alpha.1"
 dependencies = [
  "anyhow",
  "futures",
- "opentelemetry",
+ "metrics",
  "serde",
  "serde_json",
  "strata-tasks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1355,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1374,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1761,10 +1774,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54e5a5d54deb1941f7f47d8b9370ab9d7c11827c93dc4eec8310013a4c0d86db"
 dependencies = [
  "metrics",
- "metrics-util",
+ "metrics-util 0.20.1",
  "opentelemetry",
  "portable-atomic",
  "scc",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util 0.19.1",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -1773,10 +1822,12 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "metrics",
+ "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -1815,6 +1866,15 @@ dependencies = [
  "secp256k1",
  "sha2",
  "subtle",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -2511,6 +2571,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,6 +2617,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -2630,6 +2715,15 @@ dependencies = [
  "itertools 0.12.1",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3944,8 +4038,6 @@ dependencies = [
 name = "strata-logging"
 version = "0.1.0"
 dependencies = [
- "metrics",
- "metrics-exporter-otel",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -3974,6 +4066,22 @@ dependencies = [
  "thiserror 2.0.18",
  "tree_hash",
  "tree_hash_derive",
+]
+
+[[package]]
+name = "strata-metrics"
+version = "0.1.0"
+dependencies = [
+ "metrics",
+ "metrics-exporter-otel",
+ "metrics-exporter-prometheus",
+ "metrics-util 0.20.1",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/l1proto/envelope-fmt",
   "crates/l1proto/txfmt",
   "crates/logging",
+  "crates/metrics",
   "crates/merkle",
   "crates/msg-fmt",
   "crates/predicate",
@@ -30,6 +31,7 @@ strata-crypto = { path = "crates/crypto" }
 strata-identifiers = { path = "crates/identifiers" }
 strata-l1-txfmt = { path = "crates/l1proto/txfmt" }
 strata-logging = { path = "crates/logging" }
+strata-metrics = { path = "crates/metrics" }
 strata-merkle = { path = "crates/merkle" }
 strata-msg-fmt = { path = "crates/msg-fmt" }
 strata-predicate = { path = "crates/predicate" }
@@ -61,6 +63,10 @@ hex = { version = "0.4", features = ["serde"] }
 int-enum = "1"
 metrics = "0.24"
 metrics-exporter-otel = "0.3"
+metrics-exporter-prometheus = { version = "0.16", default-features = false, features = [
+  "http-listener",
+] }
+metrics-util = { version = "0.20", default-features = false, features = ["layers"] }
 musig2 = "0.1"
 num_enum = "0.7"
 opentelemetry = "0.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ strata-metrics = { path = "crates/metrics" }
 strata-merkle = { path = "crates/merkle" }
 strata-msg-fmt = { path = "crates/msg-fmt" }
 strata-predicate = { path = "crates/predicate" }
-strata-service = { path = "crates/services" }
+strata-service = { path = "crates/service" }
 strata-ssz-tests = { path = "crates/ssz-tests" }
 strata-tasks = { path = "crates/tasks" }
 

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,7 +1,10 @@
-//! Logging subsystem with OpenTelemetry support.
+//! Process-level logging and tracing initialization.
+//!
+//! This crate installs global `tracing` state. Binaries should initialize it
+//! once at process startup. Libraries should emit `tracing` spans/events and let
+//! the owning binary decide where they are exported.
 
 pub mod manager;
-pub mod metrics_layer;
 pub mod service;
 pub mod types;
 
@@ -9,9 +12,10 @@ pub mod types;
 mod tests;
 
 // Re-export main types and functions
-pub use manager::{finalize, init};
-pub use metrics_layer::MetricsLayer;
-pub use service::{LoggingInitConfig, init_logging_from_config};
+pub use manager::{BoxedLayer, finalize, init, init_with_layers};
+pub use service::{
+    LoggingInitConfig, init_logging_from_config, init_logging_from_config_with_layers,
+};
 // Re-export tracing-appender types for convenience
 pub use tracing_appender::rolling::Rotation;
 pub use types::{FileLoggingConfig, LoggerConfig, OtlpExportConfig, ResourceConfig, StdoutConfig};

--- a/crates/logging/src/manager.rs
+++ b/crates/logging/src/manager.rs
@@ -1,43 +1,43 @@
-//! Logging initialization and shutdown management.
+//! Logging and tracing initialization and shutdown management.
 
 use std::env;
 use std::sync::OnceLock;
 
-use metrics_exporter_otel::OpenTelemetryRecorder;
-use opentelemetry::InstrumentationScope;
-use opentelemetry::global::{set_meter_provider, set_text_map_propagator};
-use opentelemetry::metrics::MeterProvider;
+use opentelemetry::global::set_text_map_propagator;
 use opentelemetry::trace::TracerProvider;
-use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig};
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::*;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_subscriber::fmt::layer;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::Registry;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-use super::metrics_layer::MetricsLayer;
 use super::types::LoggerConfig;
 
 /// Global tracer provider for proper shutdown
 static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
 
-/// Global meter provider for proper shutdown.
-///
-/// When the OTLP endpoint is configured, [`init`] builds an
-/// [`SdkMeterProvider`] alongside the tracer provider, sets it as the global
-/// meter provider, and installs a `metrics`-crate recorder that bridges
-/// `metrics::counter!` / `gauge!` / `histogram!` calls into the OpenTelemetry
-/// meter. This means hand-written `metrics::*!` calls, reth's free metrics,
-/// span timings via [`MetricsLayer`], and `strata-service` framework
-/// instrumentation all flow through one OpenTelemetry pipeline.
-static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+/// Boxed tracing subscriber layer accepted by [`init_with_layers`].
+pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 
-/// Initializes the logging subsystem with the provided config.
+/// Initializes process-global logging and tracing with the provided config.
+///
+/// Call this once from the process entrypoint. Library crates should not call
+/// it; they should emit `tracing` signals and rely on the binary to install the
+/// subscriber.
 pub fn init(config: LoggerConfig) {
+    init_with_layers(config, Vec::new());
+}
+
+/// Initializes process-global logging and tracing with extra subscriber layers.
+///
+/// This exists so companion crates can provide tracing layers without making
+/// `strata-logging` depend on those systems directly.
+pub fn init_with_layers(config: LoggerConfig, extra_layers: Vec<BoxedLayer>) {
     // Set the global trace context propagator for distributed tracing
     set_text_map_propagator(TraceContextPropagator::new());
 
@@ -52,22 +52,22 @@ pub fn init(config: LoggerConfig) {
     );
 
     // Configure stdout logging with JSON or compact format
-    let stdout_sub = if config.stdout_config.json_format {
+    let stdout_sub: BoxedLayer = if config.stdout_config.json_format {
         layer()
             .json()
-            .with_span_events(config.stdout_config.fmt_span)
+            .with_span_events(config.stdout_config.fmt_span.clone())
             .with_filter(filt.clone())
             .boxed()
     } else {
         layer()
             .compact()
-            .with_span_events(config.stdout_config.fmt_span)
+            .with_span_events(config.stdout_config.fmt_span.clone())
             .with_filter(filt.clone())
             .boxed()
     };
 
     // Build optional file logging layer
-    let file_layer = config.file_logging_config.as_ref().map(|file_config| {
+    let file_layer: Option<BoxedLayer> = config.file_logging_config.as_ref().map(|file_config| {
         let file_appender = RollingFileAppender::new(
             file_config.rotation.clone(),
             &file_config.directory,
@@ -91,10 +91,8 @@ pub fn init(config: LoggerConfig) {
         }
     });
 
-    // Build optional OpenTelemetry layer plus the meter provider and the
-    // metrics-crate recorder bridge. Both pipelines share the same OTLP gRPC
-    // endpoint and Resource. The Collector demuxes by signal type.
-    let otel_layer = config.otel_url.as_ref().map(|otel_url| {
+    // Build optional OpenTelemetry tracing layer.
+    let otel_layer: Option<BoxedLayer> = config.otel_url.as_ref().map(|otel_url| {
         let resource = config.resource.build_resource();
 
         // Trace pipeline. tonic is the gRPC exporter; its underlying client
@@ -115,51 +113,16 @@ pub fn init(config: LoggerConfig) {
             error!("Failed to set global tracer provider");
         }
 
-        // Metric pipeline. PeriodicReader exports on a default interval; the
-        // SDK handles batching.
-        let metric_exporter = MetricExporter::builder()
-            .with_tonic()
-            .with_endpoint(otel_url)
-            .with_timeout(config.otlp_export_config.timeout)
-            .build()
-            .expect("init: failed to build OTLP metric exporter");
-
-        let mp = SdkMeterProvider::builder()
-            .with_resource(resource)
-            .with_periodic_exporter(metric_exporter)
-            .build();
-
-        set_meter_provider(mp.clone());
-
-        // Bridge `metrics`-crate calls into the OpenTelemetry meter. After
-        // this, every `metrics::counter!` / `gauge!` / `histogram!` site,
-        // including reth's internals and the [`MetricsLayer`] span timings,
-        // flows through OTLP push to the collector. Using `meter_with_scope`
-        // (instead of `global::meter`) lets the meter name come from a
-        // runtime String without leaking via `&'static str`.
-        let meter_scope = InstrumentationScope::builder(config.meter_name.clone()).build();
-        let recorder = OpenTelemetryRecorder::new(mp.meter_with_scope(meter_scope));
-
-        if METER_PROVIDER.set(mp).is_err() {
-            error!("Failed to set global meter provider");
-        }
-        if let Err(e) = metrics::set_global_recorder(recorder) {
-            error!(err = %e, "failed to install metrics-otel recorder");
-        }
-
-        let tt = tp.tracer("alpen-tracer");
-        tracing_opentelemetry::layer().with_tracer(tt)
+        let tracer = tp.tracer("alpen-tracer");
+        tracing_opentelemetry::layer().with_tracer(tracer).boxed()
     });
 
-    let metrics_layer = config.enable_metrics_layer.then_some(MetricsLayer);
+    let mut layers = vec![stdout_sub];
+    layers.extend(file_layer);
+    layers.extend(otel_layer);
+    layers.extend(extra_layers);
 
-    // Register all layers - with() accepts Option<Layer> so this scales cleanly
-    tracing_subscriber::registry()
-        .with(stdout_sub)
-        .with(file_layer)
-        .with(otel_layer)
-        .with(metrics_layer)
-        .init();
+    tracing_subscriber::registry().with(layers).init();
 
     info!(
         service_name = %config.resource.service_name,
@@ -207,15 +170,5 @@ pub fn finalize() {
         }
     } else {
         debug!("no tracer provider to shut down");
-    }
-
-    if let Some(provider) = METER_PROVIDER.get() {
-        if let Err(e) = provider.shutdown() {
-            error!(err = %e, "failed to shut down meter provider");
-        } else {
-            info!("meter provider shut down successfully");
-        }
-    } else {
-        debug!("no meter provider to shut down");
     }
 }

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -1,10 +1,10 @@
-//! Common logging service initialization for binaries.
+//! Common logging and tracing initialization for binaries.
 
 use std::path::PathBuf;
 
 use tracing::info;
 
-use super::{FileLoggingConfig, LoggerConfig, format_service_name, init};
+use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, init_with_layers};
 
 /// Configuration parameters for logging initialization.
 #[derive(Debug)]
@@ -23,11 +23,6 @@ pub struct LoggingInitConfig<'a> {
     pub json_format: Option<bool>,
     /// Default log file prefix if not specified in config
     pub default_log_prefix: &'a str,
-    /// Enable the tracing-to-metrics bridge layer.
-    ///
-    /// Set to `true` only when a `metrics` recorder has been (or will be)
-    /// installed. See [`MetricsLayer`](super::MetricsLayer).
-    pub enable_metrics_layer: bool,
     /// Extra `EnvFilter` directives to merge before `RUST_LOG`.
     ///
     /// Forwarded to [`LoggerConfig::extra_filter_directives`]. Use this from
@@ -36,11 +31,23 @@ pub struct LoggingInitConfig<'a> {
     pub extra_filter_directives: &'a [&'a str],
 }
 
-/// Initialize logging from configuration with all standard setup.
+/// Initialize process-global logging from configuration with all standard setup.
 ///
 /// This function encapsulates the common logging initialization logic used
-/// across all binaries:
+/// across binaries. It should be called once from a process entrypoint, not
+/// from libraries.
 pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
+    init_logging_from_config_with_layers(config, Vec::new());
+}
+
+/// Initialize process-global logging from configuration with extra subscriber layers.
+///
+/// This keeps logging initialization centralized while allowing companion crates
+/// to provide tracing layers without making this crate depend on them.
+pub fn init_logging_from_config_with_layers(
+    config: LoggingInitConfig<'_>,
+    extra_layers: Vec<BoxedLayer>,
+) {
     // Construct service name with optional label
     let service_name = format_service_name(config.service_base_name, config.service_label);
 
@@ -69,15 +76,13 @@ pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
         lconfig = lconfig.with_json_logging(json_format);
     }
 
-    lconfig = lconfig.with_metrics_layer(config.enable_metrics_layer);
-
     if !config.extra_filter_directives.is_empty() {
         lconfig =
             lconfig.with_extra_filter_directives(config.extra_filter_directives.iter().copied());
     }
 
     // Initialize logging
-    init(lconfig);
+    init_with_layers(lconfig, extra_layers);
 
     // Log configuration after init
     if let Some(url) = config.otlp_url {

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -128,18 +128,6 @@ fn test_trace_context_propagation() {
 }
 
 #[test]
-fn test_logger_config_metrics_layer_builder() {
-    let config = LoggerConfig::new("test-service".to_string());
-    assert!(!config.enable_metrics_layer);
-
-    let enabled = LoggerConfig::new("test-service".to_string()).with_metrics_layer(true);
-    assert!(enabled.enable_metrics_layer);
-
-    let disabled = enabled.with_metrics_layer(false);
-    assert!(!disabled.enable_metrics_layer);
-}
-
-#[test]
 fn test_logger_config_extra_filter_directives_default_empty() {
     let config = LoggerConfig::new("test-service".to_string());
     assert!(config.extra_filter_directives.is_empty());

--- a/crates/logging/src/types.rs
+++ b/crates/logging/src/types.rs
@@ -1,4 +1,4 @@
-//! Configuration types for the logging subsystem.
+//! Configuration types for the logging and tracing subsystem.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -152,19 +152,6 @@ pub struct LoggerConfig {
     pub file_logging_config: Option<FileLoggingConfig>,
     /// OTLP export configuration
     pub otlp_export_config: OtlpExportConfig,
-    /// Whether to install the tracing-to-metrics bridge layer.
-    ///
-    /// When `true`, a [`MetricsLayer`](super::MetricsLayer) is added to the
-    /// subscriber stack and records per-span busy/idle histograms via the
-    /// `metrics` facade. Only enable this when a `metrics` recorder is (or
-    /// will be) installed by the binary; otherwise the per-span state is
-    /// allocated for nothing.
-    pub enable_metrics_layer: bool,
-    /// Name passed to `opentelemetry::global::meter(...)` when installing
-    /// the `metrics`-crate to OpenTelemetry bridge. Identifies the
-    /// instrumentation library (the `otel.scope.name` attribute) on the
-    /// emitted metrics. Defaults to `"strata"`.
-    pub meter_name: String,
     /// Extra `EnvFilter` directives applied before the value of `RUST_LOG`.
     ///
     /// Each entry is a directive in the same syntax as `RUST_LOG`
@@ -184,8 +171,6 @@ impl LoggerConfig {
             stdout_config: StdoutConfig::default(),
             file_logging_config: None,
             otlp_export_config: OtlpExportConfig::default(),
-            enable_metrics_layer: false,
-            meter_name: "strata".to_string(),
             extra_filter_directives: Vec::new(),
         }
     }
@@ -234,19 +219,6 @@ impl LoggerConfig {
     /// Set OTLP export configuration
     pub fn with_otlp_export_config(mut self, config: OtlpExportConfig) -> Self {
         self.otlp_export_config = config;
-        self
-    }
-
-    /// Enable or disable the tracing-to-metrics bridge layer.
-    pub fn with_metrics_layer(mut self, enabled: bool) -> Self {
-        self.enable_metrics_layer = enabled;
-        self
-    }
-
-    /// Override the meter name passed to `opentelemetry::global::meter(...)`
-    /// when installing the `metrics`-crate to OpenTelemetry bridge.
-    pub fn with_meter_name(mut self, name: String) -> Self {
-        self.meter_name = name;
         self
     }
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,16 +1,19 @@
 [package]
 edition = "2024"
-name = "strata-logging"
+name = "strata-metrics"
 version = "0.1.0"
 
 [lints]
 workspace = true
 
 [dependencies]
+metrics.workspace = true
+metrics-exporter-otel.workspace = true
+metrics-exporter-prometheus.workspace = true
+metrics-util.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
+tokio.workspace = true
 tracing.workspace = true
-tracing-appender.workspace = true
-tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -6,14 +6,26 @@ version = "0.1.0"
 [lints]
 workspace = true
 
+[features]
+default = ["otlp", "prometheus"]
+otlp = [
+  "dep:metrics-exporter-otel",
+  "dep:metrics-util",
+  "dep:opentelemetry",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry_sdk",
+]
+prometheus = ["dep:metrics-exporter-prometheus", "dep:metrics-util"]
+
 [dependencies]
 metrics.workspace = true
-metrics-exporter-otel.workspace = true
-metrics-exporter-prometheus.workspace = true
-metrics-util.workspace = true
-opentelemetry.workspace = true
-opentelemetry-otlp.workspace = true
-opentelemetry_sdk.workspace = true
+metrics-exporter-otel = { workspace = true, optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
+metrics-util = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -1,0 +1,16 @@
+//! Process-level metrics initialization.
+//!
+//! This crate installs the process-global `metrics` recorder and optional
+//! metrics exporter tasks. Binaries should initialize it once at process
+//! startup. Library crates should only emit metrics instruments.
+
+pub mod manager;
+pub mod metrics_layer;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use manager::{finalize, init};
+pub use metrics_layer::MetricsLayer;
+pub use types::{MetricsConfig, MetricsInitConfig, OtlpExportConfig, ResourceConfig};

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -11,6 +11,8 @@ pub mod types;
 #[cfg(test)]
 mod tests;
 
-pub use manager::{finalize, init};
+pub use manager::{MetricsInitError, finalize, init};
 pub use metrics_layer::MetricsLayer;
-pub use types::{MetricsConfig, MetricsInitConfig, OtlpExportConfig, ResourceConfig};
+pub use types::{MetricsConfig, MetricsInitConfig};
+#[cfg(feature = "otlp")]
+pub use types::{OtlpExportConfig, ResourceConfig};

--- a/crates/metrics/src/manager.rs
+++ b/crates/metrics/src/manager.rs
@@ -1,0 +1,128 @@
+//! Metrics recorder initialization and shutdown management.
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
+use metrics::Recorder;
+use metrics_exporter_otel::OpenTelemetryRecorder;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_util::layers::FanoutBuilder;
+use opentelemetry::InstrumentationScope;
+use opentelemetry::global::set_meter_provider;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use tracing::{debug, error, info};
+
+use crate::types::MetricsInitConfig;
+
+/// Global meter provider for proper shutdown.
+static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+/// Initializes process-global metrics with the provided config.
+///
+/// Call this once from the process entrypoint. Library crates should not call
+/// it; they should emit `metrics` instruments and rely on the binary to install
+/// the recorder.
+pub fn init(config: MetricsInitConfig) {
+    let metrics_config = config.metrics_config.resolve(config.otlp_url.is_some());
+    let otlp_recorder = metrics_config
+        .uses_otlp()
+        .then(|| build_otlp_metrics_recorder(&config));
+    let prometheus_recorder = metrics_config
+        .prometheus_listen_addr()
+        .map(build_prometheus_recorder);
+
+    match (otlp_recorder, prometheus_recorder) {
+        (Some(otlp), Some(prometheus)) => {
+            let recorder = FanoutBuilder::default()
+                .add_recorder(otlp)
+                .add_recorder(prometheus)
+                .build();
+            install_global_metrics_recorder(recorder, "fanout");
+        }
+        (Some(otlp), None) => {
+            install_global_metrics_recorder(otlp, "metrics-otel");
+        }
+        (None, Some(prometheus)) => {
+            install_global_metrics_recorder(prometheus, "Prometheus");
+        }
+        (None, None) => {}
+    }
+
+    if metrics_config.uses_otlp() {
+        info!("using OpenTelemetry metrics output");
+    }
+    if let Some(listen_addr) = metrics_config.prometheus_listen_addr() {
+        info!(%listen_addr, "using Prometheus metrics output");
+    }
+}
+
+fn install_global_metrics_recorder<R>(recorder: R, recorder_name: &str)
+where
+    R: Recorder + Sync + 'static,
+{
+    if let Err(e) = metrics::set_global_recorder(recorder) {
+        panic!("metrics init: failed to install {recorder_name} metrics recorder: {e}");
+    }
+}
+
+fn build_otlp_metrics_recorder(config: &MetricsInitConfig) -> OpenTelemetryRecorder {
+    let Some(otel_url) = config.otlp_url.as_ref() else {
+        panic!("metrics init: OTLP metrics requested without an OTLP endpoint URL");
+    };
+
+    let metric_exporter = MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(otel_url)
+        .with_timeout(config.otlp_export_config.timeout)
+        .build()
+        .expect("metrics init: failed to build OTLP metric exporter");
+
+    let mp = SdkMeterProvider::builder()
+        .with_resource(config.resource.build_resource())
+        .with_periodic_exporter(metric_exporter)
+        .build();
+
+    set_meter_provider(mp.clone());
+
+    let meter_scope = InstrumentationScope::builder(config.meter_name.clone()).build();
+    let recorder = OpenTelemetryRecorder::new(mp.meter_with_scope(meter_scope));
+
+    if METER_PROVIDER.set(mp).is_err() {
+        error!("failed to set global meter provider");
+    }
+
+    recorder
+}
+
+fn build_prometheus_recorder(
+    listen_addr: SocketAddr,
+) -> metrics_exporter_prometheus::PrometheusRecorder {
+    tokio::runtime::Handle::try_current()
+        .expect("metrics init: Prometheus metrics exporter requires an active Tokio runtime");
+
+    let (recorder, exporter) = PrometheusBuilder::new()
+        .with_http_listener(listen_addr)
+        .build()
+        .expect("metrics init: failed to build Prometheus metrics exporter");
+
+    tokio::spawn(exporter);
+
+    recorder
+}
+
+/// Shuts down the metrics subsystem, flushing pending OTLP metrics.
+pub fn finalize() {
+    info!("shutting down metrics");
+
+    if let Some(provider) = METER_PROVIDER.get() {
+        if let Err(e) = provider.shutdown() {
+            error!(err = %e, "failed to shut down meter provider");
+        } else {
+            info!("meter provider shut down successfully");
+        }
+    } else {
+        debug!("no meter provider to shut down");
+    }
+}

--- a/crates/metrics/src/manager.rs
+++ b/crates/metrics/src/manager.rs
@@ -1,83 +1,151 @@
 //! Metrics recorder initialization and shutdown management.
 
-use std::net::SocketAddr;
+#[cfg(feature = "otlp")]
 use std::sync::OnceLock;
 
+#[cfg(any(feature = "otlp", feature = "prometheus"))]
 use metrics::Recorder;
+#[cfg(feature = "otlp")]
 use metrics_exporter_otel::OpenTelemetryRecorder;
+#[cfg(feature = "prometheus")]
 use metrics_exporter_prometheus::PrometheusBuilder;
+#[cfg(any(feature = "otlp", feature = "prometheus"))]
 use metrics_util::layers::FanoutBuilder;
+#[cfg(feature = "otlp")]
 use opentelemetry::InstrumentationScope;
+#[cfg(feature = "otlp")]
 use opentelemetry::global::set_meter_provider;
+#[cfg(feature = "otlp")]
 use opentelemetry::metrics::MeterProvider;
+#[cfg(feature = "otlp")]
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::metrics::SdkMeterProvider;
-use tracing::{debug, error, info};
+use tokio::runtime::Handle;
+#[cfg(feature = "otlp")]
+use tracing::error;
+use tracing::{debug, info};
 
 use crate::types::MetricsInitConfig;
 
 /// Global meter provider for proper shutdown.
+#[cfg(feature = "otlp")]
 static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+/// Metrics initialization error.
+#[derive(Debug, thiserror::Error)]
+pub enum MetricsInitError {
+    /// OTLP metrics were requested but the crate was compiled without OTLP support.
+    #[error("OTLP metrics exporter requested but strata-metrics was compiled without `otlp`")]
+    OtlpDisabled,
+    /// Prometheus metrics were requested but the crate was compiled without Prometheus support.
+    #[error(
+        "Prometheus metrics exporter requested but strata-metrics was compiled without `prometheus`"
+    )]
+    PrometheusDisabled,
+    /// Failed to build the OTLP metrics exporter.
+    #[error("failed to build OTLP metrics exporter: {0}")]
+    BuildOtlpExporter(String),
+    /// Failed to build the Prometheus metrics exporter.
+    #[error("failed to build Prometheus metrics exporter: {0}")]
+    BuildPrometheusExporter(String),
+    /// Failed to install the process-global metrics recorder.
+    #[error(
+        "failed to install {recorder_name} metrics recorder because a global recorder is already installed"
+    )]
+    SetRecorder {
+        /// Recorder backend name.
+        recorder_name: &'static str,
+    },
+}
 
 /// Initializes process-global metrics with the provided config.
 ///
 /// Call this once from the process entrypoint. Library crates should not call
 /// it; they should emit `metrics` instruments and rely on the binary to install
 /// the recorder.
-pub fn init(config: MetricsInitConfig) {
-    let metrics_config = config.metrics_config.resolve(config.otlp_url.is_some());
-    let otlp_recorder = metrics_config
-        .uses_otlp()
-        .then(|| build_otlp_metrics_recorder(&config));
-    let prometheus_recorder = metrics_config
-        .prometheus_listen_addr()
-        .map(build_prometheus_recorder);
+pub fn init(config: MetricsInitConfig, runtime_handle: &Handle) -> Result<(), MetricsInitError> {
+    validate_enabled_features(&config)?;
 
-    match (otlp_recorder, prometheus_recorder) {
-        (Some(otlp), Some(prometheus)) => {
-            let recorder = FanoutBuilder::default()
-                .add_recorder(otlp)
-                .add_recorder(prometheus)
-                .build();
-            install_global_metrics_recorder(recorder, "fanout");
-        }
-        (Some(otlp), None) => {
-            install_global_metrics_recorder(otlp, "metrics-otel");
-        }
-        (None, Some(prometheus)) => {
-            install_global_metrics_recorder(prometheus, "Prometheus");
-        }
-        (None, None) => {}
+    #[cfg(not(any(feature = "otlp", feature = "prometheus")))]
+    let _ = runtime_handle;
+
+    #[cfg(any(feature = "otlp", feature = "prometheus"))]
+    let mut recorder_count = 0;
+    #[cfg(any(feature = "otlp", feature = "prometheus"))]
+    let mut fanout = FanoutBuilder::default();
+
+    #[cfg(feature = "otlp")]
+    if config.metrics_config.uses_otlp() {
+        let otlp = build_otlp_metrics_recorder(&config, runtime_handle)?;
+        fanout = fanout.add_recorder(otlp);
+        recorder_count += 1;
     }
 
-    if metrics_config.uses_otlp() {
+    #[cfg(feature = "prometheus")]
+    if let Some(listen_addr) = config.metrics_config.prometheus_listen_addr() {
+        let prometheus = build_prometheus_recorder(listen_addr, runtime_handle)?;
+        fanout = fanout.add_recorder(prometheus);
+        recorder_count += 1;
+    }
+
+    #[cfg(any(feature = "otlp", feature = "prometheus"))]
+    if recorder_count > 0 {
+        install_global_metrics_recorder(fanout.build(), "fanout")?;
+    }
+
+    if config.metrics_config.uses_otlp() {
         info!("using OpenTelemetry metrics output");
     }
-    if let Some(listen_addr) = metrics_config.prometheus_listen_addr() {
+    if let Some(listen_addr) = config.metrics_config.prometheus_listen_addr() {
         info!(%listen_addr, "using Prometheus metrics output");
     }
+
+    Ok(())
 }
 
-fn install_global_metrics_recorder<R>(recorder: R, recorder_name: &str)
+fn validate_enabled_features(_config: &MetricsInitConfig) -> Result<(), MetricsInitError> {
+    #[cfg(not(feature = "otlp"))]
+    if _config.metrics_config.uses_otlp() {
+        return Err(MetricsInitError::OtlpDisabled);
+    }
+
+    #[cfg(not(feature = "prometheus"))]
+    if _config.metrics_config.prometheus_listen_addr().is_some() {
+        return Err(MetricsInitError::PrometheusDisabled);
+    }
+
+    Ok(())
+}
+
+#[cfg(any(feature = "otlp", feature = "prometheus"))]
+fn install_global_metrics_recorder<R>(
+    recorder: R,
+    recorder_name: &'static str,
+) -> Result<(), MetricsInitError>
 where
     R: Recorder + Sync + 'static,
 {
-    if let Err(e) = metrics::set_global_recorder(recorder) {
-        panic!("metrics init: failed to install {recorder_name} metrics recorder: {e}");
-    }
+    metrics::set_global_recorder(recorder)
+        .map_err(|_source| MetricsInitError::SetRecorder { recorder_name })
 }
 
-fn build_otlp_metrics_recorder(config: &MetricsInitConfig) -> OpenTelemetryRecorder {
-    let Some(otel_url) = config.otlp_url.as_ref() else {
-        panic!("metrics init: OTLP metrics requested without an OTLP endpoint URL");
+#[cfg(feature = "otlp")]
+fn build_otlp_metrics_recorder(
+    config: &MetricsInitConfig,
+    runtime_handle: &Handle,
+) -> Result<OpenTelemetryRecorder, MetricsInitError> {
+    let Some(otel_url) = config.metrics_config.otlp_endpoint() else {
+        unreachable!("OTLP recorder is only built when an OTLP endpoint is configured");
     };
 
+    let _runtime_guard = runtime_handle.enter();
     let metric_exporter = MetricExporter::builder()
         .with_tonic()
         .with_endpoint(otel_url)
         .with_timeout(config.otlp_export_config.timeout)
         .build()
-        .expect("metrics init: failed to build OTLP metric exporter");
+        .map_err(|err| MetricsInitError::BuildOtlpExporter(err.to_string()))?;
 
     let mp = SdkMeterProvider::builder()
         .with_resource(config.resource.build_resource())
@@ -93,29 +161,29 @@ fn build_otlp_metrics_recorder(config: &MetricsInitConfig) -> OpenTelemetryRecor
         error!("failed to set global meter provider");
     }
 
-    recorder
+    Ok(recorder)
 }
 
+#[cfg(feature = "prometheus")]
 fn build_prometheus_recorder(
-    listen_addr: SocketAddr,
-) -> metrics_exporter_prometheus::PrometheusRecorder {
-    tokio::runtime::Handle::try_current()
-        .expect("metrics init: Prometheus metrics exporter requires an active Tokio runtime");
-
+    listen_addr: std::net::SocketAddr,
+    runtime_handle: &Handle,
+) -> Result<metrics_exporter_prometheus::PrometheusRecorder, MetricsInitError> {
     let (recorder, exporter) = PrometheusBuilder::new()
         .with_http_listener(listen_addr)
         .build()
-        .expect("metrics init: failed to build Prometheus metrics exporter");
+        .map_err(|err| MetricsInitError::BuildPrometheusExporter(err.to_string()))?;
 
-    tokio::spawn(exporter);
+    runtime_handle.spawn(exporter);
 
-    recorder
+    Ok(recorder)
 }
 
 /// Shuts down the metrics subsystem, flushing pending OTLP metrics.
 pub fn finalize() {
     info!("shutting down metrics");
 
+    #[cfg(feature = "otlp")]
     if let Some(provider) = METER_PROVIDER.get() {
         if let Err(e) = provider.shutdown() {
             error!(err = %e, "failed to shut down meter provider");
@@ -125,4 +193,7 @@ pub fn finalize() {
     } else {
         debug!("no meter provider to shut down");
     }
+
+    #[cfg(not(feature = "otlp"))]
+    debug!("no meter provider to shut down");
 }

--- a/crates/metrics/src/metrics_layer.rs
+++ b/crates/metrics/src/metrics_layer.rs
@@ -17,18 +17,14 @@ struct SpanTiming {
 
 /// A tracing [`Layer`] that records span busy/idle time as `metrics` histograms.
 ///
-/// For every span that closes, two histograms are recorded (microseconds):
+/// For every span that closes, two histograms are recorded in microseconds:
 ///
 /// - `strata_span_busy_us{span="<name>"}`: time the span was actively executing.
 /// - `strata_span_idle_us{span="<name>"}`: wall time the span existed but was not executing.
 ///
-/// The layer always emits these via the `metrics` facade. If no recorder is
-/// installed, the calls are cheap no-ops, but the per-span state is still
-/// allocated. Callers who never run with a recorder should install this layer
-/// conditionally (see [`LoggerConfig::enable_metrics_layer`][super::LoggerConfig]).
-///
-/// Timing assumes each span is entered and exited in balanced pairs, which is
-/// the contract `tracing` guarantees for correctly instrumented async code.
+/// The layer always emits via the `metrics` facade. If no recorder is
+/// installed, the calls are no-ops, but the per-span state is still allocated.
+/// Binaries should install this layer only when span timing metrics are wanted.
 #[derive(Debug)]
 pub struct MetricsLayer;
 
@@ -77,25 +73,5 @@ where
             metrics::histogram!("strata_span_idle_us", "span" => name)
                 .record(idle.as_micros() as f64);
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use tracing::{info_span, subscriber};
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::registry;
-
-    use super::*;
-
-    /// Exercising the layer without a metrics recorder installed should not
-    /// panic. `metrics::histogram!` is a no-op in that case.
-    #[test]
-    fn records_without_panicking_when_no_recorder_is_installed() {
-        let subscriber = registry().with(MetricsLayer);
-        subscriber::with_default(subscriber, || {
-            let span = info_span!("test_span");
-            let _guard = span.enter();
-        });
     }
 }

--- a/crates/metrics/src/tests.rs
+++ b/crates/metrics/src/tests.rs
@@ -2,6 +2,7 @@
 
 use std::net::SocketAddr;
 
+#[cfg(feature = "otlp")]
 use opentelemetry::KeyValue;
 use tracing::{info_span, subscriber};
 use tracing_subscriber::layer::SubscriberExt;
@@ -10,6 +11,7 @@ use tracing_subscriber::registry;
 use super::metrics_layer::MetricsLayer;
 use super::types::*;
 
+#[cfg(feature = "otlp")]
 #[test]
 fn test_resource_config_new() {
     let config = ResourceConfig::new("test-service".to_string());
@@ -20,6 +22,7 @@ fn test_resource_config_new() {
     assert!(config.custom_attributes.is_empty());
 }
 
+#[cfg(feature = "otlp")]
 #[test]
 fn test_resource_config_build_minimal() {
     let config = ResourceConfig::new("test-service".to_string());
@@ -33,6 +36,7 @@ fn test_resource_config_build_minimal() {
     );
 }
 
+#[cfg(feature = "otlp")]
 #[test]
 fn test_resource_config_build_with_all_semantic_conventions() {
     let config = ResourceConfig {
@@ -86,71 +90,103 @@ fn test_resource_config_build_with_all_semantic_conventions() {
 #[test]
 fn test_metrics_config_helpers() {
     let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+    let otlp_endpoint = "http://127.0.0.1:4317".to_string();
 
-    assert!(!MetricsConfig::Default.is_explicitly_enabled());
-    assert!(!MetricsConfig::Default.uses_otlp());
-    assert_eq!(MetricsConfig::Default.prometheus_listen_addr(), None);
-    assert_eq!(
-        MetricsConfig::Default.resolve(false),
-        MetricsConfig::Disabled
-    );
-    assert_eq!(MetricsConfig::Default.resolve(true), MetricsConfig::Otlp);
+    let disabled = MetricsConfig::default();
+    assert!(!disabled.is_explicitly_enabled());
+    assert!(!disabled.uses_otlp());
+    assert_eq!(disabled.otlp_endpoint(), None);
+    assert_eq!(disabled.prometheus_listen_addr(), None);
+    assert_eq!(MetricsConfig::disabled(), disabled);
 
-    assert!(!MetricsConfig::Disabled.is_explicitly_enabled());
-    assert!(!MetricsConfig::Disabled.uses_otlp());
-    assert_eq!(MetricsConfig::Disabled.prometheus_listen_addr(), None);
+    let otlp = MetricsConfig::default().with_otlp_endpoint(otlp_endpoint.clone());
+    assert!(otlp.is_explicitly_enabled());
+    assert!(otlp.uses_otlp());
+    assert_eq!(otlp.otlp_endpoint(), Some(otlp_endpoint.as_str()));
+    assert_eq!(otlp.prometheus_listen_addr(), None);
 
-    assert!(MetricsConfig::Otlp.is_explicitly_enabled());
-    assert!(MetricsConfig::Otlp.uses_otlp());
-    assert_eq!(MetricsConfig::Otlp.prometheus_listen_addr(), None);
-
-    let prometheus = MetricsConfig::Prometheus { listen_addr };
+    let prometheus = MetricsConfig::default().with_prometheus_listener(listen_addr);
     assert!(prometheus.is_explicitly_enabled());
     assert!(!prometheus.uses_otlp());
+    assert_eq!(prometheus.otlp_endpoint(), None);
     assert_eq!(prometheus.prometheus_listen_addr(), Some(listen_addr));
 
-    let fanout = MetricsConfig::OtlpAndPrometheus { listen_addr };
+    let fanout = MetricsConfig::from_exporters(Some(otlp_endpoint.clone()), Some(listen_addr));
     assert!(fanout.is_explicitly_enabled());
     assert!(fanout.uses_otlp());
+    assert_eq!(fanout.otlp_endpoint(), Some(otlp_endpoint.as_str()));
     assert_eq!(fanout.prometheus_listen_addr(), Some(listen_addr));
 }
 
 #[test]
 fn test_metrics_config_from_exporters() {
     let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+    let otlp_endpoint = "http://127.0.0.1:4317".to_string();
 
     assert_eq!(
-        MetricsConfig::from_exporters(false, None),
-        MetricsConfig::Disabled
+        MetricsConfig::from_exporters(None, None),
+        MetricsConfig::disabled()
     );
     assert_eq!(
-        MetricsConfig::from_exporters(true, None),
-        MetricsConfig::Otlp
+        MetricsConfig::from_exporters(Some(otlp_endpoint.clone()), None),
+        MetricsConfig {
+            otlp_endpoint: Some(otlp_endpoint.clone()),
+            prometheus_listener_addr: None,
+        }
     );
     assert_eq!(
-        MetricsConfig::from_exporters(false, Some(listen_addr)),
-        MetricsConfig::Prometheus { listen_addr }
+        MetricsConfig::from_exporters(None, Some(listen_addr)),
+        MetricsConfig {
+            otlp_endpoint: None,
+            prometheus_listener_addr: Some(listen_addr),
+        }
     );
     assert_eq!(
-        MetricsConfig::from_exporters(true, Some(listen_addr)),
-        MetricsConfig::OtlpAndPrometheus { listen_addr }
+        MetricsConfig::from_exporters(Some(otlp_endpoint.clone()), Some(listen_addr)),
+        MetricsConfig {
+            otlp_endpoint: Some(otlp_endpoint),
+            prometheus_listener_addr: Some(listen_addr),
+        }
     );
 }
 
 #[test]
 fn test_metrics_init_config_builder_pattern() {
     let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+    let otlp_endpoint = "http://127.0.0.1:4317".to_string();
     let config = MetricsInitConfig::new("test-service".to_string())
-        .with_otlp_url("http://127.0.0.1:4317".to_string())
-        .with_metrics_config(MetricsConfig::Prometheus { listen_addr })
-        .with_meter_name("test-meter".to_string());
+        .with_otlp_endpoint(otlp_endpoint.clone())
+        .with_metrics_config(MetricsConfig::from_exporters(
+            Some(otlp_endpoint.clone()),
+            Some(listen_addr),
+        ));
 
+    #[cfg(feature = "otlp")]
     assert_eq!(config.resource.service_name, "test-service");
-    assert_eq!(config.otlp_url, Some("http://127.0.0.1:4317".to_string()));
     assert_eq!(
         config.metrics_config,
-        MetricsConfig::Prometheus { listen_addr }
+        MetricsConfig::from_exporters(Some(otlp_endpoint), Some(listen_addr))
     );
+}
+
+#[test]
+fn test_metrics_init_config_otlp_url_alias() {
+    let otlp_endpoint = "http://127.0.0.1:4317".to_string();
+    let config =
+        MetricsInitConfig::new("test-service".to_string()).with_otlp_url(otlp_endpoint.clone());
+
+    assert_eq!(
+        config.metrics_config.otlp_endpoint(),
+        Some(otlp_endpoint.as_str())
+    );
+}
+
+#[cfg(feature = "otlp")]
+#[test]
+fn test_metrics_init_config_meter_name_builder() {
+    let config = MetricsInitConfig::new("test-service".to_string())
+        .with_meter_name("test-meter".to_string());
+
     assert_eq!(config.meter_name, "test-meter");
 }
 

--- a/crates/metrics/src/tests.rs
+++ b/crates/metrics/src/tests.rs
@@ -1,0 +1,164 @@
+//! Unit tests for the metrics subsystem.
+
+use std::net::SocketAddr;
+
+use opentelemetry::KeyValue;
+use tracing::{info_span, subscriber};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry;
+
+use super::metrics_layer::MetricsLayer;
+use super::types::*;
+
+#[test]
+fn test_resource_config_new() {
+    let config = ResourceConfig::new("test-service".to_string());
+    assert_eq!(config.service_name, "test-service");
+    assert_eq!(config.service_version, None);
+    assert_eq!(config.deployment_environment, None);
+    assert_eq!(config.service_instance_id, None);
+    assert!(config.custom_attributes.is_empty());
+}
+
+#[test]
+fn test_resource_config_build_minimal() {
+    let config = ResourceConfig::new("test-service".to_string());
+    let resource = config.build_resource();
+
+    let attrs: Vec<_> = resource.iter().collect();
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "service.name" && value.as_str() == "test-service")
+    );
+}
+
+#[test]
+fn test_resource_config_build_with_all_semantic_conventions() {
+    let config = ResourceConfig {
+        service_name: "test-service".to_string(),
+        service_version: Some("1.0.0".to_string()),
+        deployment_environment: Some("production".to_string()),
+        service_instance_id: Some("instance-123".to_string()),
+        custom_attributes: vec![
+            KeyValue::new("custom.key1", "value1"),
+            KeyValue::new("custom.key2", "value2"),
+        ],
+    };
+
+    let resource = config.build_resource();
+    let attrs: Vec<_> = resource.iter().collect();
+
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "service.name" && value.as_str() == "test-service")
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "service.version" && value.as_str() == "1.0.0")
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "deployment.environment"
+                && value.as_str() == "production")
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "service.instance.id"
+                && value.as_str() == "instance-123")
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "custom.key1" && value.as_str() == "value1")
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|(key, value)| key.as_str() == "custom.key2" && value.as_str() == "value2")
+    );
+}
+
+#[test]
+fn test_metrics_config_helpers() {
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+
+    assert!(!MetricsConfig::Default.is_explicitly_enabled());
+    assert!(!MetricsConfig::Default.uses_otlp());
+    assert_eq!(MetricsConfig::Default.prometheus_listen_addr(), None);
+    assert_eq!(
+        MetricsConfig::Default.resolve(false),
+        MetricsConfig::Disabled
+    );
+    assert_eq!(MetricsConfig::Default.resolve(true), MetricsConfig::Otlp);
+
+    assert!(!MetricsConfig::Disabled.is_explicitly_enabled());
+    assert!(!MetricsConfig::Disabled.uses_otlp());
+    assert_eq!(MetricsConfig::Disabled.prometheus_listen_addr(), None);
+
+    assert!(MetricsConfig::Otlp.is_explicitly_enabled());
+    assert!(MetricsConfig::Otlp.uses_otlp());
+    assert_eq!(MetricsConfig::Otlp.prometheus_listen_addr(), None);
+
+    let prometheus = MetricsConfig::Prometheus { listen_addr };
+    assert!(prometheus.is_explicitly_enabled());
+    assert!(!prometheus.uses_otlp());
+    assert_eq!(prometheus.prometheus_listen_addr(), Some(listen_addr));
+
+    let fanout = MetricsConfig::OtlpAndPrometheus { listen_addr };
+    assert!(fanout.is_explicitly_enabled());
+    assert!(fanout.uses_otlp());
+    assert_eq!(fanout.prometheus_listen_addr(), Some(listen_addr));
+}
+
+#[test]
+fn test_metrics_config_from_exporters() {
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+
+    assert_eq!(
+        MetricsConfig::from_exporters(false, None),
+        MetricsConfig::Disabled
+    );
+    assert_eq!(
+        MetricsConfig::from_exporters(true, None),
+        MetricsConfig::Otlp
+    );
+    assert_eq!(
+        MetricsConfig::from_exporters(false, Some(listen_addr)),
+        MetricsConfig::Prometheus { listen_addr }
+    );
+    assert_eq!(
+        MetricsConfig::from_exporters(true, Some(listen_addr)),
+        MetricsConfig::OtlpAndPrometheus { listen_addr }
+    );
+}
+
+#[test]
+fn test_metrics_init_config_builder_pattern() {
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], 9615));
+    let config = MetricsInitConfig::new("test-service".to_string())
+        .with_otlp_url("http://127.0.0.1:4317".to_string())
+        .with_metrics_config(MetricsConfig::Prometheus { listen_addr })
+        .with_meter_name("test-meter".to_string());
+
+    assert_eq!(config.resource.service_name, "test-service");
+    assert_eq!(config.otlp_url, Some("http://127.0.0.1:4317".to_string()));
+    assert_eq!(
+        config.metrics_config,
+        MetricsConfig::Prometheus { listen_addr }
+    );
+    assert_eq!(config.meter_name, "test-meter");
+}
+
+#[test]
+fn span_metrics_layer_records_without_panicking_when_no_recorder_is_installed() {
+    let subscriber = registry().with(MetricsLayer);
+    subscriber::with_default(subscriber, || {
+        let span = info_span!("test_span");
+        let _guard = span.enter();
+    });
+}

--- a/crates/metrics/src/types.rs
+++ b/crates/metrics/src/types.rs
@@ -1,0 +1,207 @@
+//! Configuration types for metrics exporters.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::Resource;
+
+/// Configuration for OTLP exporter retry and timeout.
+#[derive(Debug, Clone)]
+pub struct OtlpExportConfig {
+    /// Timeout for export requests.
+    pub timeout: Duration,
+    /// Maximum number of retry attempts.
+    pub max_retries: u32,
+}
+
+impl Default for OtlpExportConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(10),
+            max_retries: 3,
+        }
+    }
+}
+
+/// Metrics exporter configuration.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum MetricsConfig {
+    /// Preserve default metrics behavior for the configured backend.
+    ///
+    /// When an OTLP endpoint is configured, this installs the OTLP metrics
+    /// recorder. Otherwise, it leaves metrics disabled.
+    #[default]
+    Default,
+    /// Do not install a `metrics` recorder.
+    Disabled,
+    /// Export metrics through the configured OTLP endpoint.
+    Otlp,
+    /// Expose metrics through a Prometheus scrape endpoint.
+    Prometheus {
+        /// Address used by the Prometheus HTTP listener.
+        listen_addr: SocketAddr,
+    },
+    /// Export metrics through OTLP and expose them through Prometheus.
+    OtlpAndPrometheus {
+        /// Address used by the Prometheus HTTP listener.
+        listen_addr: SocketAddr,
+    },
+}
+
+impl MetricsConfig {
+    /// Builds a metrics configuration from explicit exporter inputs.
+    pub const fn from_exporters(
+        otlp_enabled: bool,
+        prometheus_listen_addr: Option<SocketAddr>,
+    ) -> Self {
+        match (otlp_enabled, prometheus_listen_addr) {
+            (true, Some(listen_addr)) => Self::OtlpAndPrometheus { listen_addr },
+            (true, None) => Self::Otlp,
+            (false, Some(listen_addr)) => Self::Prometheus { listen_addr },
+            (false, None) => Self::Disabled,
+        }
+    }
+
+    /// Resolves default behavior against the configured OTLP endpoint.
+    pub const fn resolve(self, otlp_endpoint_configured: bool) -> Self {
+        match (self, otlp_endpoint_configured) {
+            (Self::Default, true) => Self::Otlp,
+            (Self::Default, false) => Self::Disabled,
+            (config, _) => config,
+        }
+    }
+
+    /// Returns `true` when this config explicitly enables a metrics recorder.
+    pub const fn is_explicitly_enabled(self) -> bool {
+        matches!(
+            self,
+            Self::Otlp | Self::Prometheus { .. } | Self::OtlpAndPrometheus { .. }
+        )
+    }
+
+    /// Returns `true` when metrics should be exported over OTLP.
+    pub const fn uses_otlp(self) -> bool {
+        matches!(self, Self::Otlp | Self::OtlpAndPrometheus { .. })
+    }
+
+    /// Returns the Prometheus listener address, if configured.
+    pub const fn prometheus_listen_addr(self) -> Option<SocketAddr> {
+        match self {
+            Self::Prometheus { listen_addr } | Self::OtlpAndPrometheus { listen_addr } => {
+                Some(listen_addr)
+            }
+            Self::Default | Self::Disabled | Self::Otlp => None,
+        }
+    }
+}
+
+/// Resource attributes following OpenTelemetry semantic conventions.
+#[derive(Debug, Clone)]
+pub struct ResourceConfig {
+    /// Service name.
+    pub service_name: String,
+    /// Service version.
+    pub service_version: Option<String>,
+    /// Deployment environment.
+    pub deployment_environment: Option<String>,
+    /// Service instance ID.
+    pub service_instance_id: Option<String>,
+    /// Additional custom attributes.
+    pub custom_attributes: Vec<KeyValue>,
+}
+
+impl ResourceConfig {
+    /// Creates a new resource configuration with the given service name.
+    pub fn new(service_name: String) -> Self {
+        Self {
+            service_name,
+            service_version: None,
+            deployment_environment: None,
+            service_instance_id: None,
+            custom_attributes: Vec::new(),
+        }
+    }
+
+    /// Builds an OpenTelemetry resource from config.
+    pub fn build_resource(&self) -> Resource {
+        let ResourceConfig {
+            service_name,
+            service_version,
+            deployment_environment,
+            service_instance_id,
+            custom_attributes,
+        } = self;
+
+        let mut attributes = vec![KeyValue::new("service.name", service_name.clone())];
+
+        if let Some(version) = service_version {
+            attributes.push(KeyValue::new("service.version", version.clone()));
+        }
+
+        if let Some(env) = deployment_environment {
+            attributes.push(KeyValue::new("deployment.environment", env.clone()));
+        }
+
+        if let Some(instance_id) = service_instance_id {
+            attributes.push(KeyValue::new("service.instance.id", instance_id.clone()));
+        }
+
+        attributes.extend(custom_attributes.iter().cloned());
+
+        Resource::builder().with_attributes(attributes).build()
+    }
+}
+
+/// Process-level metrics initialization config.
+#[derive(Debug, Clone)]
+pub struct MetricsInitConfig {
+    /// Resource configuration used for OTLP metrics.
+    pub resource: ResourceConfig,
+    /// OTLP endpoint URL.
+    pub otlp_url: Option<String>,
+    /// OTLP export configuration.
+    pub otlp_export_config: OtlpExportConfig,
+    /// Metrics exporter configuration.
+    pub metrics_config: MetricsConfig,
+    /// Name of the OpenTelemetry instrumentation scope used by the metrics
+    /// facade bridge.
+    pub meter_name: String,
+}
+
+impl MetricsInitConfig {
+    /// Creates a metrics initialization config with defaults.
+    pub fn new(service_name: String) -> Self {
+        Self {
+            resource: ResourceConfig::new(service_name),
+            otlp_url: None,
+            otlp_export_config: OtlpExportConfig::default(),
+            metrics_config: MetricsConfig::default(),
+            meter_name: "strata".to_string(),
+        }
+    }
+
+    /// Sets the OTLP endpoint URL.
+    pub fn with_otlp_url(mut self, url: String) -> Self {
+        self.otlp_url = Some(url);
+        self
+    }
+
+    /// Sets the metrics exporter configuration.
+    pub fn with_metrics_config(mut self, config: MetricsConfig) -> Self {
+        self.metrics_config = config;
+        self
+    }
+
+    /// Sets the OTLP export configuration.
+    pub fn with_otlp_export_config(mut self, config: OtlpExportConfig) -> Self {
+        self.otlp_export_config = config;
+        self
+    }
+
+    /// Sets the meter name used by the `metrics` facade to OpenTelemetry bridge.
+    pub fn with_meter_name(mut self, name: String) -> Self {
+        self.meter_name = name;
+        self
+    }
+}

--- a/crates/metrics/src/types.rs
+++ b/crates/metrics/src/types.rs
@@ -1,12 +1,16 @@
 //! Configuration types for metrics exporters.
 
 use std::net::SocketAddr;
+#[cfg(feature = "otlp")]
 use std::time::Duration;
 
+#[cfg(feature = "otlp")]
 use opentelemetry::KeyValue;
+#[cfg(feature = "otlp")]
 use opentelemetry_sdk::Resource;
 
 /// Configuration for OTLP exporter retry and timeout.
+#[cfg(feature = "otlp")]
 #[derive(Debug, Clone)]
 pub struct OtlpExportConfig {
     /// Timeout for export requests.
@@ -15,6 +19,7 @@ pub struct OtlpExportConfig {
     pub max_retries: u32,
 }
 
+#[cfg(feature = "otlp")]
 impl Default for OtlpExportConfig {
     fn default() -> Self {
         Self {
@@ -25,78 +30,74 @@ impl Default for OtlpExportConfig {
 }
 
 /// Metrics exporter configuration.
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
-pub enum MetricsConfig {
-    /// Preserve default metrics behavior for the configured backend.
-    ///
-    /// When an OTLP endpoint is configured, this installs the OTLP metrics
-    /// recorder. Otherwise, it leaves metrics disabled.
-    #[default]
-    Default,
-    /// Do not install a `metrics` recorder.
-    Disabled,
-    /// Export metrics through the configured OTLP endpoint.
-    Otlp,
-    /// Expose metrics through a Prometheus scrape endpoint.
-    Prometheus {
-        /// Address used by the Prometheus HTTP listener.
-        listen_addr: SocketAddr,
-    },
-    /// Export metrics through OTLP and expose them through Prometheus.
-    OtlpAndPrometheus {
-        /// Address used by the Prometheus HTTP listener.
-        listen_addr: SocketAddr,
-    },
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct MetricsConfig {
+    /// OTLP endpoint URL used for push-based metrics export.
+    pub otlp_endpoint: Option<String>,
+    /// Address used by the Prometheus HTTP listener.
+    pub prometheus_listener_addr: Option<SocketAddr>,
 }
 
 impl MetricsConfig {
-    /// Builds a metrics configuration from explicit exporter inputs.
-    pub const fn from_exporters(
-        otlp_enabled: bool,
-        prometheus_listen_addr: Option<SocketAddr>,
-    ) -> Self {
-        match (otlp_enabled, prometheus_listen_addr) {
-            (true, Some(listen_addr)) => Self::OtlpAndPrometheus { listen_addr },
-            (true, None) => Self::Otlp,
-            (false, Some(listen_addr)) => Self::Prometheus { listen_addr },
-            (false, None) => Self::Disabled,
+    /// Creates a disabled metrics exporter configuration.
+    pub const fn disabled() -> Self {
+        Self {
+            otlp_endpoint: None,
+            prometheus_listener_addr: None,
         }
     }
 
-    /// Resolves default behavior against the configured OTLP endpoint.
-    pub const fn resolve(self, otlp_endpoint_configured: bool) -> Self {
-        match (self, otlp_endpoint_configured) {
-            (Self::Default, true) => Self::Otlp,
-            (Self::Default, false) => Self::Disabled,
-            (config, _) => config,
+    /// Builds a metrics configuration from explicit exporter inputs.
+    pub fn from_exporters(
+        otlp_endpoint: Option<String>,
+        prometheus_listener_addr: Option<SocketAddr>,
+    ) -> Self {
+        Self {
+            otlp_endpoint,
+            prometheus_listener_addr,
         }
+    }
+
+    /// Sets the OTLP endpoint URL.
+    pub fn with_otlp_endpoint(mut self, endpoint: String) -> Self {
+        self.otlp_endpoint = Some(endpoint);
+        self
+    }
+
+    /// Sets the Prometheus listener address.
+    pub const fn with_prometheus_listener(mut self, listen_addr: SocketAddr) -> Self {
+        self.prometheus_listener_addr = Some(listen_addr);
+        self
+    }
+
+    /// Returns `true` when this config enables at least one metrics exporter.
+    pub fn is_enabled(&self) -> bool {
+        self.otlp_endpoint.is_some() || self.prometheus_listener_addr.is_some()
     }
 
     /// Returns `true` when this config explicitly enables a metrics recorder.
-    pub const fn is_explicitly_enabled(self) -> bool {
-        matches!(
-            self,
-            Self::Otlp | Self::Prometheus { .. } | Self::OtlpAndPrometheus { .. }
-        )
+    pub fn is_explicitly_enabled(&self) -> bool {
+        self.is_enabled()
     }
 
     /// Returns `true` when metrics should be exported over OTLP.
-    pub const fn uses_otlp(self) -> bool {
-        matches!(self, Self::Otlp | Self::OtlpAndPrometheus { .. })
+    pub fn uses_otlp(&self) -> bool {
+        self.otlp_endpoint.is_some()
+    }
+
+    /// Returns the OTLP endpoint URL, if configured.
+    pub fn otlp_endpoint(&self) -> Option<&str> {
+        self.otlp_endpoint.as_deref()
     }
 
     /// Returns the Prometheus listener address, if configured.
-    pub const fn prometheus_listen_addr(self) -> Option<SocketAddr> {
-        match self {
-            Self::Prometheus { listen_addr } | Self::OtlpAndPrometheus { listen_addr } => {
-                Some(listen_addr)
-            }
-            Self::Default | Self::Disabled | Self::Otlp => None,
-        }
+    pub const fn prometheus_listen_addr(&self) -> Option<SocketAddr> {
+        self.prometheus_listener_addr
     }
 }
 
 /// Resource attributes following OpenTelemetry semantic conventions.
+#[cfg(feature = "otlp")]
 #[derive(Debug, Clone)]
 pub struct ResourceConfig {
     /// Service name.
@@ -111,6 +112,7 @@ pub struct ResourceConfig {
     pub custom_attributes: Vec<KeyValue>,
 }
 
+#[cfg(feature = "otlp")]
 impl ResourceConfig {
     /// Creates a new resource configuration with the given service name.
     pub fn new(service_name: String) -> Self {
@@ -157,34 +159,45 @@ impl ResourceConfig {
 #[derive(Debug, Clone)]
 pub struct MetricsInitConfig {
     /// Resource configuration used for OTLP metrics.
+    #[cfg(feature = "otlp")]
     pub resource: ResourceConfig,
-    /// OTLP endpoint URL.
-    pub otlp_url: Option<String>,
     /// OTLP export configuration.
+    #[cfg(feature = "otlp")]
     pub otlp_export_config: OtlpExportConfig,
-    /// Metrics exporter configuration.
-    pub metrics_config: MetricsConfig,
     /// Name of the OpenTelemetry instrumentation scope used by the metrics
     /// facade bridge.
+    #[cfg(feature = "otlp")]
     pub meter_name: String,
+    /// Metrics exporter configuration.
+    pub metrics_config: MetricsConfig,
 }
 
 impl MetricsInitConfig {
     /// Creates a metrics initialization config with defaults.
     pub fn new(service_name: String) -> Self {
+        #[cfg(not(feature = "otlp"))]
+        let _ = service_name;
+
         Self {
+            #[cfg(feature = "otlp")]
             resource: ResourceConfig::new(service_name),
-            otlp_url: None,
+            #[cfg(feature = "otlp")]
             otlp_export_config: OtlpExportConfig::default(),
-            metrics_config: MetricsConfig::default(),
+            #[cfg(feature = "otlp")]
             meter_name: "strata".to_string(),
+            metrics_config: MetricsConfig::default(),
         }
     }
 
     /// Sets the OTLP endpoint URL.
     pub fn with_otlp_url(mut self, url: String) -> Self {
-        self.otlp_url = Some(url);
+        self.metrics_config = self.metrics_config.with_otlp_endpoint(url);
         self
+    }
+
+    /// Sets the OTLP endpoint URL.
+    pub fn with_otlp_endpoint(self, url: String) -> Self {
+        self.with_otlp_url(url)
     }
 
     /// Sets the metrics exporter configuration.
@@ -194,12 +207,14 @@ impl MetricsInitConfig {
     }
 
     /// Sets the OTLP export configuration.
+    #[cfg(feature = "otlp")]
     pub fn with_otlp_export_config(mut self, config: OtlpExportConfig) -> Self {
         self.otlp_export_config = config;
         self
     }
 
     /// Sets the meter name used by the `metrics` facade to OpenTelemetry bridge.
+    #[cfg(feature = "otlp")]
     pub fn with_meter_name(mut self, name: String) -> Self {
         self.meter_name = name;
         self

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -8,7 +8,7 @@ strata-tasks.workspace = true
 
 anyhow.workspace = true
 futures.workspace = true
-opentelemetry.workspace = true
+metrics.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/service/src/instrumentation.rs
+++ b/crates/service/src/instrumentation.rs
@@ -1,7 +1,7 @@
 //! Service instrumentation for automatic metrics and tracing.
 //!
-//! This module provides automatic OpenTelemetry-based instrumentation for all services
-//! built with the service framework. It tracks:
+//! This module provides automatic instrumentation for all services built with
+//! the service framework. It tracks:
 //! - Message processing metrics (count, latency, errors)
 //! - Service lifecycle metrics (launches, shutdowns)
 //! - Distributed tracing with proper span hierarchy
@@ -9,14 +9,13 @@
 //! All services automatically get:
 //! 1. Parent span wrapping entire service lifecycle
 //! 2. Child spans for launch, message processing, shutdown
-//! 3. Automatic metrics collection (counters and histograms)
+//! 3. Automatic metrics collection through the `metrics` facade
 
 use std::fmt::Display;
 use std::str::FromStr;
 use std::time::Duration;
 
-use opentelemetry::metrics::{Counter, Histogram};
-use opentelemetry::{global, KeyValue};
+use metrics::{counter, describe_counter, describe_histogram, histogram};
 use tracing::Span as TracingSpan;
 
 /// Result of an operation (success or error).
@@ -116,200 +115,23 @@ impl FromStr for ShutdownReason {
     }
 }
 
-/// Histogram bucket configuration for service metrics.
-///
-/// Defines the bucket boundaries for latency histograms. Buckets are not configurable
-/// by default to keep the API simple and ensure consistent cross-service metrics.
-#[derive(Clone, Debug)]
-pub struct HistogramBuckets {
-    /// Bucket boundaries for message processing duration (in seconds).
-    pub message: Vec<f64>,
-    /// Bucket boundaries for service launch duration (in seconds).
-    pub launch: Vec<f64>,
-    /// Bucket boundaries for service shutdown duration (in seconds).
-    pub shutdown: Vec<f64>,
-}
-
-impl Default for HistogramBuckets {
-    fn default() -> Self {
-        Self {
-            // Message processing: 1ms to 60s range covers quick operations to slow tasks
-            message: vec![0.001, 0.01, 0.1, 1.0, 10.0, 60.0],
-            // Launch: 10ms to 10s range covers initialization, connection setup, warmup
-            launch: vec![0.01, 0.1, 1.0, 5.0, 10.0],
-            // Shutdown: 1ms to 5s range covers cleanup, flush, graceful termination
-            shutdown: vec![0.001, 0.01, 0.1, 1.0, 5.0],
-        }
-    }
-}
-
-/// Builder for creating `ServiceInstrumentation` with custom configuration.
-///
-/// Use this when you need to customize histogram buckets for services with
-/// non-standard latency profiles.
-#[derive(Debug)]
-pub struct InstrumentationBuilder {
-    service_name: String,
-    buckets: HistogramBuckets,
-}
-
-impl InstrumentationBuilder {
-    /// Creates a new builder with default histogram buckets.
-    pub fn new(service_name: impl Into<String>) -> Self {
-        Self {
-            service_name: service_name.into(),
-            buckets: HistogramBuckets::default(),
-        }
-    }
-
-    /// Sets custom bucket boundaries for message processing duration histogram.
-    ///
-    /// # Arguments
-    ///
-    /// * `buckets` - Bucket boundaries in seconds, must be in ascending order
-    pub fn message_buckets(mut self, buckets: Vec<f64>) -> Self {
-        self.buckets.message = buckets;
-        self
-    }
-
-    /// Sets custom bucket boundaries for service launch duration histogram.
-    ///
-    /// # Arguments
-    ///
-    /// * `buckets` - Bucket boundaries in seconds, must be in ascending order
-    pub fn launch_buckets(mut self, buckets: Vec<f64>) -> Self {
-        self.buckets.launch = buckets;
-        self
-    }
-
-    /// Sets custom bucket boundaries for service shutdown duration histogram.
-    ///
-    /// # Arguments
-    ///
-    /// * `buckets` - Bucket boundaries in seconds, must be in ascending order
-    pub fn shutdown_buckets(mut self, buckets: Vec<f64>) -> Self {
-        self.buckets.shutdown = buckets;
-        self
-    }
-
-    /// Builds the `ServiceInstrumentation` with the configured buckets.
-    pub fn build(self) -> ServiceInstrumentation {
-        let meter = global::meter("strata-service");
-
-        // Pre-allocate service name attribute to avoid allocations on every metric call
-        let service_name = KeyValue::new("service.name", self.service_name);
-
-        // Create counters
-        let messages_processed = meter
-            .u64_counter("service.messages.processed")
-            .with_description("Total number of messages processed by the service")
-            .with_unit("messages")
-            .build();
-
-        let launches_total = meter
-            .u64_counter("service.launches.total")
-            .with_description("Total number of service launches")
-            .with_unit("launches")
-            .build();
-
-        let shutdowns_total = meter
-            .u64_counter("service.shutdowns.total")
-            .with_description("Total number of service shutdowns")
-            .with_unit("shutdowns")
-            .build();
-
-        // Create histograms with configured buckets
-        let message_duration = meter
-            .f64_histogram("service.message.duration")
-            .with_description("Duration of message processing")
-            .with_unit("s")
-            .with_boundaries(self.buckets.message)
-            .build();
-
-        let launch_duration = meter
-            .f64_histogram("service.launch.duration")
-            .with_description("Duration of service launch phase")
-            .with_unit("s")
-            .with_boundaries(self.buckets.launch)
-            .build();
-
-        let shutdown_duration = meter
-            .f64_histogram("service.shutdown.duration")
-            .with_description("Duration of service shutdown phase")
-            .with_unit("s")
-            .with_boundaries(self.buckets.shutdown)
-            .build();
-
-        ServiceInstrumentation {
-            service_name,
-            messages_processed,
-            launches_total,
-            shutdowns_total,
-            message_duration,
-            launch_duration,
-            shutdown_duration,
-        }
-    }
-}
-
 /// Service instrumentation context.
 ///
-/// This struct encapsulates all OpenTelemetry instrumentation for a service,
-/// including both tracing and metrics. It's automatically created in worker
-/// tasks and used to record service lifecycle events.
+/// This struct encapsulates the service name used when recording service
+/// lifecycle metrics. Metrics are emitted through the `metrics` facade so the
+/// process entrypoint can choose an OTLP, Prometheus, or fanout recorder.
 pub struct ServiceInstrumentation {
-    /// Pre-allocated service name attribute for reuse across metric recordings.
-    service_name: KeyValue,
-
-    /// Counter for total messages processed.
-    messages_processed: Counter<u64>,
-
-    /// Counter for total service launches.
-    launches_total: Counter<u64>,
-
-    /// Counter for total service shutdowns.
-    shutdowns_total: Counter<u64>,
-
-    /// Histogram for message processing duration.
-    message_duration: Histogram<f64>,
-
-    /// Histogram for service launch duration.
-    launch_duration: Histogram<f64>,
-
-    /// Histogram for service shutdown duration.
-    shutdown_duration: Histogram<f64>,
+    /// Service name label value reused across metric recordings.
+    service_name: String,
 }
 
 impl ServiceInstrumentation {
-    /// Creates a new service instrumentation context with default histogram buckets.
-    ///
-    /// If the OpenTelemetry provider is not initialized, this function will
-    /// return a no-op instrumentation that safely does nothing.
-    ///
-    /// For custom histogram buckets, use [`ServiceInstrumentation::builder()`].
+    /// Creates a new service instrumentation context.
     pub fn new(service_name: &str) -> Self {
-        InstrumentationBuilder::new(service_name).build()
-    }
-
-    /// Creates a builder for configuring custom histogram buckets.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use strata_service::instrumentation::ServiceInstrumentation;
-    ///
-    /// // Fast service with sub-millisecond latencies
-    /// let fast_inst = ServiceInstrumentation::builder("cache")
-    ///     .message_buckets(vec![0.0001, 0.001, 0.01, 0.1])
-    ///     .build();
-    ///
-    /// // Slow service with multi-second latencies
-    /// let slow_inst = ServiceInstrumentation::builder("batch_processor")
-    ///     .message_buckets(vec![1.0, 10.0, 60.0, 300.0])
-    ///     .build();
-    /// ```
-    pub fn builder(service_name: impl Into<String>) -> InstrumentationBuilder {
-        InstrumentationBuilder::new(service_name)
+        describe_service_metrics();
+        Self {
+            service_name: service_name.to_owned(),
+        }
     }
 
     /// Creates a lifecycle span wrapping the entire service lifetime.
@@ -346,36 +168,78 @@ impl ServiceInstrumentation {
 
     /// Records a message processing operation.
     pub fn record_message(&self, duration: Duration, result: OperationResult) {
-        let attrs = &[
-            self.service_name.clone(),
-            KeyValue::new("operation.result", result.as_str()),
-        ];
-
-        self.messages_processed.add(1, attrs);
-        self.message_duration.record(duration.as_secs_f64(), attrs);
+        counter!(
+            "strata_service_messages_processed_total",
+            "service_name" => self.service_name.clone(),
+            "operation_result" => result.as_str(),
+        )
+        .increment(1);
+        histogram!(
+            "strata_service_message_duration_seconds",
+            "service_name" => self.service_name.clone(),
+            "operation_result" => result.as_str(),
+        )
+        .record(duration.as_secs_f64());
     }
 
     /// Records a service launch operation.
     pub fn record_launch(&self, duration: Duration, result: OperationResult) {
-        let attrs = &[
-            self.service_name.clone(),
-            KeyValue::new("operation.result", result.as_str()),
-        ];
-
-        self.launches_total.add(1, attrs);
-        self.launch_duration.record(duration.as_secs_f64(), attrs);
+        counter!(
+            "strata_service_launches_total",
+            "service_name" => self.service_name.clone(),
+            "operation_result" => result.as_str(),
+        )
+        .increment(1);
+        histogram!(
+            "strata_service_launch_duration_seconds",
+            "service_name" => self.service_name.clone(),
+            "operation_result" => result.as_str(),
+        )
+        .record(duration.as_secs_f64());
     }
 
     /// Records a service shutdown operation.
     pub fn record_shutdown(&self, duration: Duration, reason: ShutdownReason) {
-        let attrs = &[
-            self.service_name.clone(),
-            KeyValue::new("shutdown.reason", reason.as_str()),
-        ];
-
-        self.shutdowns_total.add(1, attrs);
-        self.shutdown_duration.record(duration.as_secs_f64(), attrs);
+        counter!(
+            "strata_service_shutdowns_total",
+            "service_name" => self.service_name.clone(),
+            "shutdown_reason" => reason.as_str(),
+        )
+        .increment(1);
+        histogram!(
+            "strata_service_shutdown_duration_seconds",
+            "service_name" => self.service_name.clone(),
+            "shutdown_reason" => reason.as_str(),
+        )
+        .record(duration.as_secs_f64());
     }
+}
+
+fn describe_service_metrics() {
+    describe_counter!(
+        "strata_service_messages_processed_total",
+        "Total number of messages processed by the service"
+    );
+    describe_counter!(
+        "strata_service_launches_total",
+        "Total number of service launches"
+    );
+    describe_counter!(
+        "strata_service_shutdowns_total",
+        "Total number of service shutdowns"
+    );
+    describe_histogram!(
+        "strata_service_message_duration_seconds",
+        "Duration of message processing in seconds"
+    );
+    describe_histogram!(
+        "strata_service_launch_duration_seconds",
+        "Duration of service launch phase in seconds"
+    );
+    describe_histogram!(
+        "strata_service_shutdown_duration_seconds",
+        "Duration of service shutdown phase in seconds"
+    );
 }
 
 /// Common logic for recording shutdown metrics and logging results.
@@ -389,10 +253,8 @@ pub(crate) fn record_shutdown_result(
     instrumentation: &ServiceInstrumentation,
     shutdown_reason: ShutdownReason,
 ) {
-    // Record metrics
     instrumentation.record_shutdown(duration, shutdown_reason);
 
-    // Log result
     if let Err(e) = shutdown_result {
         tracing::error!(
             service.name = %service_name,
@@ -412,12 +274,6 @@ impl std::fmt::Debug for ServiceInstrumentation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServiceInstrumentation")
             .field("service_name", &self.service_name)
-            .field("messages_processed", &"<counter>")
-            .field("launches_total", &"<counter>")
-            .field("shutdowns_total", &"<counter>")
-            .field("message_duration", &"<histogram>")
-            .field("launch_duration", &"<histogram>")
-            .field("shutdown_duration", &"<histogram>")
             .finish()
     }
 }
@@ -425,6 +281,25 @@ impl std::fmt::Debug for ServiceInstrumentation {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_operation_result_display() {
+        assert_eq!(OperationResult::Success.to_string(), "success");
+        assert_eq!(OperationResult::Error.to_string(), "error");
+    }
+
+    #[test]
+    fn test_operation_result_from_str() {
+        assert_eq!(
+            "success".parse::<OperationResult>().unwrap(),
+            OperationResult::Success
+        );
+        assert_eq!(
+            "error".parse::<OperationResult>().unwrap(),
+            OperationResult::Error
+        );
+        assert!("invalid".parse::<OperationResult>().is_err());
+    }
 
     #[test]
     fn test_operation_result_from_bool() {
@@ -455,20 +330,16 @@ mod tests {
     }
 
     #[test]
-    fn test_instrumentation_new_without_provider() {
-        // Should not panic even if OpenTelemetry provider is not initialized
-        // OpenTelemetry returns a no-op meter by default
+    fn test_instrumentation_new_without_recorder() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Verify we can access the service name attribute
-        assert_eq!(instrumentation.service_name.key.as_str(), "service.name");
+        assert_eq!(instrumentation.service_name, "test_service");
     }
 
     #[test]
     fn test_instrumentation_record_message() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Should not panic when recording metrics (no-op if provider not initialized)
         instrumentation.record_message(Duration::from_millis(100), OperationResult::Success);
         instrumentation.record_message(Duration::from_millis(200), OperationResult::Error);
     }
@@ -477,7 +348,6 @@ mod tests {
     fn test_instrumentation_record_launch() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Should not panic when recording launch metrics
         instrumentation.record_launch(Duration::from_millis(50), OperationResult::Success);
         instrumentation.record_launch(Duration::from_millis(100), OperationResult::Error);
     }
@@ -486,7 +356,6 @@ mod tests {
     fn test_instrumentation_record_shutdown() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Should not panic when recording shutdown metrics
         instrumentation.record_shutdown(Duration::from_millis(10), ShutdownReason::Normal);
         instrumentation.record_shutdown(Duration::from_millis(20), ShutdownReason::Error);
         instrumentation.record_shutdown(Duration::from_millis(15), ShutdownReason::Signal);
@@ -496,21 +365,16 @@ mod tests {
     fn test_lifecycle_span_creation() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Should be able to create lifecycle spans without panicking
-        // Note: metadata() may return None if no tracing subscriber is initialized
         let _async_span =
             instrumentation.create_lifecycle_span("test_service", "test_service", "async");
         let _sync_span =
             instrumentation.create_lifecycle_span("test_service", "test_service", "sync");
-
-        // If this test completes without panicking, span creation works
     }
 
     #[test]
     fn test_instrumentation_debug_impl() {
         let instrumentation = ServiceInstrumentation::new("test_service");
 
-        // Verify Debug implementation doesn't panic
         let debug_str = format!("{:?}", instrumentation);
         assert!(debug_str.contains("ServiceInstrumentation"));
         assert!(debug_str.contains("service_name"));
@@ -518,28 +382,20 @@ mod tests {
 
     #[test]
     fn test_multiple_instrumentation_instances() {
-        // Should be able to create multiple instrumentation instances
         let inst1 = ServiceInstrumentation::new("service1");
         let inst2 = ServiceInstrumentation::new("service2");
 
-        // Record metrics on both without panicking
         inst1.record_message(Duration::from_millis(10), OperationResult::Success);
         inst2.record_message(Duration::from_millis(20), OperationResult::Success);
 
-        // Verify service names are different
-        assert_eq!(inst1.service_name.value.as_str(), "service1");
-        assert_eq!(inst2.service_name.value.as_str(), "service2");
+        assert_eq!(inst1.service_name, "service1");
+        assert_eq!(inst2.service_name, "service2");
     }
 
     #[test]
     fn test_pre_allocated_service_name() {
         let instrumentation = ServiceInstrumentation::new("my_test_service");
 
-        // Verify the service name attribute is pre-allocated correctly
-        assert_eq!(instrumentation.service_name.key.as_str(), "service.name");
-        assert_eq!(
-            instrumentation.service_name.value.as_str(),
-            "my_test_service"
-        );
+        assert_eq!(instrumentation.service_name, "my_test_service");
     }
 }

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -104,9 +104,6 @@ pub use builder::ServiceBuilder;
 pub use command::{CommandCompletionSender, CommandHandle};
 pub use errors::ServiceError;
 pub use executor::*;
-pub use instrumentation::{
-    HistogramBuckets, InstrumentationBuilder, OperationResult, ServiceInstrumentation,
-    ShutdownReason,
-};
+pub use instrumentation::{OperationResult, ServiceInstrumentation, ShutdownReason};
 pub use status::{AnyStatus, GenericStatusMonitor, ServiceMonitor, StatusMonitor};
 pub use types::*;


### PR DESCRIPTION
## Summary
- add a new `strata-metrics` crate for process-level metrics recorder setup
- keep `strata-logging` scoped to logging/tracing subscriber setup and trace OTLP
- move the span busy/idle `MetricsLayer` from `strata-logging` to `strata-metrics`
- add optional metrics exporter modes: disabled, OTLP, Prometheus `/metrics`, or OTLP+Prometheus fanout
- add a generic extra tracing-layer hook to `strata-logging` so binaries can install `strata_metrics::MetricsLayer` without coupling the crates
- restore `strata-service` to its existing OpenTelemetry instrumentation path; no service histogram bucket semantics change in this PR

## Verification
- cargo test -p strata-logging -p strata-metrics -p strata-service
- cargo check -p strata-logging -p strata-metrics -p strata-service --locked
- vertex-core: cargo check -p strata -p alpen-client -p strata-signer-bin with local patches for strata-logging, strata-metrics, strata-service, and strata-tasks
