### PR TITLE
refactor: rework SSZ impls for various wrapper-like types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,13 +3971,17 @@ dependencies = [
  "serde",
  "serde_json",
  "ssz",
+ "ssz_codegen",
  "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
  "strata-codec",
  "strata-identifiers",
  "strata-l1-txfmt",
  "strata-ssz-tests",
  "thiserror 2.0.18",
  "tree_hash",
+ "tree_hash_derive",
 ]
 
 [[package]]
@@ -4034,9 +4038,15 @@ dependencies = [
  "serde_json",
  "sha2",
  "ssz",
+ "ssz_codegen",
  "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
  "strata-identifiers",
+ "strata-ssz-tests",
  "thiserror 2.0.18",
+ "tree_hash",
+ "tree_hash_derive",
  "zeroize",
 ]
 

--- a/crates/btc-types/Cargo.toml
+++ b/crates/btc-types/Cargo.toml
@@ -21,7 +21,13 @@ thiserror.workspace = true
 
 ssz.workspace = true
 ssz_derive.workspace = true
+ssz_primitives.workspace = true
+ssz_types.workspace = true
 tree_hash.workspace = true
+tree_hash_derive.workspace = true
+
+[build-dependencies]
+ssz_codegen.workspace = true
 
 [dev-dependencies]
 rand_core = { workspace = true, features = ["getrandom"] }

--- a/crates/btc-types/build.rs
+++ b/crates/btc-types/build.rs
@@ -1,0 +1,26 @@
+//! Build script for generating SSZ delegate types from schema definitions.
+
+use std::path::Path;
+
+use ssz_codegen::{ModuleGeneration, build_ssz_files};
+
+fn main() {
+    // Generate SSZ delegate types into OUT_DIR.
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set by cargo");
+    let output_path = Path::new(&out_dir).join("generated_ssz.rs");
+
+    // Use local ssz-gen codegen.
+    let entry_points = ["btc.ssz"]; // ssz/btc.ssz
+    let base_dir = "ssz/"; // relative to this crate root
+    // External crates whose SSZ modules are imported by `btc.ssz`.
+    let crates = [];
+
+    build_ssz_files(
+        &entry_points,
+        base_dir,
+        &crates,
+        output_path.to_str().expect("utf8 path"),
+        ModuleGeneration::NestedModules,
+    )
+    .expect("Failed to generate SSZ types");
+}

--- a/crates/btc-types/src/btc.rs
+++ b/crates/btc-types/src/btc.rs
@@ -22,10 +22,28 @@ use strata_codec::{Codec, CodecError, Decoder, Encoder};
 use strata_identifiers::{Buf32, SszDelegate, impl_ssz_transparent_wrapper, impl_ssz_via_delegate};
 
 use crate::ParseError;
-use crate::ssz_generated::ssz::btc::{BitcoinOutPointSsz, BitcoinScriptSsz, BitcoinTxOutSsz};
+use crate::ssz_generated::ssz::btc::{
+    BitcoinOutPointSsz, BitcoinScriptSsz, BitcoinTxOutSsz, MAX_SCRIPT_SIZE,
+};
 
 const HASH_SIZE: usize = 32;
 const BITCOIN_TXID_LEN: usize = 32;
+
+/// Validates that a Bitcoin script fits within the SSZ-encodable bound
+/// (`MAX_SCRIPT_SIZE`).
+///
+/// This is the single chokepoint enforced by every fallible constructor and
+/// deserialization path of [`BitcoinTxOut`] and [`BitcoinScriptBuf`], so that an
+/// instance can never hold a script that would overflow the SSZ `script_pubkey`
+/// list and panic during encoding/tree-hashing.
+fn check_script_size(len: usize) -> Result<(), ParseError> {
+    let max = MAX_SCRIPT_SIZE as usize;
+    if len > max {
+        Err(ParseError::ScriptTooLarge { size: len, max })
+    } else {
+        Ok(())
+    }
+}
 
 /// L1 output reference.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
@@ -389,8 +407,27 @@ impl<'a> Arbitrary<'a> for BitcoinTxid {
 }
 
 /// A wrapper around [`bitcoin::TxOut`] that implements some additional traits.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// The wrapped script is guaranteed to be at most `MAX_SCRIPT_SIZE` bytes: every
+/// constructor and deserialization path routes through [`check_script_size`], so
+/// the SSZ encoding below can never overflow its `script_pubkey` list.
+///
+/// Note: [`Deserialize`] is implemented manually to enforce that invariant on
+/// deserialized values, mirroring the fallible [`TryFrom<TxOut>`] constructor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BitcoinTxOut(TxOut);
+
+/// [`Deserialize`] routes through [`BitcoinTxOut::try_from`] so the
+/// `MAX_SCRIPT_SIZE` invariant holds for deserialized values.
+impl<'de> Deserialize<'de> for BitcoinTxOut {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let tx_out = TxOut::deserialize(deserializer)?;
+        Self::try_from(tx_out).map_err(serde::de::Error::custom)
+    }
+}
 
 // SSZ encoding delegates to the generated [`BitcoinTxOutSsz`] container, which
 // lays out the fixed-size `value` and the length-bounded `script_pubkey`
@@ -402,6 +439,8 @@ impl SszDelegate for BitcoinTxOut {
     fn into_delegate(self) -> Self::Delegate {
         BitcoinTxOutSsz {
             value: self.0.value.to_sat(),
+            // Cannot fail: every construction/deserialization path validates the
+            // script against `MAX_SCRIPT_SIZE` via `check_script_size`.
             script_pubkey: self
                 .0
                 .script_pubkey
@@ -428,9 +467,14 @@ impl BitcoinTxOut {
     }
 }
 
-impl From<TxOut> for BitcoinTxOut {
-    fn from(value: TxOut) -> Self {
-        Self(value)
+impl TryFrom<TxOut> for BitcoinTxOut {
+    type Error = ParseError;
+
+    /// Wraps a [`TxOut`], rejecting outputs whose `script_pubkey` exceeds
+    /// `MAX_SCRIPT_SIZE` so the wrapper's SSZ encoding can never panic.
+    fn try_from(value: TxOut) -> Result<Self, Self::Error> {
+        check_script_size(value.script_pubkey.len())?;
+        Ok(Self(value))
     }
 }
 
@@ -461,8 +505,10 @@ impl BorshDeserialize for BitcoinTxOut {
         // Deserialize the value (u64)
         let value = u64::deserialize_reader(reader)?;
 
-        // Deserialize the script_pubkey (ScriptBuf)
+        // Deserialize the script_pubkey (ScriptBuf), rejecting over-long scripts
+        // so the wrapper's `MAX_SCRIPT_SIZE` invariant holds.
         let script_len = u64::deserialize_reader(reader)? as usize;
+        check_script_size(script_len).map_err(io::Error::other)?;
         let mut script_bytes = vec![0u8; script_len];
         reader.read_exact(&mut script_bytes)?;
         let script_pubkey = ScriptBuf::from(script_bytes);
@@ -695,6 +741,10 @@ impl<'a> arbitrary::Arbitrary<'a> for RawBitcoinTx {
 }
 
 /// SSZ-compatible wrapper around Bitcoin's [`ScriptBuf`].
+///
+/// The wrapped script is guaranteed to be at most `MAX_SCRIPT_SIZE` bytes: every
+/// constructor and deserialization path routes through [`check_script_size`], so
+/// the SSZ encoding below can never overflow its byte list.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BitcoinScriptBuf(ScriptBuf);
 
@@ -705,6 +755,8 @@ impl SszDelegate for BitcoinScriptBuf {
     type Delegate = BitcoinScriptSsz;
 
     fn into_delegate(self) -> Self::Delegate {
+        // Cannot fail: every construction/deserialization path validates the
+        // script against `MAX_SCRIPT_SIZE` via `check_script_size`.
         self.0
             .to_bytes()
             .try_into()
@@ -725,9 +777,14 @@ impl BitcoinScriptBuf {
     }
 }
 
-impl From<ScriptBuf> for BitcoinScriptBuf {
-    fn from(value: ScriptBuf) -> Self {
-        Self(value)
+impl TryFrom<ScriptBuf> for BitcoinScriptBuf {
+    type Error = ParseError;
+
+    /// Wraps a [`ScriptBuf`], rejecting scripts that exceed `MAX_SCRIPT_SIZE` so
+    /// the wrapper's SSZ encoding can never panic.
+    fn try_from(value: ScriptBuf) -> Result<Self, Self::Error> {
+        check_script_size(value.len())?;
+        Ok(Self(value))
     }
 }
 
@@ -744,7 +801,10 @@ impl BorshSerialize for BitcoinScriptBuf {
 // Implement BorshDeserialize for BitcoinScriptBuf
 impl BorshDeserialize for BitcoinScriptBuf {
     fn deserialize_reader<R: Read>(reader: &mut R) -> io::Result<Self> {
+        // Reject over-long scripts before allocating so the wrapper's
+        // `MAX_SCRIPT_SIZE` invariant holds.
         let script_len = u32::deserialize_reader(reader)? as usize;
+        check_script_size(script_len).map_err(io::Error::other)?;
         let mut script_bytes = vec![0u8; script_len];
         reader.read_exact(&mut script_bytes)?;
         let script_pubkey = ScriptBuf::from(script_bytes);

--- a/crates/btc-types/src/btc.rs
+++ b/crates/btc-types/src/btc.rs
@@ -16,67 +16,43 @@ use bitcoin::{
 use bitcoin_bosd::Descriptor;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
+use ssz::DecodeError;
 use ssz_derive::{Decode, Encode};
 use strata_codec::{Codec, CodecError, Decoder, Encoder};
-use strata_identifiers::{Buf32, impl_ssz_transparent_wrapper};
+use strata_identifiers::{Buf32, SszDelegate, impl_ssz_transparent_wrapper, impl_ssz_via_delegate};
 
 use crate::ParseError;
+use crate::ssz_generated::ssz::btc::{BitcoinOutPointSsz, BitcoinScriptSsz, BitcoinTxOutSsz};
 
 const HASH_SIZE: usize = 32;
-const BITCOIN_OUTPOINT_LEN: usize = 36;
 const BITCOIN_TXID_LEN: usize = 32;
 
 /// L1 output reference.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct BitcoinOutPoint(pub OutPoint);
 
-impl SszEncodeTrait for BitcoinOutPoint {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
+// SSZ encoding delegates to the generated [`BitcoinOutPointSsz`] container, which
+// lays the fixed-size `txid` and `vout` out per the SSZ spec — correct by
+// construction rather than hand-rolled.
+impl SszDelegate for BitcoinOutPoint {
+    type Delegate = BitcoinOutPointSsz;
 
-    fn ssz_fixed_len() -> usize {
-        BITCOIN_OUTPOINT_LEN
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0.txid.to_byte_array());
-        buf.extend_from_slice(&self.0.vout.to_le_bytes());
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        <Self as SszEncodeTrait>::ssz_fixed_len()
-    }
-}
-
-impl SszDecodeTrait for BitcoinOutPoint {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_fixed_len() -> usize {
-        BITCOIN_OUTPOINT_LEN
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        if bytes.len() != <Self as SszDecodeTrait>::ssz_fixed_len() {
-            return Err(DecodeError::InvalidByteLength {
-                len: bytes.len(),
-                expected: <Self as SszDecodeTrait>::ssz_fixed_len(),
-            });
+    fn into_delegate(self) -> Self::Delegate {
+        BitcoinOutPointSsz {
+            txid: self.0.txid.to_byte_array().into(),
+            vout: self.0.vout,
         }
+    }
 
-        let txid = Txid::from_slice(&bytes[..BITCOIN_TXID_LEN])
-            .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?;
-        let vout = u32::from_le_bytes(
-            bytes[BITCOIN_TXID_LEN..<Self as SszDecodeTrait>::ssz_fixed_len()]
-                .try_into()
-                .expect("slice length is checked above"),
-        );
-        Ok(Self(OutPoint { txid, vout }))
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self(OutPoint {
+            txid: Txid::from_byte_array(delegate.txid.0),
+            vout: delegate.vout,
+        }))
     }
 }
+
+impl_ssz_via_delegate!(BitcoinOutPoint);
 
 impl From<OutPoint> for BitcoinOutPoint {
     fn from(value: OutPoint) -> Self {
@@ -321,38 +297,21 @@ impl BitcoinAmount {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BitcoinTxid(Txid);
 
-impl SszEncodeTrait for BitcoinTxid {
-    fn is_ssz_fixed_len() -> bool {
-        true
+// Delegates SSZ encoding to the upstream `[u8; 32]` impl so the layout is correct
+// by construction (a single fixed-size byte vector) rather than hand-rolled.
+impl SszDelegate for BitcoinTxid {
+    type Delegate = [u8; BITCOIN_TXID_LEN];
+
+    fn into_delegate(self) -> Self::Delegate {
+        self.0.to_byte_array()
     }
 
-    fn ssz_fixed_len() -> usize {
-        BITCOIN_TXID_LEN
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0.to_byte_array());
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        <Self as SszEncodeTrait>::ssz_fixed_len()
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self(Txid::from_byte_array(delegate)))
     }
 }
 
-impl SszDecodeTrait for BitcoinTxid {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_fixed_len() -> usize {
-        BITCOIN_TXID_LEN
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let serialized = <[u8; BITCOIN_TXID_LEN]>::from_ssz_bytes(bytes)?;
-        Ok(Self(Txid::from_byte_array(serialized)))
-    }
-}
+impl_ssz_via_delegate!(BitcoinTxid);
 
 impl From<Txid> for BitcoinTxid {
     fn from(value: Txid) -> Self {
@@ -433,33 +392,34 @@ impl<'a> Arbitrary<'a> for BitcoinTxid {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BitcoinTxOut(TxOut);
 
-impl SszEncodeTrait for BitcoinTxOut {
-    fn is_ssz_fixed_len() -> bool {
-        false
+// SSZ encoding delegates to the generated [`BitcoinTxOutSsz`] container, which
+// lays out the fixed-size `value` and the length-bounded `script_pubkey`
+// (`List[byte, MAX_SCRIPT_SIZE]`) per the SSZ spec. The script bound is enforced
+// by the generated `VariableList` type rather than a hand-written impl.
+impl SszDelegate for BitcoinTxOut {
+    type Delegate = BitcoinTxOutSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        BitcoinTxOutSsz {
+            value: self.0.value.to_sat(),
+            script_pubkey: self
+                .0
+                .script_pubkey
+                .to_bytes()
+                .try_into()
+                .expect("scriptPubKey exceeds MAX_SCRIPT_SIZE"),
+        }
     }
 
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        (self.0.value.to_sat(), self.0.script_pubkey.to_bytes()).ssz_append(buf);
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        (self.0.value.to_sat(), self.0.script_pubkey.to_bytes()).ssz_bytes_len()
-    }
-}
-
-impl SszDecodeTrait for BitcoinTxOut {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let (value, script_pubkey): (u64, Vec<u8>) = <(u64, Vec<u8>)>::from_ssz_bytes(bytes)?;
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
         Ok(Self(TxOut {
-            value: Amount::from_sat(value),
-            script_pubkey: ScriptBuf::from(script_pubkey),
+            value: Amount::from_sat(delegate.value),
+            script_pubkey: ScriptBuf::from(delegate.script_pubkey.to_vec()),
         }))
     }
 }
+
+impl_ssz_via_delegate!(BitcoinTxOut);
 
 impl BitcoinTxOut {
     /// Returns a reference to the inner [`TxOut`].
@@ -738,29 +698,25 @@ impl<'a> arbitrary::Arbitrary<'a> for RawBitcoinTx {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BitcoinScriptBuf(ScriptBuf);
 
-impl SszEncodeTrait for BitcoinScriptBuf {
-    fn is_ssz_fixed_len() -> bool {
-        false
+// SSZ encoding delegates to [`BitcoinScriptSsz`] (`List[byte, MAX_SCRIPT_SIZE]`),
+// the generated length-bounded byte list, so the layout and bound are correct by
+// construction rather than hand-rolled.
+impl SszDelegate for BitcoinScriptBuf {
+    type Delegate = BitcoinScriptSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        self.0
+            .to_bytes()
+            .try_into()
+            .expect("script exceeds MAX_SCRIPT_SIZE")
     }
 
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        self.0.to_bytes().ssz_append(buf);
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        self.0.to_bytes().ssz_bytes_len()
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self(ScriptBuf::from(delegate.to_vec())))
     }
 }
 
-impl SszDecodeTrait for BitcoinScriptBuf {
-    fn is_ssz_fixed_len() -> bool {
-        false
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        Vec::<u8>::from_ssz_bytes(bytes).map(|bytes| Self(ScriptBuf::from(bytes)))
-    }
-}
+impl_ssz_via_delegate!(BitcoinScriptBuf);
 
 impl BitcoinScriptBuf {
     /// Returns a reference to the inner [`ScriptBuf`].
@@ -918,6 +874,27 @@ mod tests {
 
             prop_assert_eq!(decoded, tx_out);
         }
+    }
+
+    #[test]
+    fn bitcoin_outpoint_ssz_byte_layout() {
+        // Guards the wire format: 32-byte txid followed by little-endian vout.
+        let outpoint = BitcoinOutPoint(OutPoint {
+            txid: Txid::from_byte_array([0xAB; 32]),
+            vout: 0x01020304,
+        });
+
+        let mut expected = vec![0xAB; 32];
+        expected.extend_from_slice(&0x01020304u32.to_le_bytes());
+
+        assert_eq!(outpoint.as_ssz_bytes(), expected);
+    }
+
+    #[test]
+    fn bitcoin_txid_ssz_byte_layout() {
+        // Guards the wire format: the raw 32-byte txid with no length prefix.
+        let txid = BitcoinTxid::from(Txid::from_byte_array([0xCD; 32]));
+        assert_eq!(txid.as_ssz_bytes(), vec![0xCD; 32]);
     }
 
     #[test]

--- a/crates/btc-types/src/btc.rs
+++ b/crates/btc-types/src/btc.rs
@@ -409,11 +409,11 @@ impl<'a> Arbitrary<'a> for BitcoinTxid {
 /// A wrapper around [`bitcoin::TxOut`] that implements some additional traits.
 ///
 /// The wrapped script is guaranteed to be at most `MAX_SCRIPT_SIZE` bytes: every
-/// constructor and deserialization path routes through [`check_script_size`], so
+/// constructor and deserialization path routes through `check_script_size`, so
 /// the SSZ encoding below can never overflow its `script_pubkey` list.
 ///
 /// Note: [`Deserialize`] is implemented manually to enforce that invariant on
-/// deserialized values, mirroring the fallible [`TryFrom<TxOut>`] constructor.
+/// deserialized values, mirroring the fallible `TryFrom<TxOut>` constructor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct BitcoinTxOut(TxOut);
 
@@ -743,7 +743,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RawBitcoinTx {
 /// SSZ-compatible wrapper around Bitcoin's [`ScriptBuf`].
 ///
 /// The wrapped script is guaranteed to be at most `MAX_SCRIPT_SIZE` bytes: every
-/// constructor and deserialization path routes through [`check_script_size`], so
+/// constructor and deserialization path routes through `check_script_size`, so
 /// the SSZ encoding below can never overflow its byte list.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BitcoinScriptBuf(ScriptBuf);
@@ -839,8 +839,9 @@ mod tests {
 
     use super::{
         BitcoinAmount, BitcoinOutPoint, BitcoinScriptBuf, BitcoinTxOut, BitcoinTxid,
-        BitcoinXOnlyPublicKey, BorshDeserialize, BorshSerialize, RawBitcoinTx,
+        BitcoinXOnlyPublicKey, BorshDeserialize, BorshSerialize, MAX_SCRIPT_SIZE, RawBitcoinTx,
     };
+    use crate::ParseError;
     use crate::test_helpers::ArbitraryGenerator;
 
     #[test]
@@ -1017,6 +1018,92 @@ mod tests {
             scriptbuf.0, deserialized_scriptbuf.0,
             "original and deserialized scriptbuf must be the same"
         );
+    }
+
+    /// A script one byte larger than the SSZ-encodable maximum.
+    fn oversized_script() -> ScriptBuf {
+        ScriptBuf::from_bytes(vec![0u8; MAX_SCRIPT_SIZE as usize + 1])
+    }
+
+    #[test]
+    fn bitcoin_txout_try_from_enforces_script_bound() {
+        let max = MAX_SCRIPT_SIZE as usize;
+
+        // A script exactly at the bound is accepted.
+        let ok = TxOut {
+            value: Amount::from_sat(1),
+            script_pubkey: ScriptBuf::from_bytes(vec![0u8; max]),
+        };
+        assert!(BitcoinTxOut::try_from(ok).is_ok());
+
+        // One byte over the bound is rejected rather than producing a value that
+        // would panic when SSZ-encoded.
+        let too_big = TxOut {
+            value: Amount::from_sat(1),
+            script_pubkey: oversized_script(),
+        };
+        assert!(matches!(
+            BitcoinTxOut::try_from(too_big),
+            Err(ParseError::ScriptTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn bitcoin_txout_serde_json_roundtrip() {
+        // The derived `Serialize` and manual `Deserialize` must agree on the wire
+        // format for an in-bound value.
+        let tx_out = BitcoinTxOut::try_from(TxOut {
+            value: Amount::from_sat(4321),
+            script_pubkey: ScriptBuf::from_bytes(vec![0x51, 0x21, 0xff]),
+        })
+        .unwrap();
+
+        let json = serde_json::to_string(&tx_out).unwrap();
+        let decoded: BitcoinTxOut = serde_json::from_str(&json).unwrap();
+        assert_eq!(tx_out, decoded);
+    }
+
+    #[test]
+    fn bitcoin_txout_deserialize_rejects_oversized_script() {
+        // The validating serde `Deserialize` rejects an over-long script instead
+        // of decoding a value that later panics on SSZ encoding.
+        let tx_out = TxOut {
+            value: Amount::from_sat(1),
+            script_pubkey: oversized_script(),
+        };
+        let json = serde_json::to_string(&tx_out).unwrap();
+        assert!(serde_json::from_str::<BitcoinTxOut>(&json).is_err());
+    }
+
+    #[test]
+    fn bitcoin_txout_borsh_rejects_oversized_script() {
+        // Hand-craft a borsh header (value || script_len) claiming an over-long
+        // script; the length is rejected before any allocation.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0u64.to_le_bytes()); // value
+        buf.extend_from_slice(&(MAX_SCRIPT_SIZE + 1).to_le_bytes()); // script_len
+        assert!(BitcoinTxOut::deserialize(&mut &buf[..]).is_err());
+    }
+
+    #[test]
+    fn bitcoin_scriptbuf_try_from_enforces_script_bound() {
+        let max = MAX_SCRIPT_SIZE as usize;
+
+        let ok = ScriptBuf::from_bytes(vec![0u8; max]);
+        assert!(BitcoinScriptBuf::try_from(ok).is_ok());
+
+        assert!(matches!(
+            BitcoinScriptBuf::try_from(oversized_script()),
+            Err(ParseError::ScriptTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn bitcoin_scriptbuf_borsh_rejects_oversized_script() {
+        // Hand-craft a borsh header (script_len) claiming an over-long script.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(MAX_SCRIPT_SIZE as u32 + 1).to_le_bytes());
+        assert!(BitcoinScriptBuf::deserialize(&mut &buf[..]).is_err());
     }
 
     // Property-based tests for BitcoinAmount SSZ serialization

--- a/crates/btc-types/src/errors.rs
+++ b/crates/btc-types/src/errors.rs
@@ -20,6 +20,15 @@ pub enum ParseError {
     #[error("supplied script is invalid")]
     InvalidScript(#[from] address::FromScriptError),
 
+    /// The provided script exceeds the maximum encodable size.
+    #[error("script of {size} bytes exceeds the maximum of {max} bytes")]
+    ScriptTooLarge {
+        /// Size of the offending script, in bytes.
+        size: usize,
+        /// Maximum allowed script size, in bytes (`MAX_SCRIPT_SIZE`).
+        max: usize,
+    },
+
     /// The provided 32-byte buffer is not a valid point on the curve.
     #[error("not a valid point on the curve: {0}")]
     InvalidPoint(Buf32),

--- a/crates/btc-types/src/lib.rs
+++ b/crates/btc-types/src/lib.rs
@@ -1,5 +1,15 @@
 //! Types relating to things we find or generate from Bitcoin blocks/txs/etc.
 
+// `ssz_primitives` (FixedBytes) and `ssz_types` (VariableList) are referenced by
+// the generated SSZ delegate types in `ssz_generated`.
+use {ssz_primitives as _, ssz_types as _};
+
+/// SSZ delegate types generated from `ssz/btc.ssz`.
+#[allow(unreachable_pub, missing_docs, reason = "generated code")]
+mod ssz_generated {
+    include!(concat!(env!("OUT_DIR"), "/generated_ssz.rs"));
+}
+
 mod btc;
 mod convert;
 mod errors;

--- a/crates/btc-types/src/lib.rs
+++ b/crates/btc-types/src/lib.rs
@@ -2,7 +2,8 @@
 
 // `ssz_primitives` (FixedBytes) and `ssz_types` (VariableList) are referenced by
 // the generated SSZ delegate types in `ssz_generated`.
-use {ssz_primitives as _, ssz_types as _};
+use ssz_primitives as _;
+use ssz_types as _;
 
 /// SSZ delegate types generated from `ssz/btc.ssz`.
 #[allow(unreachable_pub, missing_docs, reason = "generated code")]

--- a/crates/btc-types/src/params.rs
+++ b/crates/btc-types/src/params.rs
@@ -3,62 +3,61 @@ use std::io;
 use bitcoin::params::{MAINNET, Params};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
+use ssz::DecodeError;
+use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
 
 /// Wrapper around Bitcoin consensus [`Params`] with serialization support.
 #[derive(Debug, Clone)]
 pub struct BtcParams(Params);
 
-impl SszEncodeTrait for BtcParams {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_fixed_len() -> usize {
-        1
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let network_index = match self.0.network {
-            bitcoin::Network::Bitcoin => 0u8,
-            bitcoin::Network::Testnet => 1u8,
-            bitcoin::Network::Signet => 2u8,
-            bitcoin::Network::Regtest => 3u8,
-            _ => panic!("unsupported bitcoin network"),
-        };
-        buf.push(network_index);
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        <Self as SszEncodeTrait>::ssz_fixed_len()
-    }
+/// Maps a Bitcoin [`Network`](bitcoin::Network) to its SSZ selector index,
+/// preserving the historical encoding (Bitcoin=0, Testnet=1, Signet=2,
+/// Regtest=3).
+fn conv_network_to_selector(network: bitcoin::Network) -> Option<u8> {
+    Some(match network {
+        bitcoin::Network::Bitcoin => 0,
+        bitcoin::Network::Testnet => 1,
+        bitcoin::Network::Signet => 2,
+        bitcoin::Network::Regtest => 3,
+        _ => return None,
+    })
 }
 
-impl SszDecodeTrait for BtcParams {
-    fn is_ssz_fixed_len() -> bool {
-        true
+/// Inverse of [`conv_network_to_selector`].
+fn conv_selector_to_network(selector: u8) -> Option<bitcoin::Network> {
+    Some(match selector {
+        0 => bitcoin::Network::Bitcoin,
+        1 => bitcoin::Network::Testnet,
+        2 => bitcoin::Network::Signet,
+        3 => bitcoin::Network::Regtest,
+        _ => return None,
+    })
+}
+
+// SSZ encoding delegates to the upstream `u8` impl: the network is encoded as a
+// single selector byte, so the layout is correct by construction rather than
+// hand-rolled.
+//
+// NOTE: the ticket suggested modelling this as an SSZ `Union`. We deliberately
+// keep the one-byte selector instead — `ssz-gen`'s `Union` emits standard union
+// behaviour (a selector byte *plus* the serialized variant value), which would
+// widen the encoding to two bytes and change the wire format.
+impl SszDelegate for BtcParams {
+    type Delegate = u8;
+
+    fn into_delegate(self) -> Self::Delegate {
+        conv_network_to_selector(self.0.network).expect("unsupported bitcoin network")
     }
 
-    fn ssz_fixed_len() -> usize {
-        1
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let network_index = u8::from_ssz_bytes(bytes)?;
-        let network = match network_index {
-            0 => bitcoin::Network::Bitcoin,
-            1 => bitcoin::Network::Testnet,
-            2 => bitcoin::Network::Signet,
-            3 => bitcoin::Network::Regtest,
-            _ => {
-                return Err(DecodeError::BytesInvalid(format!(
-                    "invalid bitcoin network index {network_index}"
-                )));
-            }
-        };
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let network = conv_selector_to_network(delegate).ok_or_else(|| {
+            DecodeError::BytesInvalid(format!("invalid bitcoin network index {delegate}"))
+        })?;
         Ok(Self::from(Params::from(network)))
     }
 }
+
+impl_ssz_via_delegate!(BtcParams);
 
 impl PartialEq for BtcParams {
     fn eq(&self, other: &Self) -> bool {
@@ -203,6 +202,23 @@ mod tests {
             let json_data = serde_json::to_string(&params).unwrap();
             let serde_result: BtcParams = serde_json::from_str(&json_data).unwrap();
             assert_eq!(params, serde_result);
+        }
+    }
+
+    #[test]
+    fn test_network_ssz_byte_layout() {
+        // Guards the wire format: a single selector byte per network, preserving the
+        // historical index mapping (Bitcoin=0, Testnet=1, Signet=2, Regtest=3).
+        let cases = [
+            (Network::Bitcoin, 0u8),
+            (Network::Testnet, 1u8),
+            (Network::Signet, 2u8),
+            (Network::Regtest, 3u8),
+        ];
+
+        for (network, expected) in cases {
+            let params = BtcParams::from(Params::from(network));
+            assert_eq!(params.as_ssz_bytes(), vec![expected]);
         }
     }
 

--- a/crates/btc-types/src/payload.rs
+++ b/crates/btc-types/src/payload.rs
@@ -8,10 +8,11 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
 use ssz_derive::{Decode, Encode};
+use ssz_primitives::FixedBytes;
 use strata_identifiers::{Buf32, SszDelegate, impl_borsh_via_ssz, impl_ssz_via_delegate};
 use strata_l1_txfmt::TagData;
 
-use crate::ssz_generated::ssz::btc::L1PayloadSsz;
+use crate::ssz_generated::ssz::btc::{BlobSpecSsz, L1PayloadSsz, PayloadIntentSsz, PayloadSpecSsz};
 
 /// DA destination identifier. This will eventually be used to enable
 /// storing payloads on alternative availability schemes.
@@ -64,8 +65,6 @@ impl<'a> Arbitrary<'a> for PayloadDest {
     BorshSerialize,
     Serialize,
     Deserialize,
-    Encode,
-    Decode,
 )]
 pub struct BlobSpec {
     /// Target settlement layer we're expecting the DA on.
@@ -75,6 +74,29 @@ pub struct BlobSpec {
     /// merkle root) that we expect to see committed to DA.
     commitment: Buf32,
 }
+
+// SSZ encoding delegates to the generated [`BlobSpecSsz`] container — correct by
+// construction rather than hand-rolled.
+impl SszDelegate for BlobSpec {
+    type Delegate = BlobSpecSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        BlobSpecSsz {
+            dest: self.dest.into(),
+            commitment: FixedBytes(self.commitment.0),
+        }
+    }
+
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self {
+            dest: PayloadDest::try_from(delegate.dest)
+                .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?,
+            commitment: Buf32::from(delegate.commitment),
+        })
+    }
+}
+
+impl_ssz_via_delegate!(BlobSpec);
 
 impl BlobSpec {
     /// The target we expect the DA payload to be stored on.
@@ -107,8 +129,6 @@ impl BlobSpec {
     BorshSerialize,
     Serialize,
     Deserialize,
-    Encode,
-    Decode,
 )]
 pub struct PayloadSpec {
     /// Target settlement layer we're expecting the DA on.
@@ -118,6 +138,29 @@ pub struct PayloadSpec {
     /// merkle root) that we expect to see committed to DA.
     commitment: Buf32,
 }
+
+// SSZ encoding delegates to the generated [`PayloadSpecSsz`] container — correct
+// by construction rather than hand-rolled.
+impl SszDelegate for PayloadSpec {
+    type Delegate = PayloadSpecSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        PayloadSpecSsz {
+            dest: self.dest.into(),
+            commitment: FixedBytes(self.commitment.0),
+        }
+    }
+
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self {
+            dest: PayloadDest::try_from(delegate.dest)
+                .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?,
+            commitment: Buf32::from(delegate.commitment),
+        })
+    }
+}
+
+impl_ssz_via_delegate!(PayloadSpec);
 
 impl PayloadSpec {
     /// The target we expect the DA payload to be stored on.
@@ -247,9 +290,7 @@ impl<'a> arbitrary::Arbitrary<'a> for L1Payload {
 /// about it.
 ///
 /// These are never stored on-chain.
-#[derive(
-    Clone, Debug, Eq, PartialEq, Arbitrary, BorshSerialize, BorshDeserialize, Encode, Decode,
-)]
+#[derive(Clone, Debug, Eq, PartialEq, Arbitrary, BorshSerialize, BorshDeserialize)]
 // TODO: rename this to L1PayloadIntent and remove the dest field
 pub struct PayloadIntent {
     /// The destination for this payload.
@@ -261,6 +302,32 @@ pub struct PayloadIntent {
     /// Blob payload.
     payload: L1Payload,
 }
+
+// SSZ encoding delegates to the generated [`PayloadIntentSsz`] container, whose
+// `payload` field reuses the [`L1PayloadSsz`] delegate — correct by construction
+// rather than hand-rolled.
+impl SszDelegate for PayloadIntent {
+    type Delegate = PayloadIntentSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        PayloadIntentSsz {
+            dest: self.dest.into(),
+            commitment: FixedBytes(self.commitment.0),
+            payload: self.payload.into_delegate(),
+        }
+    }
+
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self {
+            dest: PayloadDest::try_from(delegate.dest)
+                .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?,
+            commitment: Buf32::from(delegate.commitment),
+            payload: L1Payload::from_delegate(delegate.payload)?,
+        })
+    }
+}
+
+impl_ssz_via_delegate!(PayloadIntent);
 
 impl PayloadIntent {
     /// Creates a new payload intent with a destination, commitment, and payload.

--- a/crates/btc-types/src/payload.rs
+++ b/crates/btc-types/src/payload.rs
@@ -2,16 +2,16 @@
 //!
 //! These types don't care about the *purpose* of the payloads, we only care about what's in them.
 
-use std::io;
-
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Deserialize, Serialize, de};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
+use serde::{Deserialize, Serialize};
+use ssz::DecodeError;
 use ssz_derive::{Decode, Encode};
-use strata_identifiers::Buf32;
+use strata_identifiers::{Buf32, SszDelegate, impl_borsh_via_ssz, impl_ssz_via_delegate};
 use strata_l1_txfmt::TagData;
+
+use crate::ssz_generated::ssz::btc::L1PayloadSsz;
 
 /// DA destination identifier. This will eventually be used to enable
 /// storing payloads on alternative availability schemes.
@@ -136,29 +136,19 @@ impl PayloadSpec {
 }
 
 /// Data that is submitted to L1. This can be DA, Checkpoint, etc.
-#[derive(Clone, Debug, Eq, PartialEq)]
+///
+/// The serde representation flattens the [`TagData`] fields alongside the
+/// payload (`{payload, subproto_id, tx_type, aux_data}`); deserialization is
+/// validated by `TagData`'s own (validating) `Deserialize` impl.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct L1Payload {
     /// Data payload.
+    #[serde(rename = "payload")]
     data: Vec<Vec<u8>>,
 
     /// Transaction type.
+    #[serde(flatten)]
     tag: TagData,
-}
-
-/// SSZ representation of a [L1Payload].
-#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
-struct L1PayloadSsz {
-    /// Data payload.
-    data: Vec<Vec<u8>>,
-
-    /// Subprotocol ID (first 8 bits of the [`TagData`]).
-    subproto_id: u8,
-
-    /// Transaction type (second 8 bits of the [`TagData`]).
-    tx_type: u8,
-
-    /// Auxiliary data (remaining bytes of the [`TagData`]).
-    aux_data: Vec<u8>,
 }
 
 impl L1Payload {
@@ -178,123 +168,59 @@ impl L1Payload {
     }
 }
 
-impl BorshSerialize for L1Payload {
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        // Serialize payload Vec<Vec<u8>>
-        BorshSerialize::serialize(&self.data, writer)?;
+// Borsh is implemented as a length-prefixed shim over the SSZ encoding, so it
+// inherits the same validation (bounded lists and `TagData::new`) on decode
+// rather than re-implementing it by hand.
+impl_borsh_via_ssz!(L1Payload);
 
-        // Serialize TagData fields
-        BorshSerialize::serialize(&self.tag.subproto_id(), writer)?;
-        BorshSerialize::serialize(&self.tag.tx_type(), writer)?;
-        BorshSerialize::serialize(&self.tag.aux_data().to_vec(), writer)?;
+// SSZ encoding delegates to the generated [`L1PayloadSsz`] container, whose
+// length-bounded lists (`data`, `aux_data`) lay out the fixed/variable parts per
+// the SSZ spec — correct by construction rather than hand-rolled.
+impl SszDelegate for L1Payload {
+    type Delegate = L1PayloadSsz;
 
-        Ok(())
+    fn into_delegate(self) -> Self::Delegate {
+        let data = self
+            .data
+            .into_iter()
+            .map(|chunk| {
+                chunk
+                    .try_into()
+                    .expect("payload chunk exceeds MAX_PAYLOAD_CHUNK_LEN")
+            })
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("payload has more than MAX_PAYLOAD_CHUNKS chunks");
+        L1PayloadSsz {
+            data,
+            subproto_id: self.tag.subproto_id(),
+            tx_type: self.tag.tx_type(),
+            aux_data: self
+                .tag
+                .aux_data()
+                .to_vec()
+                .try_into()
+                .expect("aux data exceeds MAX_AUX_DATA_LEN"),
+        }
     }
-}
 
-impl BorshDeserialize for L1Payload {
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        // Deserialize payload Vec<Vec<u8>>
-        let data = Vec::<Vec<u8>>::deserialize_reader(reader)?;
-
-        // Deserialize TagData fields
-        let subproto_id = u8::deserialize_reader(reader)?;
-        let tx_type = u8::deserialize_reader(reader)?;
-        let aux_data = Vec::<u8>::deserialize_reader(reader)?;
-
-        let tag = TagData::new(subproto_id, tx_type, aux_data).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Invalid TagData: {}", e),
-            )
-        })?;
-
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let tag = TagData::new(
+            delegate.subproto_id,
+            delegate.tx_type,
+            delegate.aux_data.to_vec(),
+        )
+        .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?;
+        let data = delegate
+            .data
+            .iter()
+            .map(|chunk| chunk.to_vec())
+            .collect::<Vec<Vec<u8>>>();
         Ok(Self { data, tag })
     }
 }
 
-impl SszEncodeTrait for L1Payload {
-    fn is_ssz_fixed_len() -> bool {
-        <L1PayloadSsz as SszEncodeTrait>::is_ssz_fixed_len()
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        L1PayloadSsz {
-            data: self.data.clone(),
-            subproto_id: self.tag.subproto_id(),
-            tx_type: self.tag.tx_type(),
-            aux_data: self.tag.aux_data().to_vec(),
-        }
-        .ssz_append(buf);
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        L1PayloadSsz {
-            data: self.data.clone(),
-            subproto_id: self.tag.subproto_id(),
-            tx_type: self.tag.tx_type(),
-            aux_data: self.tag.aux_data().to_vec(),
-        }
-        .ssz_bytes_len()
-    }
-}
-
-impl SszDecodeTrait for L1Payload {
-    fn is_ssz_fixed_len() -> bool {
-        <L1PayloadSsz as SszDecodeTrait>::is_ssz_fixed_len()
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let decoded = L1PayloadSsz::from_ssz_bytes(bytes)?;
-        let tag = TagData::new(decoded.subproto_id, decoded.tx_type, decoded.aux_data)
-            .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?;
-        Ok(Self {
-            data: decoded.data,
-            tag,
-        })
-    }
-}
-
-// REVIEW: serde serialize/deserialize is only needed for the strata-dbtool
-impl Serialize for L1Payload {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("L1Payload", 4)?;
-        state.serialize_field("payload", &self.data)?;
-        state.serialize_field("subproto_id", &self.tag.subproto_id())?;
-        state.serialize_field("tx_type", &self.tag.tx_type())?;
-        state.serialize_field("aux_data", &self.tag.aux_data())?;
-        state.end()
-    }
-}
-
-// REVIEW: serde serialize/deserialize is only needed for the strata-dbtool
-impl<'de> Deserialize<'de> for L1Payload {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            payload: Vec<Vec<u8>>,
-            subproto_id: u8,
-            tx_type: u8,
-            aux_data: Vec<u8>,
-        }
-
-        Helper::deserialize(deserializer).and_then(|h| {
-            TagData::new(h.subproto_id, h.tx_type, h.aux_data)
-                .map(|tag| L1Payload {
-                    data: h.payload,
-                    tag,
-                })
-                .map_err(de::Error::custom)
-        })
-    }
-}
+impl_ssz_via_delegate!(L1Payload);
 
 impl<'a> arbitrary::Arbitrary<'a> for L1Payload {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -372,6 +298,8 @@ impl PayloadIntent {
 
 #[cfg(test)]
 mod tests {
+    use strata_l1_txfmt::TagData;
+
     use crate::payload::L1Payload;
     use crate::test_helpers::ArbitraryGenerator;
 
@@ -389,5 +317,26 @@ mod tests {
         let json = serde_json::to_string(&l1_payload).unwrap();
         let res: L1Payload = serde_json::from_str(&json).unwrap();
         assert_eq!(res, l1_payload);
+    }
+
+    #[test]
+    fn test_l1_payload_serde_flat_shape() {
+        // Guards the JSON layout: the tag fields are flattened alongside
+        // `payload` rather than nested, preserving the historical shape.
+        let payload = L1Payload::new(
+            vec![vec![1, 2, 3]],
+            TagData::new(5, 9, vec![0xAA, 0xBB]).unwrap(),
+        );
+        let value: serde_json::Value = serde_json::to_value(&payload).unwrap();
+        let obj = value.as_object().unwrap();
+
+        assert_eq!(obj["payload"], serde_json::json!([[1, 2, 3]]));
+        assert_eq!(obj["subproto_id"], 5);
+        assert_eq!(obj["tx_type"], 9);
+        assert_eq!(obj["aux_data"], serde_json::json!([0xAA, 0xBB]));
+        assert!(
+            !obj.contains_key("tag"),
+            "tag must be flattened, not nested"
+        );
     }
 }

--- a/crates/btc-types/src/payload.rs
+++ b/crates/btc-types/src/payload.rs
@@ -12,7 +12,10 @@ use ssz_primitives::FixedBytes;
 use strata_identifiers::{Buf32, SszDelegate, impl_borsh_via_ssz, impl_ssz_via_delegate};
 use strata_l1_txfmt::TagData;
 
-use crate::ssz_generated::ssz::btc::{BlobSpecSsz, L1PayloadSsz, PayloadIntentSsz, PayloadSpecSsz};
+use crate::ssz_generated::ssz::btc::{
+    BlobSpecSsz, L1PayloadSsz, MAX_PAYLOAD_CHUNK_LEN, MAX_PAYLOAD_CHUNKS, PayloadIntentSsz,
+    PayloadSpecSsz,
+};
 
 /// DA destination identifier. This will eventually be used to enable
 /// storing payloads on alternative availability schemes.
@@ -178,12 +181,36 @@ impl PayloadSpec {
     }
 }
 
+/// Error returned when constructing an [`L1Payload`] with data that exceeds the
+/// SSZ encoding bounds.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum L1PayloadError {
+    /// A single payload chunk is longer than [`MAX_PAYLOAD_CHUNK_LEN`].
+    #[error("payload chunk of {len} bytes exceeds maximum of {MAX_PAYLOAD_CHUNK_LEN}")]
+    ChunkTooLong {
+        /// Length of the offending chunk.
+        len: usize,
+    },
+
+    /// The payload has more than [`MAX_PAYLOAD_CHUNKS`] chunks.
+    #[error("payload has {count} chunks, exceeding maximum of {MAX_PAYLOAD_CHUNKS}")]
+    TooManyChunks {
+        /// Number of chunks supplied.
+        count: usize,
+    },
+}
+
 /// Data that is submitted to L1. This can be DA, Checkpoint, etc.
 ///
+/// The chunk bounds enforced by [`L1Payload::new`] mirror the SSZ container's
+/// length-bounded lists, so a constructed (or deserialized) `L1Payload` is
+/// always SSZ-encodable.
+///
 /// The serde representation flattens the [`TagData`] fields alongside the
-/// payload (`{payload, subproto_id, tx_type, aux_data}`); deserialization is
-/// validated by `TagData`'s own (validating) `Deserialize` impl.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+/// payload (`{payload, subproto_id, tx_type, aux_data}`); deserialization
+/// routes through [`L1Payload::new`] (and `TagData`'s own validating
+/// `Deserialize`) so the same invariants hold.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct L1Payload {
     /// Data payload.
     #[serde(rename = "payload")]
@@ -196,8 +223,25 @@ pub struct L1Payload {
 
 impl L1Payload {
     /// Creates a new L1 payload from data chunks and tag metadata.
-    pub fn new(payload: Vec<Vec<u8>>, tag: TagData) -> Self {
-        Self { data: payload, tag }
+    ///
+    /// # Errors
+    ///
+    /// Returns [`L1PayloadError`] if the data exceeds the SSZ encoding bounds:
+    /// any chunk longer than [`MAX_PAYLOAD_CHUNK_LEN`], or more than
+    /// [`MAX_PAYLOAD_CHUNKS`] chunks.
+    pub fn new(payload: Vec<Vec<u8>>, tag: TagData) -> Result<Self, L1PayloadError> {
+        if payload.len() > MAX_PAYLOAD_CHUNKS as usize {
+            return Err(L1PayloadError::TooManyChunks {
+                count: payload.len(),
+            });
+        }
+        if let Some(chunk) = payload
+            .iter()
+            .find(|chunk| chunk.len() > MAX_PAYLOAD_CHUNK_LEN as usize)
+        {
+            return Err(L1PayloadError::ChunkTooLong { len: chunk.len() });
+        }
+        Ok(Self { data: payload, tag })
     }
 
     /// Returns the data payload chunks.
@@ -208,6 +252,26 @@ impl L1Payload {
     /// Returns a reference to the tag metadata.
     pub fn tag(&self) -> &TagData {
         &self.tag
+    }
+}
+
+/// [`Deserialize`] is implemented manually to route through [`L1Payload::new`],
+/// enforcing the same chunk bounds that direct construction does.
+impl<'de> Deserialize<'de> for L1Payload {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(rename = "payload")]
+            data: Vec<Vec<u8>>,
+            #[serde(flatten)]
+            tag: TagData,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        Self::new(raw.data, raw.tag).map_err(serde::de::Error::custom)
     }
 }
 
@@ -223,6 +287,8 @@ impl SszDelegate for L1Payload {
     type Delegate = L1PayloadSsz;
 
     fn into_delegate(self) -> Self::Delegate {
+        // These conversions cannot fail: `L1Payload::new` (and all decode paths)
+        // enforce the same bounds, so the type can never hold out-of-range data.
         let data = self
             .data
             .into_iter()
@@ -267,7 +333,18 @@ impl_ssz_via_delegate!(L1Payload);
 
 impl<'a> arbitrary::Arbitrary<'a> for L1Payload {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let data = Vec::<Vec<u8>>::arbitrary(u)?;
+        // Generate a bounded number of bounded chunks so the result is always a
+        // valid (SSZ-encodable) payload.
+        let num_chunks = u.int_in_range(0..=8)?;
+        let mut data = Vec::with_capacity(num_chunks);
+        for _ in 0..num_chunks {
+            let chunk_len = u.int_in_range(0..=64)?;
+            let mut chunk = Vec::with_capacity(chunk_len);
+            for _ in 0..chunk_len {
+                chunk.push(u8::arbitrary(u)?);
+            }
+            data.push(chunk);
+        }
 
         let subproto_id = u8::arbitrary(u)?;
         let tx_type = u8::arbitrary(u)?;
@@ -367,7 +444,8 @@ impl PayloadIntent {
 mod tests {
     use strata_l1_txfmt::TagData;
 
-    use crate::payload::L1Payload;
+    use crate::payload::{L1Payload, L1PayloadError};
+    use crate::ssz_generated::ssz::btc::{MAX_PAYLOAD_CHUNK_LEN, MAX_PAYLOAD_CHUNKS};
     use crate::test_helpers::ArbitraryGenerator;
 
     #[test]
@@ -393,7 +471,8 @@ mod tests {
         let payload = L1Payload::new(
             vec![vec![1, 2, 3]],
             TagData::new(5, 9, vec![0xAA, 0xBB]).unwrap(),
-        );
+        )
+        .unwrap();
         let value: serde_json::Value = serde_json::to_value(&payload).unwrap();
         let obj = value.as_object().unwrap();
 
@@ -405,5 +484,39 @@ mod tests {
             !obj.contains_key("tag"),
             "tag must be flattened, not nested"
         );
+    }
+
+    #[test]
+    fn test_l1_payload_new_rejects_long_chunk() {
+        let tag = TagData::new(1, 1, vec![]).unwrap();
+        let chunk = vec![0u8; MAX_PAYLOAD_CHUNK_LEN as usize + 1];
+        assert!(matches!(
+            L1Payload::new(vec![chunk], tag),
+            Err(L1PayloadError::ChunkTooLong { .. })
+        ));
+    }
+
+    #[test]
+    fn test_l1_payload_new_rejects_too_many_chunks() {
+        let tag = TagData::new(1, 1, vec![]).unwrap();
+        let chunks = vec![vec![]; MAX_PAYLOAD_CHUNKS as usize + 1];
+        assert!(matches!(
+            L1Payload::new(chunks, tag),
+            Err(L1PayloadError::TooManyChunks { .. })
+        ));
+    }
+
+    #[test]
+    fn test_l1_payload_deserialize_rejects_long_chunk() {
+        // A JSON payload with an over-long chunk must be rejected by the
+        // validating `Deserialize` rather than producing a panicking value.
+        let long = MAX_PAYLOAD_CHUNK_LEN as usize + 1;
+        let json = serde_json::json!({
+            "payload": [vec![0u8; long]],
+            "subproto_id": 1,
+            "tx_type": 1,
+            "aux_data": [],
+        });
+        assert!(serde_json::from_value::<L1Payload>(json).is_err());
     }
 }

--- a/crates/btc-types/src/payload.rs
+++ b/crates/btc-types/src/payload.rs
@@ -185,14 +185,14 @@ impl PayloadSpec {
 /// SSZ encoding bounds.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum L1PayloadError {
-    /// A single payload chunk is longer than [`MAX_PAYLOAD_CHUNK_LEN`].
+    /// A single payload chunk is longer than `MAX_PAYLOAD_CHUNK_LEN`.
     #[error("payload chunk of {len} bytes exceeds maximum of {MAX_PAYLOAD_CHUNK_LEN}")]
     ChunkTooLong {
         /// Length of the offending chunk.
         len: usize,
     },
 
-    /// The payload has more than [`MAX_PAYLOAD_CHUNKS`] chunks.
+    /// The payload has more than `MAX_PAYLOAD_CHUNKS` chunks.
     #[error("payload has {count} chunks, exceeding maximum of {MAX_PAYLOAD_CHUNKS}")]
     TooManyChunks {
         /// Number of chunks supplied.
@@ -227,8 +227,8 @@ impl L1Payload {
     /// # Errors
     ///
     /// Returns [`L1PayloadError`] if the data exceeds the SSZ encoding bounds:
-    /// any chunk longer than [`MAX_PAYLOAD_CHUNK_LEN`], or more than
-    /// [`MAX_PAYLOAD_CHUNKS`] chunks.
+    /// any chunk longer than `MAX_PAYLOAD_CHUNK_LEN`, or more than
+    /// `MAX_PAYLOAD_CHUNKS` chunks.
     pub fn new(payload: Vec<Vec<u8>>, tag: TagData) -> Result<Self, L1PayloadError> {
         if payload.len() > MAX_PAYLOAD_CHUNKS as usize {
             return Err(L1PayloadError::TooManyChunks {

--- a/crates/btc-types/ssz/btc.ssz
+++ b/crates/btc-types/ssz/btc.ssz
@@ -47,3 +47,28 @@ class L1PayloadSsz(Container):
     tx_type: uint8
     ### Auxiliary tag data (remaining tag bytes).
     aux_data: List[byte, MAX_AUX_DATA_LEN]
+
+### SSZ delegate for a DA blob spec (target + commitment).
+###
+### `dest` is the single-byte `PayloadDest` selector.
+class BlobSpecSsz(Container):
+    ### Target settlement layer selector.
+    dest: uint8
+    ### Commitment to the payload.
+    commitment: Bytes32
+
+### SSZ delegate for a DA payload spec (target + commitment).
+class PayloadSpecSsz(Container):
+    ### Target settlement layer selector.
+    dest: uint8
+    ### Commitment to the payload.
+    commitment: Bytes32
+
+### SSZ delegate for a payload intent (target + commitment + payload).
+class PayloadIntentSsz(Container):
+    ### Target settlement layer selector.
+    dest: uint8
+    ### Commitment to the payload.
+    commitment: Bytes32
+    ### The blob payload itself.
+    payload: L1PayloadSsz

--- a/crates/btc-types/ssz/btc.ssz
+++ b/crates/btc-types/ssz/btc.ssz
@@ -1,0 +1,49 @@
+# SSZ schema definitions for strata-btc-types wrapper types.
+#
+# These containers are the canonical SSZ "delegate" representations for the
+# Bitcoin wrapper types in this crate. The Rust wrappers implement `SszDelegate`
+# against the generated types and obtain their `Encode`/`Decode` impls via
+# `impl_ssz_via_delegate!`, so the wire layout is correct by construction (the
+# SSZ fixed-part/variable-part split is handled entirely by the generated code).
+
+### Maximum size of a Bitcoin scriptPubKey, in bytes (Bitcoin Core `MAX_SCRIPT_SIZE`).
+MAX_SCRIPT_SIZE = 10000
+
+### Maximum size of a single envelope payload chunk, in bytes
+### (Bitcoin `MAX_SCRIPT_ELEMENT_SIZE`).
+MAX_PAYLOAD_CHUNK_LEN = 520
+
+### Maximum number of envelope payload chunks
+### (`MAX_ENVELOPE_PAYLOAD_SIZE` / `MAX_SCRIPT_ELEMENT_SIZE`, rounded up).
+MAX_PAYLOAD_CHUNKS = 760
+
+### Maximum length of L1 tag auxiliary data, in bytes (`strata-l1-txfmt` `MAX_AUX_LEN`).
+MAX_AUX_DATA_LEN = 74
+
+### A Bitcoin locking script (scriptPubKey), bounded by the consensus script size.
+BitcoinScriptSsz = List[byte, MAX_SCRIPT_SIZE]
+
+### SSZ delegate for a Bitcoin outpoint (a reference to a specific tx output).
+class BitcoinOutPointSsz(Container):
+    ### Transaction ID the output belongs to.
+    txid: Bytes32
+    ### Index of the referenced output within that transaction.
+    vout: uint32
+
+### SSZ delegate for a Bitcoin transaction output.
+class BitcoinTxOutSsz(Container):
+    ### Output value, in satoshis.
+    value: uint64
+    ### Locking script (scriptPubKey).
+    script_pubkey: List[byte, MAX_SCRIPT_SIZE]
+
+### SSZ delegate for an L1 DA payload.
+class L1PayloadSsz(Container):
+    ### Payload data, split into envelope-sized chunks.
+    data: List[List[byte, MAX_PAYLOAD_CHUNK_LEN], MAX_PAYLOAD_CHUNKS]
+    ### Subprotocol ID (first byte of the tag metadata).
+    subproto_id: uint8
+    ### Transaction type (second byte of the tag metadata).
+    tx_type: uint8
+    ### Auxiliary tag data (remaining tag bytes).
+    aux_data: List[byte, MAX_AUX_DATA_LEN]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "strata-crypto"
 version = "0.3.0-alpha.1"
 
@@ -20,8 +20,15 @@ serde.workspace = true
 sha2.workspace = true
 ssz.workspace = true
 ssz_derive.workspace = true
+ssz_primitives.workspace = true
+ssz_types.workspace = true
 thiserror.workspace = true
+tree_hash.workspace = true
+tree_hash_derive.workspace = true
 zeroize.workspace = true
+
+[build-dependencies]
+ssz_codegen.workspace = true
 
 [dev-dependencies]
 bitcoin.workspace = true
@@ -29,6 +36,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_core = { workspace = true, features = ["getrandom"] }
 serde_json.workspace = true
+strata-ssz-tests.workspace = true
 
 [features]
 default = []

--- a/crates/crypto/build.rs
+++ b/crates/crypto/build.rs
@@ -1,0 +1,26 @@
+//! Build script for generating SSZ delegate types from schema definitions.
+
+use std::path::Path;
+
+use ssz_codegen::{ModuleGeneration, build_ssz_files};
+
+fn main() {
+    // Generate SSZ delegate types into OUT_DIR.
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set by cargo");
+    let output_path = Path::new(&out_dir).join("generated_ssz.rs");
+
+    // Use local ssz-gen codegen.
+    let entry_points = ["threshold.ssz"]; // ssz/threshold.ssz
+    let base_dir = "ssz/"; // relative to this crate root
+    // External crates whose SSZ modules are imported by `threshold.ssz`.
+    let crates = [];
+
+    build_ssz_files(
+        &entry_points,
+        base_dir,
+        &crates,
+        output_path.to_str().expect("utf8 path"),
+        ModuleGeneration::NestedModules,
+    )
+    .expect("Failed to generate SSZ types");
+}

--- a/crates/crypto/src/hash.rs
+++ b/crates/crypto/src/hash.rs
@@ -48,9 +48,9 @@ pub fn sha256d(buf: &[u8]) -> Buf32 {
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::hashes::{sha256d, Hash};
-    use rand::rngs::OsRng;
+    use bitcoin::hashes::{Hash, sha256d};
     use rand::RngCore;
+    use rand::rngs::OsRng;
     use strata_identifiers::Buf32;
 
     use super::sha256d;

--- a/crates/crypto/src/keys/compressed.rs
+++ b/crates/crypto/src/keys/compressed.rs
@@ -7,7 +7,8 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use secp256k1::{Error, PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
+use ssz::DecodeError;
+use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
 
 /// A compressed secp256k1 public key (33 bytes).
 ///
@@ -25,38 +26,21 @@ use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompressedPublicKey(PublicKey);
 
-impl SszEncodeTrait for CompressedPublicKey {
-    fn is_ssz_fixed_len() -> bool {
-        true
+// Delegates SSZ encoding to the upstream `[u8; 33]` impl (the 33-byte compressed
+// point), making the layout correct by construction rather than hand-rolled.
+impl SszDelegate for CompressedPublicKey {
+    type Delegate = [u8; 33];
+
+    fn into_delegate(self) -> Self::Delegate {
+        self.serialize()
     }
 
-    fn ssz_fixed_len() -> usize {
-        33
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.serialize());
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        <Self as SszEncodeTrait>::ssz_fixed_len()
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Self::from_slice(&delegate).map_err(|err| DecodeError::BytesInvalid(err.to_string()))
     }
 }
 
-impl SszDecodeTrait for CompressedPublicKey {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_fixed_len() -> usize {
-        33
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let serialized = <[u8; 33]>::from_ssz_bytes(bytes)?;
-        Self::from_slice(&serialized).map_err(|err| DecodeError::BytesInvalid(err.to_string()))
-    }
-}
+impl_ssz_via_delegate!(CompressedPublicKey);
 
 impl CompressedPublicKey {
     /// Create a new `CompressedPublicKey` from a byte slice.
@@ -207,5 +191,33 @@ mod tests {
         let invalid = [0u8; 33];
         let result = CompressedPublicKey::from_slice(&invalid);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compressed_pubkey_ssz_roundtrip_and_layout() {
+        use secp256k1::{Secp256k1, SecretKey};
+        use ssz::{Decode, Encode};
+
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x03; 32]).unwrap();
+        let pk = PublicKey::from_secret_key(&secp, &sk);
+        let compressed = CompressedPublicKey::from(pk);
+
+        // Byte layout: the raw 33-byte compressed point with no length prefix.
+        let encoded = compressed.as_ssz_bytes();
+        assert_eq!(encoded, compressed.serialize().to_vec());
+        assert_eq!(encoded.len(), 33);
+
+        let decoded = CompressedPublicKey::from_ssz_bytes(&encoded).unwrap();
+        assert_eq!(compressed, decoded);
+    }
+
+    #[test]
+    fn test_compressed_pubkey_ssz_rejects_invalid() {
+        use ssz::Decode;
+        // Wrong length.
+        assert!(CompressedPublicKey::from_ssz_bytes(&[0u8; 32]).is_err());
+        // Right length, not a valid curve point.
+        assert!(CompressedPublicKey::from_ssz_bytes(&[0u8; 33]).is_err());
     }
 }

--- a/crates/crypto/src/keys/constants.rs
+++ b/crates/crypto/src/keys/constants.rs
@@ -5,9 +5,9 @@
 
 use std::sync::LazyLock;
 
-use bitcoin::bip32::ChildNumber;
 use bitcoin::XOnlyPublicKey;
-use secp256k1::hashes::{sha256, Hash};
+use bitcoin::bip32::ChildNumber;
+use secp256k1::hashes::{Hash, sha256};
 
 /// Strata base index for keys.
 ///

--- a/crates/crypto/src/keys/even.rs
+++ b/crates/crypto/src/keys/even.rs
@@ -9,11 +9,11 @@ use std::ops::Deref;
 use arbitrary::{Arbitrary, Unstructured};
 use borsh::{BorshDeserialize, BorshSerialize};
 use hex;
-use secp256k1::{Parity, PublicKey, SecretKey, XOnlyPublicKey, SECP256K1};
+use secp256k1::{Parity, PublicKey, SECP256K1, SecretKey, XOnlyPublicKey};
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
-use strata_identifiers::Buf32;
+use ssz::DecodeError;
+use strata_identifiers::{Buf32, SszDelegate, impl_ssz_via_delegate};
 
 /// Represents a secret key whose x-only public key has even parity.
 ///
@@ -58,40 +58,23 @@ impl From<EvenSecretKey> for SecretKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct EvenPublicKey(PublicKey);
 
-impl SszEncodeTrait for EvenPublicKey {
-    fn is_ssz_fixed_len() -> bool {
-        true
+// Delegates SSZ encoding to the upstream `[u8; 32]` impl (the x-only serialization),
+// making the layout correct by construction rather than hand-rolled.
+impl SszDelegate for EvenPublicKey {
+    type Delegate = [u8; 32];
+
+    fn into_delegate(self) -> Self::Delegate {
+        self.0.x_only_public_key().0.serialize()
     }
 
-    fn ssz_fixed_len() -> usize {
-        32
-    }
-
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&self.0.x_only_public_key().0.serialize());
-    }
-
-    fn ssz_bytes_len(&self) -> usize {
-        <Self as SszEncodeTrait>::ssz_fixed_len()
-    }
-}
-
-impl SszDecodeTrait for EvenPublicKey {
-    fn is_ssz_fixed_len() -> bool {
-        true
-    }
-
-    fn ssz_fixed_len() -> usize {
-        32
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let serialized = <[u8; 32]>::from_ssz_bytes(bytes)?;
-        let x_only = XOnlyPublicKey::from_slice(&serialized)
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let x_only = XOnlyPublicKey::from_slice(&delegate)
             .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?;
         Ok(PublicKey::from_x_only_public_key(x_only, Parity::Even).into())
     }
 }
+
+impl_ssz_via_delegate!(EvenPublicKey);
 
 impl Deref for EvenPublicKey {
     type Target = PublicKey;
@@ -225,10 +208,10 @@ pub fn even_kp((sk, pk): (SecretKey, PublicKey)) -> (EvenSecretKey, EvenPublicKe
 #[cfg(test)]
 mod tests {
     use borsh::{from_slice, to_vec};
-    use secp256k1::{Parity, PublicKey, SecretKey, SECP256K1};
+    use secp256k1::{Parity, PublicKey, SECP256K1, SecretKey};
     use strata_identifiers::Buf32;
 
-    use super::{even_kp, EvenPublicKey, EvenSecretKey};
+    use super::{EvenPublicKey, EvenSecretKey, even_kp};
 
     fn sample_secret_keys() -> (SecretKey, SecretKey) {
         let sk = SecretKey::from_slice(&[0x01; 32]).expect("valid secret key");
@@ -292,6 +275,32 @@ mod tests {
         let decoded = EvenPublicKey::try_from(buf).expect("valid x-only key");
 
         assert_eq!(even_pk, decoded);
+    }
+
+    #[test]
+    fn test_even_public_key_ssz_roundtrip_and_layout() {
+        use ssz::{Decode, Encode};
+
+        let (even_pk, _) = sample_public_keys();
+        let even_pk = EvenPublicKey::from(even_pk);
+
+        // Byte layout: the raw 32-byte x-only serialization with no length prefix.
+        let encoded = even_pk.as_ssz_bytes();
+        assert_eq!(
+            encoded,
+            even_pk.0.x_only_public_key().0.serialize().to_vec()
+        );
+        assert_eq!(encoded.len(), 32);
+
+        let decoded = EvenPublicKey::from_ssz_bytes(&encoded).expect("valid x-only key");
+        assert_eq!(even_pk, decoded);
+    }
+
+    #[test]
+    fn test_even_public_key_ssz_rejects_wrong_length() {
+        use ssz::Decode;
+        assert!(EvenPublicKey::from_ssz_bytes(&[0u8; 31]).is_err());
+        assert!(EvenPublicKey::from_ssz_bytes(&[0u8; 33]).is_err());
     }
 
     #[test]

--- a/crates/crypto/src/keys/zeroizable.rs
+++ b/crates/crypto/src/keys/zeroizable.rs
@@ -135,12 +135,12 @@ impl Deref for ZeroizedBuf32 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
+    use bitcoin::Network;
     use bitcoin::bip32::Xpriv;
     use bitcoin::secp256k1::SECP256K1;
-    use bitcoin::Network;
     use zeroize::Zeroize;
 
     use super::*;

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -1,5 +1,17 @@
 //! Cryptographic primitives.
 
+// `ssz_primitives` (FixedBytes), `tree_hash`, and `tree_hash_derive` are
+// referenced by the generated SSZ delegate types in `ssz_generated`.
+#[cfg(test)]
+use strata_ssz_tests as _;
+use {ssz_primitives as _, tree_hash as _, tree_hash_derive as _};
+
+/// SSZ delegate types generated from `ssz/threshold.ssz`.
+#[allow(unreachable_pub, missing_docs, reason = "generated code")]
+mod ssz_generated {
+    include!(concat!(env!("OUT_DIR"), "/generated_ssz.rs"));
+}
+
 /// Hashing functions.
 pub mod hash;
 /// Key types, derivation paths, and constants.
@@ -14,9 +26,9 @@ pub mod test_utils;
 pub mod threshold_signature;
 
 // Re-export even parity key types
-pub use keys::even::{even_kp, EvenPublicKey, EvenSecretKey};
+pub use keys::even::{EvenPublicKey, EvenSecretKey, even_kp};
 // Re-export MuSig2 key aggregation
-pub use musig2::{aggregate_schnorr_keys, Musig2Error};
+pub use musig2::{Musig2Error, aggregate_schnorr_keys};
 pub use schnorr::*;
 
 #[cfg(test)]

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -2,9 +2,11 @@
 
 // `ssz_primitives` (FixedBytes), `tree_hash`, and `tree_hash_derive` are
 // referenced by the generated SSZ delegate types in `ssz_generated`.
+use ssz_primitives as _;
 #[cfg(test)]
 use strata_ssz_tests as _;
-use {ssz_primitives as _, tree_hash as _, tree_hash_derive as _};
+use tree_hash as _;
+use tree_hash_derive as _;
 
 /// SSZ delegate types generated from `ssz/threshold.ssz`.
 #[allow(unreachable_pub, missing_docs, reason = "generated code")]

--- a/crates/crypto/src/musig2/mod.rs
+++ b/crates/crypto/src/musig2/mod.rs
@@ -6,4 +6,4 @@
 
 mod aggregation;
 
-pub use aggregation::{aggregate_schnorr_keys, Musig2Error};
+pub use aggregation::{Musig2Error, aggregate_schnorr_keys};

--- a/crates/crypto/src/schnorr.rs
+++ b/crates/crypto/src/schnorr.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use borsh::{BorshDeserialize, BorshSerialize};
 use hex;
 use secp256k1::schnorr::Signature;
-use secp256k1::{Keypair, Message, Parity, PublicKey, SecretKey, XOnlyPublicKey, SECP256K1};
+use secp256k1::{Keypair, Message, Parity, PublicKey, SECP256K1, SecretKey, XOnlyPublicKey};
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
 use strata_identifiers::{Buf32, Buf64};
@@ -202,8 +202,8 @@ pub fn even_kp((sk, pk): (SecretKey, PublicKey)) -> (EvenSecretKey, EvenPublicKe
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::OsRng;
     use rand::Rng;
+    use rand::rngs::OsRng;
     use strata_identifiers::Buf32;
 
     use super::{sign_schnorr_sig, verify_schnorr_sig};
@@ -211,9 +211,9 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "zkvm"))]
     fn test_schnorr_signature_pass() {
-        use secp256k1::{SecretKey, SECP256K1};
+        use secp256k1::{SECP256K1, SecretKey};
 
-        let msg: [u8; 32] = [(); 32].map(|_| OsRng.gen());
+        let msg: [u8; 32] = [(); 32].map(|_| OsRng.r#gen());
 
         let mut mod_msg = msg;
         mod_msg.swap(1, 2);

--- a/crates/crypto/src/test_utils/schnorr.rs
+++ b/crates/crypto/src/test_utils/schnorr.rs
@@ -1,6 +1,6 @@
 use musig2::{FirstRound, KeyAggContext, SecNonceSpices};
-use rand::rngs::OsRng;
 use rand::RngCore;
+use rand::rngs::OsRng;
 use secp256k1::{PublicKey, Secp256k1, XOnlyPublicKey};
 use strata_identifiers::Buf32;
 
@@ -143,11 +143,11 @@ pub fn create_agg_pubkey_from_privkeys(operators_privkeys: &[EvenSecretKey]) -> 
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::TapNodeHash;
     use bitcoin::hashes::Hash;
     use bitcoin::key::TapTweak;
     use bitcoin::secp256k1::schnorr::Signature;
     use bitcoin::secp256k1::{self, Secp256k1};
-    use bitcoin::TapNodeHash;
     use rand::rngs::OsRng;
     use secp256k1::SecretKey;
 

--- a/crates/crypto/src/threshold_signature/indexed/config.rs
+++ b/crates/crypto/src/threshold_signature/indexed/config.rs
@@ -438,6 +438,28 @@ mod tests {
     }
 
     #[test]
+    fn test_update_rejects_more_than_max_signers() {
+        // Each member list is bounded independently to MAX_SIGNERS, so a standalone
+        // update with an over-long add (or remove) list is rejected rather than
+        // constructed into a value that later panics on SSZ encoding.
+        let oversized: Vec<_> = (0..=MAX_SIGNERS as u32).map(make_key_n).collect();
+
+        let add_too_big =
+            ThresholdConfigUpdate::try_new(oversized.clone(), vec![], NonZero::new(1).unwrap());
+        assert!(matches!(
+            add_too_big,
+            Err(ThresholdSignatureError::TooManySigners { .. })
+        ));
+
+        let remove_too_big =
+            ThresholdConfigUpdate::try_new(vec![], oversized, NonZero::new(1).unwrap());
+        assert!(matches!(
+            remove_too_big,
+            Err(ThresholdSignatureError::TooManySigners { .. })
+        ));
+    }
+
+    #[test]
     fn test_config_threshold_exceeds_keys() {
         let keys = vec![make_key(1), make_key(2)];
         let result = ThresholdConfig::try_new(keys, NonZero::new(3).unwrap());

--- a/crates/crypto/src/threshold_signature/indexed/config.rs
+++ b/crates/crypto/src/threshold_signature/indexed/config.rs
@@ -9,11 +9,13 @@ use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
-use ssz::{Decode as SszDecodeTrait, DecodeError, Encode as SszEncodeTrait};
-use ssz_derive::{Decode, Encode};
+use ssz::DecodeError;
+use ssz_primitives::FixedBytes;
+use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
 
 use super::ThresholdSignatureError;
 use crate::keys::compressed::CompressedPublicKey;
+use crate::ssz_generated::ssz::threshold::{ThresholdConfigSsz, ThresholdConfigUpdateSsz};
 
 /// Maximum number of signers allowed in a threshold configuration.
 ///
@@ -36,15 +38,6 @@ pub struct ThresholdConfig {
     keys: Vec<CompressedPublicKey>,
     /// Minimum number of signatures required (always >= 1).
     threshold: NonZero<u8>,
-}
-
-/// SSZ representation of a [ThresholdConfig].
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-struct ThresholdConfigSsz {
-    /// Public keys of all authorized signers.
-    keys: Vec<CompressedPublicKey>,
-    /// Minimum number of signatures required (always >= 1).
-    threshold: u8,
 }
 
 /// [`Deserialize`] is implemented manually to route through [`Self::try_new`].
@@ -101,41 +94,40 @@ impl<'a> Arbitrary<'a> for ThresholdConfig {
     }
 }
 
-impl SszEncodeTrait for ThresholdConfig {
-    fn is_ssz_fixed_len() -> bool {
-        <ThresholdConfigSsz as SszEncodeTrait>::is_ssz_fixed_len()
-    }
+// SSZ encoding delegates to the generated [`ThresholdConfigSsz`] container, whose
+// `keys` field is a length-bounded `List[Bytes33, MAX_SIGNERS]` — correct by
+// construction rather than hand-rolled.
+impl SszDelegate for ThresholdConfig {
+    type Delegate = ThresholdConfigSsz;
 
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
+    fn into_delegate(self) -> Self::Delegate {
+        let keys = self
+            .keys
+            .into_iter()
+            .map(|key| FixedBytes(key.serialize()))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("more than MAX_SIGNERS keys");
         ThresholdConfigSsz {
-            keys: self.keys.clone(),
+            keys,
             threshold: self.threshold.get(),
         }
-        .ssz_append(buf);
     }
 
-    fn ssz_bytes_len(&self) -> usize {
-        ThresholdConfigSsz {
-            keys: self.keys.clone(),
-            threshold: self.threshold.get(),
-        }
-        .ssz_bytes_len()
-    }
-}
-
-impl SszDecodeTrait for ThresholdConfig {
-    fn is_ssz_fixed_len() -> bool {
-        <ThresholdConfigSsz as SszDecodeTrait>::is_ssz_fixed_len()
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let decoded = ThresholdConfigSsz::from_ssz_bytes(bytes)?;
-        let threshold = NonZero::new(decoded.threshold)
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let keys = delegate
+            .keys
+            .iter()
+            .map(|key| CompressedPublicKey::from_slice(&key.0))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| DecodeError::BytesInvalid(err.to_string()))?;
+        let threshold = NonZero::new(delegate.threshold)
             .ok_or_else(|| DecodeError::BytesInvalid("threshold must be non-zero".into()))?;
-        Self::try_new(decoded.keys, threshold)
-            .map_err(|err| DecodeError::BytesInvalid(err.to_string()))
+        Self::try_new(keys, threshold).map_err(|err| DecodeError::BytesInvalid(err.to_string()))
     }
 }
+
+impl_ssz_via_delegate!(ThresholdConfig);
 
 impl ThresholdConfig {
     /// Create a new threshold configuration.
@@ -268,17 +260,6 @@ pub struct ThresholdConfigUpdate {
     new_threshold: NonZero<u8>,
 }
 
-/// SSZ representation of a [ThresholdConfigUpdate].
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
-struct ThresholdConfigUpdateSsz {
-    /// Public keys of all authorized signers.
-    add_members: Vec<CompressedPublicKey>,
-    /// Public keys to remove.
-    remove_members: Vec<CompressedPublicKey>,
-    /// Minimum number of signatures required (always >= 1).
-    new_threshold: u8,
-}
-
 impl ThresholdConfigUpdate {
     /// Creates a new threshold configuration update.
     pub fn new(
@@ -337,46 +318,43 @@ impl<'a> Arbitrary<'a> for ThresholdConfigUpdate {
     }
 }
 
-impl SszEncodeTrait for ThresholdConfigUpdate {
-    fn is_ssz_fixed_len() -> bool {
-        <ThresholdConfigUpdateSsz as SszEncodeTrait>::is_ssz_fixed_len()
-    }
+// SSZ encoding delegates to the generated [`ThresholdConfigUpdateSsz`] container,
+// whose member lists are length-bounded `List[Bytes33, MAX_SIGNERS]` — correct by
+// construction rather than hand-rolled.
+impl SszDelegate for ThresholdConfigUpdate {
+    type Delegate = ThresholdConfigUpdateSsz;
 
-    fn ssz_append(&self, buf: &mut Vec<u8>) {
+    fn into_delegate(self) -> Self::Delegate {
+        let to_bytes_list = |keys: Vec<CompressedPublicKey>| {
+            keys.into_iter()
+                .map(|key| FixedBytes(key.serialize()))
+                .collect::<Vec<_>>()
+                .try_into()
+                .expect("more than MAX_SIGNERS members")
+        };
         ThresholdConfigUpdateSsz {
-            add_members: self.add_members.clone(),
-            remove_members: self.remove_members.clone(),
+            add_members: to_bytes_list(self.add_members),
+            remove_members: to_bytes_list(self.remove_members),
             new_threshold: self.new_threshold.get(),
         }
-        .ssz_append(buf);
     }
 
-    fn ssz_bytes_len(&self) -> usize {
-        ThresholdConfigUpdateSsz {
-            add_members: self.add_members.clone(),
-            remove_members: self.remove_members.clone(),
-            new_threshold: self.new_threshold.get(),
-        }
-        .ssz_bytes_len()
-    }
-}
-
-impl SszDecodeTrait for ThresholdConfigUpdate {
-    fn is_ssz_fixed_len() -> bool {
-        <ThresholdConfigUpdateSsz as SszDecodeTrait>::is_ssz_fixed_len()
-    }
-
-    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        let decoded = ThresholdConfigUpdateSsz::from_ssz_bytes(bytes)?;
-        let new_threshold = NonZero::new(decoded.new_threshold)
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let from_bytes_list = |keys: &ssz_types::VariableList<FixedBytes<33>, 256>| {
+            keys.iter()
+                .map(|key| CompressedPublicKey::from_slice(&key.0))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| DecodeError::BytesInvalid(err.to_string()))
+        };
+        let add_members = from_bytes_list(&delegate.add_members)?;
+        let remove_members = from_bytes_list(&delegate.remove_members)?;
+        let new_threshold = NonZero::new(delegate.new_threshold)
             .ok_or_else(|| DecodeError::BytesInvalid("threshold must be non-zero".into()))?;
-        Ok(Self::new(
-            decoded.add_members,
-            decoded.remove_members,
-            new_threshold,
-        ))
+        Ok(Self::new(add_members, remove_members, new_threshold))
     }
 }
+
+impl_ssz_via_delegate!(ThresholdConfigUpdate);
 
 #[cfg(test)]
 mod tests {
@@ -469,5 +447,96 @@ mod tests {
         let decoded: ThresholdConfig = borsh::from_slice(&encoded).unwrap();
 
         assert_eq!(config, decoded);
+    }
+
+    #[test]
+    fn test_config_ssz_byte_layout() {
+        use ssz::Encode;
+
+        let keys = vec![make_key(1), make_key(2), make_key(3)];
+        let config = ThresholdConfig::try_new(keys.clone(), NonZero::new(2).unwrap()).unwrap();
+
+        // Byte layout of the `keys || threshold` container: a 4-byte offset to the
+        // variable `keys` list and the 1-byte `threshold` make up the 5-byte fixed
+        // part, followed by the 33-byte compressed keys concatenated.
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&5u32.to_le_bytes()); // offset to keys
+        expected.push(2); // threshold
+        for key in &keys {
+            expected.extend_from_slice(&key.serialize());
+        }
+        assert_eq!(config.as_ssz_bytes(), expected);
+    }
+
+    /// Strategy producing a valid [`ThresholdConfig`] with distinct keys and a
+    /// threshold within range.
+    fn arb_threshold_config() -> impl proptest::strategy::Strategy<Value = ThresholdConfig> {
+        use proptest::prelude::*;
+
+        (1usize..=8)
+            .prop_flat_map(|n| (Just(n), 1u8..=(n as u8)))
+            .prop_map(|(n, threshold)| {
+                let keys = (0..n).map(|i| make_key(i as u8 + 1)).collect::<Vec<_>>();
+                ThresholdConfig::try_new(keys, NonZero::new(threshold).unwrap()).unwrap()
+            })
+    }
+
+    /// Strategy producing a [`ThresholdConfigUpdate`] with distinct add/remove sets.
+    fn arb_threshold_update() -> impl proptest::strategy::Strategy<Value = ThresholdConfigUpdate> {
+        use proptest::prelude::*;
+
+        (0usize..=4, 0usize..=4).prop_map(|(add, remove)| {
+            let add_members = (0..add).map(|i| make_key(i as u8 + 1)).collect::<Vec<_>>();
+            let remove_members = (0..remove)
+                .map(|i| make_key(i as u8 + 100))
+                .collect::<Vec<_>>();
+            ThresholdConfigUpdate::new(add_members, remove_members, NonZero::new(1).unwrap())
+        })
+    }
+
+    // SSZ roundtrip + deterministic tree-hash property tests. Each lives in its
+    // own module because `ssz_proptest!` defines fixed test-function names.
+    mod config_ssz {
+        use strata_ssz_tests::ssz_proptest;
+
+        use super::*;
+
+        ssz_proptest!(ThresholdConfig, arb_threshold_config());
+    }
+
+    mod update_ssz {
+        use strata_ssz_tests::ssz_proptest;
+
+        use super::*;
+
+        ssz_proptest!(ThresholdConfigUpdate, arb_threshold_update());
+    }
+
+    #[test]
+    fn test_config_ssz_rejects_non_curve_point() {
+        use ssz::Decode;
+
+        // A well-formed container whose single 33-byte key is not a valid point.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&5u32.to_le_bytes());
+        bytes.push(1);
+        bytes.extend_from_slice(&[0u8; 33]);
+
+        assert!(ThresholdConfig::from_ssz_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_config_tree_hash_matches_delegate() {
+        use tree_hash::{Sha256Hasher, TreeHash};
+
+        let config =
+            ThresholdConfig::try_new(vec![make_key(1), make_key(2)], NonZero::new(2).unwrap())
+                .unwrap();
+
+        // The wrapper's tree hash root must equal that of its SSZ delegate.
+        let wrapper_root = TreeHash::tree_hash_root::<Sha256Hasher>(&config);
+        let delegate_root =
+            TreeHash::tree_hash_root::<Sha256Hasher>(&config.clone().into_delegate());
+        assert_eq!(wrapper_root, delegate_root);
     }
 }

--- a/crates/crypto/src/threshold_signature/indexed/config.rs
+++ b/crates/crypto/src/threshold_signature/indexed/config.rs
@@ -136,7 +136,7 @@ impl ThresholdConfig {
             keys: vec![],
             threshold,
         };
-        let update = ThresholdConfigUpdate::new(keys, vec![], threshold);
+        let update = ThresholdConfigUpdate::try_new(keys, vec![], threshold)?;
         config.apply_update(&update)?;
         Ok(config)
     }
@@ -264,16 +264,32 @@ pub struct ThresholdConfigUpdate {
 
 impl ThresholdConfigUpdate {
     /// Creates a new threshold configuration update.
-    pub fn new(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ThresholdSignatureError::TooManySigners`] if either the add or
+    /// remove list holds more than [`MAX_SIGNERS`] members. Each list is bounded
+    /// independently because the SSZ delegate encodes them as separate
+    /// `List[_, MAX_SIGNERS]`s; without this check an oversized update would panic
+    /// when SSZ-encoded or tree-hashed.
+    pub fn try_new(
         add_members: Vec<CompressedPublicKey>,
         remove_members: Vec<CompressedPublicKey>,
         new_threshold: NonZero<u8>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ThresholdSignatureError> {
+        for list in [&add_members, &remove_members] {
+            if list.len() > MAX_SIGNERS {
+                return Err(ThresholdSignatureError::TooManySigners {
+                    count: list.len(),
+                    max: MAX_SIGNERS,
+                });
+            }
+        }
+        Ok(Self {
             add_members,
             remove_members,
             new_threshold,
-        }
+        })
     }
 
     /// Returns the public keys to add.
@@ -305,18 +321,24 @@ impl ThresholdConfigUpdate {
 
 impl<'a> Arbitrary<'a> for ThresholdConfigUpdate {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let add_members = Vec::<CompressedPublicKey>::arbitrary(u)?;
-        let remove_members = Vec::<CompressedPublicKey>::arbitrary(u)?;
-        // Generate a threshold between 1 and max(1, len(add_members))
-        let max_threshold = add_members.len().max(1);
-        let threshold_u8 = u.int_in_range(1..=(max_threshold as u8))?;
+        // Keep the member lists small and well under MAX_SIGNERS so the generated
+        // update is always SSZ-encodable (and the `as u8` threshold cast below
+        // cannot overflow).
+        let gen_members = |u: &mut arbitrary::Unstructured<'a>| {
+            let count = u.int_in_range(0..=4)?;
+            (0..count)
+                .map(|_| CompressedPublicKey::arbitrary(u))
+                .collect::<arbitrary::Result<Vec<_>>>()
+        };
+        let add_members = gen_members(u)?;
+        let remove_members = gen_members(u)?;
+        // Generate a threshold between 1 and max(1, len(add_members)).
+        let max_threshold = add_members.len().max(1) as u8;
+        let threshold_u8 = u.int_in_range(1..=max_threshold)?;
         // Safe: threshold_u8 is always >= 1
         let new_threshold = NonZero::new(threshold_u8).expect("threshold is always >= 1");
-        Ok(Self {
-            add_members,
-            remove_members,
-            new_threshold,
-        })
+        Self::try_new(add_members, remove_members, new_threshold)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 
@@ -352,7 +374,10 @@ impl SszDelegate for ThresholdConfigUpdate {
         let remove_members = from_bytes_list(&delegate.remove_members)?;
         let new_threshold = NonZero::new(delegate.new_threshold)
             .ok_or_else(|| DecodeError::BytesInvalid("threshold must be non-zero".into()))?;
-        Ok(Self::new(add_members, remove_members, new_threshold))
+        // Cannot fail: the delegate's member lists are `List[_, MAX_SIGNERS]`, so
+        // neither can exceed the bound `try_new` checks.
+        Self::try_new(add_members, remove_members, new_threshold)
+            .map_err(|err| DecodeError::BytesInvalid(err.to_string()))
     }
 }
 
@@ -428,7 +453,8 @@ mod tests {
         let mut config = ThresholdConfig::try_new(keys, NonZero::new(2).unwrap()).unwrap();
 
         let update =
-            ThresholdConfigUpdate::new(vec![make_key(3)], vec![], NonZero::new(2).unwrap());
+            ThresholdConfigUpdate::try_new(vec![make_key(3)], vec![], NonZero::new(2).unwrap())
+                .unwrap();
         config.apply_update(&update).unwrap();
 
         assert_eq!(config.keys().len(), 3);
@@ -443,7 +469,8 @@ mod tests {
         let mut config =
             ThresholdConfig::try_new(vec![k1, k2, k3], NonZero::new(2).unwrap()).unwrap();
 
-        let update = ThresholdConfigUpdate::new(vec![], vec![k2], NonZero::new(2).unwrap());
+        let update =
+            ThresholdConfigUpdate::try_new(vec![], vec![k2], NonZero::new(2).unwrap()).unwrap();
         config.apply_update(&update).unwrap();
 
         assert_eq!(config.keys().len(), 2);
@@ -501,7 +528,8 @@ mod tests {
             let remove_members = (0..remove)
                 .map(|i| make_key(i as u8 + 100))
                 .collect::<Vec<_>>();
-            ThresholdConfigUpdate::new(add_members, remove_members, NonZero::new(1).unwrap())
+            ThresholdConfigUpdate::try_new(add_members, remove_members, NonZero::new(1).unwrap())
+                .unwrap()
         })
     }
 

--- a/crates/crypto/src/threshold_signature/indexed/config.rs
+++ b/crates/crypto/src/threshold_signature/indexed/config.rs
@@ -2,11 +2,9 @@
 
 use std::collections::HashSet;
 use std::hash::{self, Hash};
-use std::io;
 use std::num::NonZero;
 
 use arbitrary::Arbitrary;
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
@@ -29,10 +27,10 @@ pub const MAX_SIGNERS: usize = 256;
 /// The threshold is stored as `NonZero<u8>` to enforce at the type level
 /// that it can never be zero.
 ///
-/// Note: [`Deserialize`] and [`BorshDeserialize`] are implemented manually
-/// to route through [`Self::try_new`], ensuring that deserialized values
-/// satisfy the same invariants.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, BorshSerialize)]
+/// Note: [`Deserialize`] is implemented manually to route through
+/// [`Self::try_new`], ensuring that deserialized values satisfy the same
+/// invariants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ThresholdConfig {
     /// Public keys of all authorized signers.
     keys: Vec<CompressedPublicKey>,
@@ -54,15 +52,6 @@ impl<'de> Deserialize<'de> for ThresholdConfig {
 
         let raw = Raw::deserialize(deserializer)?;
         Self::try_new(raw.keys, raw.threshold).map_err(Error::custom)
-    }
-}
-
-/// [`BorshDeserialize`] is implemented manually to route through [`Self::try_new`].
-impl BorshDeserialize for ThresholdConfig {
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let keys = Vec::<CompressedPublicKey>::deserialize_reader(reader)?;
-        let threshold = NonZero::<u8>::deserialize_reader(reader)?;
-        Self::try_new(keys, threshold).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 }
 
@@ -101,6 +90,8 @@ impl SszDelegate for ThresholdConfig {
     type Delegate = ThresholdConfigSsz;
 
     fn into_delegate(self) -> Self::Delegate {
+        // Cannot fail: `validate_update` (which gates every construction and
+        // mutation path) rejects configs with more than `MAX_SIGNERS` keys.
         let keys = self
             .keys
             .into_iter()
@@ -212,6 +203,17 @@ impl ThresholdConfig {
         let updated_size =
             self.keys.len() + update.add_members().len() - update.remove_members().len();
 
+        // Ensure the resulting member count stays within the SSZ-encodable bound.
+        // This is the single chokepoint for all construction/mutation/decode paths
+        // (`try_new`, `apply_update`, serde decode), so enforcing it here guarantees
+        // a `ThresholdConfig` can never hold more than `MAX_SIGNERS` keys.
+        if updated_size > MAX_SIGNERS {
+            return Err(ThresholdSignatureError::TooManySigners {
+                count: updated_size,
+                max: MAX_SIGNERS,
+            });
+        }
+
         if (update.new_threshold().get() as usize) > updated_size {
             return Err(ThresholdSignatureError::InvalidThreshold {
                 threshold: update.new_threshold().get(),
@@ -250,7 +252,7 @@ impl Hash for CompressedPublicKey {
 }
 
 /// Represents a change to the threshold configuration.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThresholdConfigUpdate {
     /// Public keys to add.
     add_members: Vec<CompressedPublicKey>,
@@ -371,6 +373,15 @@ mod tests {
         CompressedPublicKey::from(secp256k1::PublicKey::from_secret_key(&secp, &sk))
     }
 
+    /// Distinct key from a wider seed, for generating more than 255 unique keys.
+    fn make_key_n(i: u32) -> CompressedPublicKey {
+        let secp = Secp256k1::new();
+        let mut sk_bytes = [0u8; 32];
+        sk_bytes[28..32].copy_from_slice(&(i + 1).to_be_bytes());
+        let sk = SecretKey::from_slice(&sk_bytes).unwrap();
+        CompressedPublicKey::from(secp256k1::PublicKey::from_secret_key(&secp, &sk))
+    }
+
     #[test]
     fn test_config_creation() {
         let keys = vec![make_key(1), make_key(2), make_key(3)];
@@ -378,6 +389,27 @@ mod tests {
 
         assert_eq!(config.keys().len(), 3);
         assert_eq!(config.threshold(), 2);
+    }
+
+    #[test]
+    fn test_config_rejects_more_than_max_signers() {
+        // 257 distinct keys exceeds the MAX_SIGNERS = 256 cap.
+        let keys: Vec<_> = (0..=MAX_SIGNERS as u32).map(make_key_n).collect();
+        let result = ThresholdConfig::try_new(keys, NonZero::new(1).unwrap());
+        assert!(matches!(
+            result,
+            Err(ThresholdSignatureError::TooManySigners { .. })
+        ));
+    }
+
+    #[test]
+    fn test_config_deserialize_rejects_more_than_max_signers() {
+        // The validating `Deserialize` routes through `try_new`, so a JSON config
+        // with more than MAX_SIGNERS keys must be rejected rather than decoded into
+        // a value that later panics on SSZ encoding.
+        let keys: Vec<_> = (0..=MAX_SIGNERS as u32).map(make_key_n).collect();
+        let json = serde_json::json!({ "keys": keys, "threshold": 1 });
+        assert!(serde_json::from_value::<ThresholdConfig>(json).is_err());
     }
 
     #[test]
@@ -419,32 +451,11 @@ mod tests {
     }
 
     #[test]
-    fn test_config_borsh_roundtrip() {
-        let keys = vec![make_key(1), make_key(2)];
-        let config = ThresholdConfig::try_new(keys, NonZero::new(2).unwrap()).unwrap();
-
-        let encoded = borsh::to_vec(&config).unwrap();
-        let decoded: ThresholdConfig = borsh::from_slice(&encoded).unwrap();
-
-        assert_eq!(config, decoded);
-    }
-
-    #[test]
     fn test_config_serde_json_roundtrip_arbitrary() {
         let config: ThresholdConfig = ArbitraryGenerator::new().generate();
 
         let json = serde_json::to_string(&config).unwrap();
         let decoded: ThresholdConfig = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(config, decoded);
-    }
-
-    #[test]
-    fn test_config_borsh_roundtrip_arbitrary() {
-        let config: ThresholdConfig = ArbitraryGenerator::new().generate();
-
-        let encoded = borsh::to_vec(&config).unwrap();
-        let decoded: ThresholdConfig = borsh::from_slice(&encoded).unwrap();
 
         assert_eq!(config, decoded);
     }

--- a/crates/crypto/src/threshold_signature/indexed/errors.rs
+++ b/crates/crypto/src/threshold_signature/indexed/errors.rs
@@ -75,6 +75,15 @@ pub enum ThresholdSignatureError {
     /// Invalid message hash.
     #[error("invalid message hash")]
     InvalidMessageHash,
+
+    /// The configuration would exceed the maximum number of signers.
+    #[error("too many signers (count {count}, max {max})")]
+    TooManySigners {
+        /// Number of signers the configuration would hold.
+        count: usize,
+        /// Maximum number of signers allowed ([`MAX_SIGNERS`](super::config::MAX_SIGNERS)).
+        max: usize,
+    },
 }
 
 impl From<secp256k1::Error> for ThresholdSignatureError {

--- a/crates/crypto/src/threshold_signature/indexed/mod.rs
+++ b/crates/crypto/src/threshold_signature/indexed/mod.rs
@@ -9,7 +9,7 @@ mod errors;
 mod signature;
 mod verification;
 
-pub use config::{ThresholdConfig, ThresholdConfigUpdate, MAX_SIGNERS};
+pub use config::{MAX_SIGNERS, ThresholdConfig, ThresholdConfigUpdate};
 pub use errors::ThresholdSignatureError;
 pub use signature::{IndexedSignature, SignatureSet};
 pub use verification::verify_threshold_signatures;

--- a/crates/crypto/src/threshold_signature/indexed/signature.rs
+++ b/crates/crypto/src/threshold_signature/indexed/signature.rs
@@ -3,9 +3,12 @@
 use std::collections::HashSet;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use ssz_derive::{Decode, Encode};
+use ssz::DecodeError;
+use ssz_primitives::FixedBytes;
+use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
 
 use super::ThresholdSignatureError;
+use crate::ssz_generated::ssz::threshold::{IndexedSignatureSsz, SignatureSetSsz};
 
 /// An ECDSA signature with its signer index.
 ///
@@ -27,7 +30,7 @@ use super::ThresholdSignatureError;
 /// The signer includes their own index (position in `ThresholdConfig::keys`) when creating
 /// an `IndexedSignature`. Verification uses that index to fetch the expected public key and
 /// compare it against the recovered key from the signature.
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct IndexedSignature {
     /// Index of the signer in the ThresholdConfig keys array (0-255).
     index: u8,
@@ -83,16 +86,66 @@ impl IndexedSignature {
     }
 }
 
+// SSZ encoding delegates to the generated [`IndexedSignatureSsz`] container —
+// correct by construction rather than hand-rolled.
+impl SszDelegate for IndexedSignature {
+    type Delegate = IndexedSignatureSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        IndexedSignatureSsz {
+            index: self.index,
+            signature: FixedBytes(self.signature),
+        }
+    }
+
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        Ok(Self {
+            index: delegate.index,
+            signature: delegate.signature.0,
+        })
+    }
+}
+
+impl_ssz_via_delegate!(IndexedSignature);
+
 /// A set of indexed ECDSA signatures for threshold verification.
 ///
 /// Signatures are guaranteed duplicate-free.
-#[derive(
-    Debug, Clone, PartialEq, Eq, Default, BorshSerialize, BorshDeserialize, Encode, Decode,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, BorshSerialize, BorshDeserialize)]
 pub struct SignatureSet {
     /// Sorted signatures by index, no duplicates.
     signatures: Vec<IndexedSignature>,
 }
+
+// SSZ encoding delegates to the generated [`SignatureSetSsz`] container, whose
+// `signatures` field is a length-bounded `List[IndexedSignatureSsz, MAX_SIGNERS]`.
+// `from_delegate` re-applies the duplicate-free invariant via [`SignatureSet::new`].
+impl SszDelegate for SignatureSet {
+    type Delegate = SignatureSetSsz;
+
+    fn into_delegate(self) -> Self::Delegate {
+        let signatures = self
+            .signatures
+            .into_iter()
+            .map(SszDelegate::into_delegate)
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("more than MAX_SIGNERS signatures");
+        SignatureSetSsz { signatures }
+    }
+
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+        let signatures = delegate
+            .signatures
+            .iter()
+            .cloned()
+            .map(IndexedSignature::from_delegate)
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::new(signatures).map_err(|err| DecodeError::BytesInvalid(err.to_string()))
+    }
+}
+
+impl_ssz_via_delegate!(SignatureSet);
 
 impl SignatureSet {
     /// Create a new signature set from a vector of indexed signatures.

--- a/crates/crypto/src/threshold_signature/mod.rs
+++ b/crates/crypto/src/threshold_signature/mod.rs
@@ -8,6 +8,6 @@ pub mod indexed;
 
 // Re-export commonly used types from indexed
 pub use indexed::{
-    verify_threshold_signatures, IndexedSignature, SignatureSet, ThresholdConfig,
-    ThresholdConfigUpdate, ThresholdSignatureError,
+    IndexedSignature, SignatureSet, ThresholdConfig, ThresholdConfigUpdate,
+    ThresholdSignatureError, verify_threshold_signatures,
 };

--- a/crates/crypto/ssz/threshold.ssz
+++ b/crates/crypto/ssz/threshold.ssz
@@ -1,0 +1,33 @@
+# SSZ schema definitions for strata-crypto threshold-signature types.
+#
+# These containers are the canonical SSZ "delegate" representations for the
+# threshold-config wrapper types. The Rust wrappers implement `SszDelegate`
+# against the generated types and obtain their `Encode`/`Decode`/`TreeHash`
+# impls via `impl_ssz_via_delegate!`, so the layout is correct by construction.
+#
+# Signer public keys are modelled as raw 33-byte compressed points (`Bytes33`)
+# rather than the `CompressedPublicKey` wrapper: the wrapper's curve-point
+# validation is reapplied during `from_delegate`, which keeps the generated
+# container free of any dependency on the wrapper's trait impls.
+
+### Maximum number of signers in a threshold configuration.
+###
+### Matches the `MAX_SIGNERS` runtime cap (the signer index is a `u8`, so at
+### most 256 unique signers are addressable).
+MAX_SIGNERS = 256
+
+### SSZ delegate for a threshold-signature configuration.
+class ThresholdConfigSsz(Container):
+    ### Compressed public keys of all authorized signers.
+    keys: List[Bytes33, MAX_SIGNERS]
+    ### Minimum number of signatures required (always >= 1).
+    threshold: uint8
+
+### SSZ delegate for a threshold-configuration update.
+class ThresholdConfigUpdateSsz(Container):
+    ### Compressed public keys to add.
+    add_members: List[Bytes33, MAX_SIGNERS]
+    ### Compressed public keys to remove.
+    remove_members: List[Bytes33, MAX_SIGNERS]
+    ### New minimum number of signatures required (always >= 1).
+    new_threshold: uint8

--- a/crates/crypto/ssz/threshold.ssz
+++ b/crates/crypto/ssz/threshold.ssz
@@ -31,3 +31,15 @@ class ThresholdConfigUpdateSsz(Container):
     remove_members: List[Bytes33, MAX_SIGNERS]
     ### New minimum number of signatures required (always >= 1).
     new_threshold: uint8
+
+### SSZ delegate for a single indexed ECDSA signature.
+class IndexedSignatureSsz(Container):
+    ### Index of the signer in the threshold config keys array.
+    index: uint8
+    ### 65-byte recoverable ECDSA signature (header || r || s).
+    signature: Vector[uint8, 65]
+
+### SSZ delegate for a set of indexed signatures (one per signer at most).
+class SignatureSetSsz(Container):
+    ### Indexed signatures, at most one per signer.
+    signatures: List[IndexedSignatureSsz, MAX_SIGNERS]

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -46,5 +46,7 @@ pub use exec::{EVMExtraPayload, EvmEeBlockCommitment, ExecBlockCommitment, Hash}
 pub use l1::L1BlockCommitmentRef;
 pub use l1::{L1BlockCommitment, L1BlockId, L1Height, WtxidsRoot};
 #[cfg(feature = "ssz")]
+pub use macros::ssz::SszDelegate;
+#[cfg(feature = "ssz")]
 pub use ol::OLBlockCommitmentRef;
 pub use ol::{Epoch, L2BlockCommitment, L2BlockId, OLBlockCommitment, OLBlockId, OLTxId, Slot};

--- a/crates/identifiers/src/macros/mod.rs
+++ b/crates/identifiers/src/macros/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod buf;
 pub(crate) mod serde_impl;
 #[cfg(feature = "ssz")]
 #[macro_use]
-mod ssz;
+pub(crate) mod ssz;
 #[macro_use]
 mod wrapper;
 

--- a/crates/identifiers/src/macros/ssz.rs
+++ b/crates/identifiers/src/macros/ssz.rs
@@ -226,7 +226,7 @@ macro_rules! impl_ssz_transparent_wrapper {
 /// Describes how a wrapper type's SSZ encoding is delegated to another,
 /// well-defined SSZ type.
 ///
-/// Implementing this trait and invoking [`impl_ssz_via_delegate!`] gives a
+/// Implementing this trait and invoking `impl_ssz_via_delegate!` gives a
 /// wrapper type [`ssz::Encode`]/[`ssz::Decode`] impls that are *correct by
 /// construction*: the byte layout is determined entirely by the
 /// [`Delegate`](SszDelegate::Delegate) type — a generated SSZ container,

--- a/crates/identifiers/src/macros/ssz.rs
+++ b/crates/identifiers/src/macros/ssz.rs
@@ -223,6 +223,148 @@ macro_rules! impl_ssz_transparent_wrapper {
     };
 }
 
+/// Describes how a wrapper type's SSZ encoding is delegated to another,
+/// well-defined SSZ type.
+///
+/// Implementing this trait and invoking [`impl_ssz_via_delegate!`] gives a
+/// wrapper type [`ssz::Encode`]/[`ssz::Decode`] impls that are *correct by
+/// construction*: the byte layout is determined entirely by the
+/// [`Delegate`](SszDelegate::Delegate) type — a generated SSZ container,
+/// `FixedBytes`, `VariableList`, a primitive, etc. — rather than by a
+/// hand-written impl that could violate the SSZ fixed-part/variable-part rules.
+///
+/// The delegate is the encoded form: [`into_delegate`](SszDelegate::into_delegate)
+/// projects a value into it for encoding, and
+/// [`from_delegate`](SszDelegate::from_delegate) reconstructs a value from a
+/// decoded delegate, validating any wrapper invariants the delegate type does
+/// not itself enforce.
+///
+/// # Example
+///
+/// ```ignore
+/// // `BitcoinOutPointSsz` is a derived/generated SSZ container.
+/// impl SszDelegate for BitcoinOutPoint {
+///     type Delegate = BitcoinOutPointSsz;
+///
+///     fn into_delegate(self) -> Self::Delegate {
+///         BitcoinOutPointSsz { txid: self.0.txid.to_byte_array(), vout: self.0.vout }
+///     }
+///
+///     fn from_delegate(d: Self::Delegate) -> Result<Self, ssz::DecodeError> {
+///         Ok(Self(OutPoint { txid: Txid::from_byte_array(d.txid), vout: d.vout }))
+///     }
+/// }
+///
+/// impl_ssz_via_delegate!(BitcoinOutPoint);
+/// ```
+pub trait SszDelegate: Sized {
+    /// The well-defined SSZ type this type's encoding delegates to.
+    type Delegate: ::ssz::Encode + ::ssz::Decode + ::tree_hash::TreeHash;
+
+    /// Projects `self` into its delegate representation for encoding.
+    fn into_delegate(self) -> Self::Delegate;
+
+    /// Reconstructs `Self` from a decoded delegate, validating any invariants
+    /// the wrapper enforces that the delegate type does not.
+    fn from_delegate(delegate: Self::Delegate) -> Result<Self, ::ssz::DecodeError>;
+}
+
+/// Generates [`ssz::Encode`], [`ssz::Decode`], and [`tree_hash::TreeHash`]
+/// implementations for a type that implements [`SszDelegate`], delegating the
+/// entire byte layout and merkleization to its
+/// [`Delegate`](SszDelegate::Delegate) type.
+///
+/// This is the "correct by construction" replacement for hand-written
+/// `Encode`/`Decode` impls: the wrapper supplies only the value-level conversion
+/// to/from a well-defined SSZ type via [`SszDelegate`], and this macro wires up
+/// the trait methods so the wrapper inherits the delegate's (spec-compliant)
+/// layout and tree-hash root verbatim. Because the tree hash is delegated too,
+/// the wrapper can be used as a field inside other SSZ containers.
+///
+/// # Requirements
+///
+/// The type must implement [`SszDelegate`] and [`Clone`] (the latter is used to
+/// project `&self` into the delegate when encoding or tree-hashing).
+///
+/// # Example
+///
+/// ```ignore
+/// impl SszDelegate for MyWrapper {
+///     type Delegate = MyWrapperSsz;
+///     fn into_delegate(self) -> Self::Delegate { /* … */ }
+///     fn from_delegate(d: Self::Delegate) -> Result<Self, ssz::DecodeError> { /* … */ }
+/// }
+///
+/// impl_ssz_via_delegate!(MyWrapper);
+/// ```
+#[macro_export]
+macro_rules! impl_ssz_via_delegate {
+    ($type:ty) => {
+        impl ::ssz::Encode for $type {
+            fn is_ssz_fixed_len() -> bool {
+                <<$type as $crate::SszDelegate>::Delegate as ::ssz::Encode>::is_ssz_fixed_len()
+            }
+
+            fn ssz_fixed_len() -> usize {
+                <<$type as $crate::SszDelegate>::Delegate as ::ssz::Encode>::ssz_fixed_len()
+            }
+
+            fn ssz_append(&self, buf: &mut ::std::vec::Vec<u8>) {
+                ::ssz::Encode::ssz_append(
+                    &$crate::SszDelegate::into_delegate(::core::clone::Clone::clone(self)),
+                    buf,
+                )
+            }
+
+            fn ssz_bytes_len(&self) -> usize {
+                ::ssz::Encode::ssz_bytes_len(&$crate::SszDelegate::into_delegate(
+                    ::core::clone::Clone::clone(self),
+                ))
+            }
+        }
+
+        impl ::ssz::Decode for $type {
+            fn is_ssz_fixed_len() -> bool {
+                <<$type as $crate::SszDelegate>::Delegate as ::ssz::Decode>::is_ssz_fixed_len()
+            }
+
+            fn ssz_fixed_len() -> usize {
+                <<$type as $crate::SszDelegate>::Delegate as ::ssz::Decode>::ssz_fixed_len()
+            }
+
+            fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ::ssz::DecodeError> {
+                let delegate =
+                    <<$type as $crate::SszDelegate>::Delegate as ::ssz::Decode>::from_ssz_bytes(
+                        bytes,
+                    )?;
+                <$type as $crate::SszDelegate>::from_delegate(delegate)
+            }
+        }
+
+        impl ::tree_hash::TreeHash for $type {
+            fn tree_hash_type() -> ::tree_hash::TreeHashType {
+                <<$type as $crate::SszDelegate>::Delegate as ::tree_hash::TreeHash>::tree_hash_type()
+            }
+
+            fn tree_hash_packed_encoding(&self) -> ::tree_hash::PackedEncoding {
+                ::tree_hash::TreeHash::tree_hash_packed_encoding(
+                    &$crate::SszDelegate::into_delegate(::core::clone::Clone::clone(self)),
+                )
+            }
+
+            fn tree_hash_packing_factor() -> usize {
+                <<$type as $crate::SszDelegate>::Delegate as ::tree_hash::TreeHash>::tree_hash_packing_factor()
+            }
+
+            fn tree_hash_root<H: ::tree_hash::TreeHashDigest>(&self) -> H::Output {
+                ::tree_hash::TreeHash::tree_hash_root::<H>(&$crate::SszDelegate::into_delegate(
+                    ::core::clone::Clone::clone(self),
+                ))
+            }
+        }
+    };
+}
+
 /// Generates SSZ view trait implementations for transparent wrappers around
 /// raw `[u8; N]` arrays.
 ///

--- a/crates/l1proto/txfmt/src/serde.rs
+++ b/crates/l1proto/txfmt/src/serde.rs
@@ -2,8 +2,9 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize, de};
 
-use crate::MagicBytes;
 use crate::magic::MAGIC_BYTES_LEN;
+use crate::types::{SubprotocolId, TxType};
+use crate::{MagicBytes, TagData};
 
 impl Serialize for MagicBytes {
     fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
@@ -56,9 +57,61 @@ impl<'de> Deserialize<'de> for MagicBytes {
     }
 }
 
+impl Serialize for TagData {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut st = s.serialize_struct("TagData", 3)?;
+        st.serialize_field("subproto_id", &self.subproto_id())?;
+        st.serialize_field("tx_type", &self.tx_type())?;
+        st.serialize_field("aux_data", self.aux_data())?;
+        st.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TagData {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Route reconstruction through `TagData::new` so deserialized values are
+        // validated (e.g. the auxiliary-data length bound) instead of trusting
+        // the input verbatim.
+        #[derive(Deserialize)]
+        struct Helper {
+            subproto_id: SubprotocolId,
+            tx_type: TxType,
+            aux_data: Vec<u8>,
+        }
+
+        let helper = Helper::deserialize(d)?;
+        TagData::new(helper.subproto_id, helper.tx_type, helper.aux_data).map_err(de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_tag_data_json_roundtrip() {
+        let tag = TagData::new(3, 7, vec![1, 2, 3, 4]).unwrap();
+        let json = serde_json::to_string(&tag).unwrap();
+        assert_eq!(
+            json,
+            r#"{"subproto_id":3,"tx_type":7,"aux_data":[1,2,3,4]}"#
+        );
+        let back: TagData = serde_json::from_str(&json).unwrap();
+        assert_eq!(tag, back);
+    }
+
+    #[test]
+    fn test_tag_data_deserialize_rejects_oversized_aux() {
+        // 75 bytes exceeds MAX_AUX_LEN (74), so deserialization must fail.
+        let aux: Vec<u8> = vec![0; 75];
+        let json = format!(
+            r#"{{"subproto_id":0,"tx_type":0,"aux_data":{}}}"#,
+            serde_json::to_string(&aux).unwrap()
+        );
+        assert!(serde_json::from_str::<TagData>(&json).is_err());
+    }
 
     #[test]
     fn test_human_readable_roundtrip() {

--- a/crates/merkle-store/Cargo.toml
+++ b/crates/merkle-store/Cargo.toml
@@ -12,5 +12,7 @@ strata-merkle = { path = "../merkle", default-features = false }
 thiserror.workspace = true
 
 [dev-dependencies]
-strata-merkle = { path = "../merkle", default-features = false, features = ["legacy_compact"] }
 proptest.workspace = true
+strata-merkle = { path = "../merkle", default-features = false, features = [
+  "legacy_compact",
+] }


### PR DESCRIPTION
## Description

This PR reworks SSZ encoding to use a more consistent "delegate" system.

I'm not really sure if this is the best approach to take here, but maybe we should expand this out some more.

**Some of these types seem like they're only used in the database, like `L1Payload`.**  So these maybe we should just remove the SSZ/borsh impls entirely and use Serde CBOR encodings for that, for forwards-compatibility.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
