### PR TITLE
feat(merkle-store): pruning for the node store

### DIFF
--- a/crates/merkle-store/src/algorithm.rs
+++ b/crates/merkle-store/src/algorithm.rs
@@ -87,44 +87,42 @@ pub fn assemble_proof<H: MerkleHash>(leaf_index: u64, cohashes: Vec<H>) -> Merkl
 /// Positions to delete to prune everything strictly before leaf `before`,
 /// keeping only the peaks of the first `before` leaves.
 ///
-/// Returns the proper descendants of each peak in [`peak_positions`]`(before)` —
+/// Yields the proper descendants of each peak in [`peak_positions`]`(before)` —
 /// exactly the nodes whose leaf-coverage lies entirely in `[0, before)`, minus
 /// the peaks themselves, which are retained so later leaves stay provable and
 /// appends keep working. Empty when `before == 0`.
-// TODO: materializes the full position list; for very large prunes this could
-// be an iterator so the backend can delete in bounded-memory chunks.
-pub fn prune_before_positions(before: u64) -> Vec<NodePos> {
-    let mut positions = Vec::new();
-    for peak in peak_positions(before) {
+///
+/// Produced lazily — only the peak list (`O(log before)`) is held, with the
+/// descendants yielded on demand. The prune op collects the full set before
+/// handing it to the node store to delete.
+pub fn prune_before_positions(before: u64) -> impl Iterator<Item = NodePos> {
+    peak_positions(before).into_iter().flat_map(|peak| {
         let peak_height = peak.height();
         let peak_index = peak.index();
-        for height in 0..peak_height {
+        (0..peak_height).flat_map(move |height| {
             // Each descendant level widens the peak's index by 2 per step down.
             let span = 1u64 << (peak_height - height);
-            for index in (peak_index * span)..((peak_index + 1) * span) {
-                positions.push(NodePos::new(height, index));
-            }
-        }
-    }
-    positions
+            (peak_index * span..(peak_index + 1) * span)
+                .map(move |index| NodePos::new(height, index))
+        })
+    })
 }
 
 /// Positions to delete to truncate an MMR from `leaf_count` leaves down to
 /// `keep` leaves.
 ///
-/// Returns every node present at `leaf_count` but not at `keep`: at each height
+/// Yields every node present at `leaf_count` but not at `keep`: at each height
 /// `h`, the indices in `[keep >> h, leaf_count >> h)` (a node `(h, i)` exists at
 /// a given count iff `i < count >> h`). Empty when `keep >= leaf_count`.
-// TODO: materializes the full position list; for very large prunes this could
-// be an iterator so the backend can delete in bounded-memory chunks.
-pub fn prune_after_positions(keep: u64, leaf_count: u64) -> Vec<NodePos> {
-    let mut positions = Vec::new();
-    let mut height = 0u8;
-    while (leaf_count >> height) > 0 {
-        for index in (keep >> height)..(leaf_count >> height) {
-            positions.push(NodePos::new(height, index));
-        }
-        height += 1;
-    }
-    positions
+///
+/// Produced lazily; the prune op collects the full set before handing it to the
+/// node store to delete. A real MMR tops out at height 63 (a height-64 node
+/// would need `2^64` leaves), so the height walk is capped there, which also
+/// avoids a `>> 64` shift overflow.
+pub fn prune_after_positions(keep: u64, leaf_count: u64) -> impl Iterator<Item = NodePos> {
+    (0u8..64)
+        .take_while(move |&height| (leaf_count >> height) > 0)
+        .flat_map(move |height| {
+            (keep >> height..leaf_count >> height).map(move |index| NodePos::new(height, index))
+        })
 }

--- a/crates/merkle-store/src/algorithm.rs
+++ b/crates/merkle-store/src/algorithm.rs
@@ -11,7 +11,7 @@
 use strata_merkle::{MerkleHash, MerkleHasher, MerkleProof};
 
 use super::error::MmrError;
-use super::index::{LeafPos, NodePos, peak_for_leaf};
+use super::index::{LeafPos, NodePos, peak_for_leaf, peak_positions};
 
 /// Computes the nodes to write when setting `leaf` at `leaf_index` in an MMR
 /// that has (or will have) `leaf_count` leaves.
@@ -82,4 +82,49 @@ pub fn proof_positions(leaf_index: u64, leaf_count: u64) -> Vec<NodePos> {
 /// order (the order returned by [`proof_positions`]).
 pub fn assemble_proof<H: MerkleHash>(leaf_index: u64, cohashes: Vec<H>) -> MerkleProof<H> {
     MerkleProof::from_cohashes(cohashes, leaf_index)
+}
+
+/// Positions to delete to prune everything strictly before leaf `before`,
+/// keeping only the peaks of the first `before` leaves.
+///
+/// Returns the proper descendants of each peak in [`peak_positions`]`(before)` —
+/// exactly the nodes whose leaf-coverage lies entirely in `[0, before)`, minus
+/// the peaks themselves, which are retained so later leaves stay provable and
+/// appends keep working. Empty when `before == 0`.
+// TODO: materializes the full position list; for very large prunes this could
+// be an iterator so the backend can delete in bounded-memory chunks.
+pub fn prune_before_positions(before: u64) -> Vec<NodePos> {
+    let mut positions = Vec::new();
+    for peak in peak_positions(before) {
+        let peak_height = peak.height();
+        let peak_index = peak.index();
+        for height in 0..peak_height {
+            // Each descendant level widens the peak's index by 2 per step down.
+            let span = 1u64 << (peak_height - height);
+            for index in (peak_index * span)..((peak_index + 1) * span) {
+                positions.push(NodePos::new(height, index));
+            }
+        }
+    }
+    positions
+}
+
+/// Positions to delete to truncate an MMR from `leaf_count` leaves down to
+/// `keep` leaves.
+///
+/// Returns every node present at `leaf_count` but not at `keep`: at each height
+/// `h`, the indices in `[keep >> h, leaf_count >> h)` (a node `(h, i)` exists at
+/// a given count iff `i < count >> h`). Empty when `keep >= leaf_count`.
+// TODO: materializes the full position list; for very large prunes this could
+// be an iterator so the backend can delete in bounded-memory chunks.
+pub fn prune_after_positions(keep: u64, leaf_count: u64) -> Vec<NodePos> {
+    let mut positions = Vec::new();
+    let mut height = 0u8;
+    while (leaf_count >> height) > 0 {
+        for index in (keep >> height)..(leaf_count >> height) {
+            positions.push(NodePos::new(height, index));
+        }
+        height += 1;
+    }
+    positions
 }

--- a/crates/merkle-store/src/algorithm.rs
+++ b/crates/merkle-store/src/algorithm.rs
@@ -95,8 +95,8 @@ pub fn assemble_proof<H: MerkleHash>(leaf_index: u64, cohashes: Vec<H>) -> Merkl
 /// Produced lazily — only the peak list (`O(log before)`) is held, with the
 /// descendants yielded on demand. The prune op collects the full set before
 /// handing it to the node store to delete.
-pub fn prune_before_positions(before: u64) -> impl Iterator<Item = NodePos> {
-    peak_positions(before).into_iter().flat_map(|peak| {
+pub fn iter_prune_before_positions(before: u64) -> impl Iterator<Item = NodePos> {
+    peak_positions(before).flat_map(|peak| {
         let peak_height = peak.height();
         let peak_index = peak.index();
         (0..peak_height).flat_map(move |height| {
@@ -119,7 +119,7 @@ pub fn prune_before_positions(before: u64) -> impl Iterator<Item = NodePos> {
 /// node store to delete. A real MMR tops out at height 63 (a height-64 node
 /// would need `2^64` leaves), so the height walk is capped there, which also
 /// avoids a `>> 64` shift overflow.
-pub fn prune_after_positions(keep: u64, leaf_count: u64) -> impl Iterator<Item = NodePos> {
+pub fn iter_prune_after_positions(keep: u64, leaf_count: u64) -> impl Iterator<Item = NodePos> {
     (0u8..64)
         .take_while(move |&height| (leaf_count >> height) > 0)
         .flat_map(move |height| {

--- a/crates/merkle-store/src/error.rs
+++ b/crates/merkle-store/src/error.rs
@@ -44,4 +44,17 @@ pub enum MmrError<E> {
     /// can be appended — the next index would overflow `u64`.
     #[error("MMR has reached max capacity")]
     MaxCapacity,
+
+    /// The requested leaf lies in the pruned prefix: it is below the store's
+    /// prune watermark, so the nodes needed to prove it have been discarded by
+    /// [`prune_before`](super::store::StoredMmr::prune_before). Unlike
+    /// [`NodeMissing`](Self::NodeMissing), this is an expected outcome of
+    /// pruning, not corruption.
+    #[error("leaf index {index} was pruned (pruned_before={pruned_before})")]
+    Pruned {
+        /// The requested leaf index, below the watermark.
+        index: u64,
+        /// The watermark: every leaf below this index has been pruned.
+        pruned_before: u64,
+    },
 }

--- a/crates/merkle-store/src/index.rs
+++ b/crates/merkle-store/src/index.rs
@@ -4,6 +4,8 @@
 //! namespace-agnostic. A node lives at `(height, index)`: leaves are height 0,
 //! and `index` is the zero-based offset within that level.
 
+use std::iter;
+
 /// Height of the reserved metadata level.
 ///
 /// A real MMR node never reaches this height (it would require `2^255` leaves),
@@ -127,20 +129,25 @@ fn highest_mountain_size(leaves: u64) -> u64 {
 }
 
 /// Returns the peak positions for an MMR of `leaf_count` leaves, left to right.
-pub fn peak_positions(leaf_count: u64) -> Vec<NodePos> {
-    let mut peaks = Vec::new();
+///
+/// Yielded lazily so callers that just walk the peaks (e.g.
+/// [`iter_prune_before_positions`](super::algorithm::iter_prune_before_positions))
+/// need not allocate a `Vec`.
+pub fn peak_positions(leaf_count: u64) -> impl Iterator<Item = NodePos> {
     let mut start_leaf = 0u64;
     let mut remaining = leaf_count;
 
-    while remaining > 0 {
+    iter::from_fn(move || {
+        if remaining == 0 {
+            return None;
+        }
         let size = highest_mountain_size(remaining);
         let height = size.trailing_zeros() as u8;
-        peaks.push(NodePos::new(height, start_leaf >> height));
+        let peak = NodePos::new(height, start_leaf >> height);
         start_leaf += size;
         remaining -= size;
-    }
-
-    peaks
+        Some(peak)
+    })
 }
 
 /// Returns the peak node that the leaf at `leaf_index` hashes up to, in an MMR
@@ -184,15 +191,13 @@ mod tests {
     // Concrete examples that document exact peak decompositions.
     #[test]
     fn peaks_match_known_decompositions() {
-        assert_eq!(peak_positions(0), vec![]);
-        assert_eq!(peak_positions(1), vec![NodePos::new(0, 0)]);
+        let peaks = |n| peak_positions(n).collect::<Vec<_>>();
+        assert_eq!(peaks(0), vec![]);
+        assert_eq!(peaks(1), vec![NodePos::new(0, 0)]);
+        assert_eq!(peaks(3), vec![NodePos::new(1, 0), NodePos::new(0, 2)]);
+        assert_eq!(peaks(4), vec![NodePos::new(2, 0)]);
         assert_eq!(
-            peak_positions(3),
-            vec![NodePos::new(1, 0), NodePos::new(0, 2)]
-        );
-        assert_eq!(peak_positions(4), vec![NodePos::new(2, 0)]);
-        assert_eq!(
-            peak_positions(11),
+            peaks(11),
             vec![NodePos::new(3, 0), NodePos::new(1, 4), NodePos::new(0, 10)]
         );
     }
@@ -252,7 +257,7 @@ mod tests {
 
         #[test]
         fn peaks_partition_leaves_with_descending_heights(leaf_count in 0u64..1_000_000) {
-            let peaks = peak_positions(leaf_count);
+            let peaks: Vec<_> = peak_positions(leaf_count).collect();
             // Each peak of height h covers 2^h leaves; together they cover all.
             let covered: u64 = peaks.iter().map(|p| 1u64 << p.height()).sum();
             prop_assert_eq!(covered, leaf_count);
@@ -265,7 +270,7 @@ mod tests {
         fn peak_for_leaf_is_a_reachable_peak(leaf_count in 1u64..1_000_000, frac in any::<u64>()) {
             let leaf_index = frac % leaf_count;
             let peak = peak_for_leaf(leaf_index, leaf_count);
-            prop_assert!(peak_positions(leaf_count).contains(&peak));
+            prop_assert!(peak_positions(leaf_count).any(|p| p == peak));
 
             // Walking up from the leaf reaches exactly that peak.
             let mut cur = LeafPos::new(leaf_index).to_node_pos();

--- a/crates/merkle-store/src/lib.rs
+++ b/crates/merkle-store/src/lib.rs
@@ -2,9 +2,10 @@
 //!
 //! Stores *every* MMR node — leaves and internal nodes — so inclusion proofs
 //! are generated in `O(log n)` by walking the stored sibling path, with no
-//! leaf replay. The surface a backend must implement is just two methods
-//! ([`MmrNodeStore::get_node`] / [`MmrNodeStore::put_node`]); the leaf- and
-//! proof-level API ([`StoredMmr`]) is derived on top.
+//! leaf replay. The surface a backend must implement is three methods
+//! ([`MmrNodeStore::get_node`] / [`MmrNodeStore::put_node`] /
+//! [`MmrNodeStore::delete_node`]); the leaf- and proof-level API
+//! ([`StoredMmr`]) is derived on top.
 //!
 //! The store is storage- and namespace-agnostic (one backend instance == one
 //! MMR) and generic over the [`MerkleHasher`](strata_merkle::MerkleHasher) used
@@ -29,4 +30,4 @@ pub use algorithm::{
 pub use error::MmrError;
 pub use index::{LeafPos, NodePos, peak_for_leaf, peak_positions};
 pub use memory::MemMmr;
-pub use store::{MmrMetaPack, MmrNodeStore, PrunableNodeStore, StoredMmr};
+pub use store::{MmrMetaPack, MmrNodeStore, StoredMmr};

--- a/crates/merkle-store/src/lib.rs
+++ b/crates/merkle-store/src/lib.rs
@@ -22,8 +22,10 @@ mod index;
 mod memory;
 mod store;
 
-pub use algorithm::{assemble_proof, proof_positions, write_plan};
+pub use algorithm::{
+    assemble_proof, proof_positions, prune_after_positions, prune_before_positions, write_plan,
+};
 pub use error::MmrError;
 pub use index::{LeafPos, NodePos, peak_for_leaf, peak_positions};
 pub use memory::MemMmr;
-pub use store::{MmrMetaPack, MmrNodeStore, StoredMmr};
+pub use store::{MmrMetaPack, MmrNodeStore, PrunableNodeStore, StoredMmr};

--- a/crates/merkle-store/src/lib.rs
+++ b/crates/merkle-store/src/lib.rs
@@ -23,7 +23,8 @@ mod memory;
 mod store;
 
 pub use algorithm::{
-    assemble_proof, proof_positions, prune_after_positions, prune_before_positions, write_plan,
+    assemble_proof, iter_prune_after_positions, iter_prune_before_positions, proof_positions,
+    write_plan,
 };
 pub use error::MmrError;
 pub use index::{LeafPos, NodePos, peak_for_leaf, peak_positions};

--- a/crates/merkle-store/src/memory.rs
+++ b/crates/merkle-store/src/memory.rs
@@ -7,7 +7,7 @@ use std::convert::Infallible;
 use strata_merkle::MerkleHash;
 
 use super::index::NodePos;
-use super::store::MmrNodeStore;
+use super::store::{MmrNodeStore, PrunableNodeStore};
 
 /// A non-persistent [`MmrNodeStore`] backed by a `BTreeMap`.
 #[derive(Debug)]
@@ -33,6 +33,13 @@ impl<H: MerkleHash> MmrNodeStore for MemMmr<H> {
 
     fn put_node(&self, pos: NodePos, value: H) -> Result<(), Infallible> {
         self.nodes.borrow_mut().insert(pos, value);
+        Ok(())
+    }
+}
+
+impl<H: MerkleHash> PrunableNodeStore for MemMmr<H> {
+    fn delete_node(&self, pos: NodePos) -> Result<(), Infallible> {
+        self.nodes.borrow_mut().remove(&pos);
         Ok(())
     }
 }

--- a/crates/merkle-store/src/memory.rs
+++ b/crates/merkle-store/src/memory.rs
@@ -7,7 +7,7 @@ use std::convert::Infallible;
 use strata_merkle::MerkleHash;
 
 use super::index::NodePos;
-use super::store::{MmrNodeStore, PrunableNodeStore};
+use super::store::MmrNodeStore;
 
 /// A non-persistent [`MmrNodeStore`] backed by a `BTreeMap`.
 #[derive(Debug)]
@@ -35,9 +35,7 @@ impl<H: MerkleHash> MmrNodeStore for MemMmr<H> {
         self.nodes.borrow_mut().insert(pos, value);
         Ok(())
     }
-}
 
-impl<H: MerkleHash> PrunableNodeStore for MemMmr<H> {
     fn delete_node(&self, pos: NodePos) -> Result<(), Infallible> {
         self.nodes.borrow_mut().remove(&pos);
         Ok(())

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -380,6 +380,34 @@ where
         }
         self.commit(&writes).map_err(MmrError::Backend)
     }
+
+    /// Removes the last leaf and returns its value, or `None` if the MMR is
+    /// already empty.
+    ///
+    /// The inverse of [`append_leaf`](Self::append_leaf), and a convenience over
+    /// [`prune_after`](Self::prune_after) at `leaf_count - 1`: it drops the final
+    /// leaf together with its now-unreachable ancestors and lowers the leaf count
+    /// by one.
+    ///
+    /// The returned value is the leaf hash read just before removal. It is `None`
+    /// when the store is empty, but also — distinct only by the count it leaves
+    /// behind — when a prior [`prune_before(leaf_count)`](Self::prune_before)
+    /// full-compaction had already discarded that leaf's hash even though the
+    /// count was non-zero; the pop still happens in that case.
+    ///
+    /// Requires a [`PrunableNodeStore`] backend.
+    fn pop_leaf(&self) -> Result<Option<MH::Hash>, MmrError<Self::Error>>
+    where
+        Self: PrunableNodeStore,
+    {
+        let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
+        let Some(last_index) = leaf_count.checked_sub(1) else {
+            return Ok(None);
+        };
+        let value = <Self as StoredMmr<MH>>::get_leaf(self, last_index)?;
+        <Self as StoredMmr<MH>>::prune_after(self, LeafPos::new(last_index))?;
+        Ok(value)
+    }
 }
 
 impl<MH, T> StoredMmr<MH> for T
@@ -434,6 +462,10 @@ mod tests {
 
     fn prune_after(store: &MemMmr<Hash32>, after: u64) {
         StoredMmr::<Sha256Hasher>::prune_after(store, LeafPos::new(after)).unwrap();
+    }
+
+    fn pop(store: &MemMmr<Hash32>) -> Option<Hash32> {
+        StoredMmr::<Sha256Hasher>::pop_leaf(store).unwrap()
     }
 
     /// Deterministic distinct leaf for the concrete (non-property) tests.
@@ -818,6 +850,57 @@ mod tests {
                 leaf_count: 3
             })
         ));
+        assert_eq!(count(&store), 3);
+    }
+
+    /// `pop_leaf` is the inverse of `append_leaf`: it returns the last value,
+    /// shrinks the count by one, and an empty store pops `None`. Repeated pops
+    /// unwind the MMR leaf-by-leaf, each leaving a store identical to one built
+    /// only up to that point.
+    #[test]
+    fn pop_leaf_unwinds_appends() {
+        let store = MemMmr::<Hash32>::default();
+        assert_eq!(pop(&store), None);
+
+        let n = 7u64;
+        for i in 0..n {
+            append(&store, leaf(i));
+        }
+
+        for k in (0..n).rev() {
+            assert_eq!(pop(&store), Some(leaf(k)), "popped value k={k}");
+            assert_eq!(count(&store), k, "count after pop k={k}");
+
+            let fresh = MemMmr::<Hash32>::default();
+            for i in 0..k {
+                append(&fresh, leaf(i));
+            }
+            for idx in 0..k {
+                assert_eq!(
+                    proof_at_size(&store, idx, k).cohashes(),
+                    proof_at_size(&fresh, idx, k).cohashes(),
+                    "k={k} idx={idx}"
+                );
+            }
+        }
+
+        // Fully drained, and popping past empty stays empty.
+        assert_eq!(count(&store), 0);
+        assert_eq!(pop(&store), None);
+    }
+
+    /// After a full `prune_before` compaction the last leaf's hash is gone, so
+    /// `pop_leaf` reports `None` yet still removes the leaf (count drops).
+    #[test]
+    fn pop_leaf_after_full_compaction_drops_count() {
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..4 {
+            append(&store, leaf(i));
+        }
+        // Leaf 3 is a descendant of peak (1,2), so compaction discards its hash.
+        prune_before(&store, 4);
+        assert_eq!(read_leaf(&store, 3), None);
+        assert_eq!(pop(&store), None);
         assert_eq!(count(&store), 3);
     }
 

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -54,10 +54,10 @@ impl<const N: usize> MmrMetaPack for [u8; N] {
 ///
 /// An implementor writes [`get_node`](Self::get_node),
 /// [`put_node`](Self::put_node), and [`delete_node`](Self::delete_node);
-/// [`get_nodes`](Self::get_nodes), [`put_nodes`](Self::put_nodes), and
-/// [`delete_nodes`](Self::delete_nodes) have correct defaults that a backend may
-/// override for batching/atomicity. One backend instance corresponds to one MMR
-/// — any namespacing is the implementor's concern and invisible here.
+/// [`get_nodes`](Self::get_nodes) and [`commit`](Self::commit) have correct
+/// defaults that a backend may override for batching/atomicity. One backend
+/// instance corresponds to one MMR — any namespacing is the implementor's
+/// concern and invisible here.
 ///
 /// The derived leaf/proof API lives in [`StoredMmr`], which is
 /// blanket-implemented for every `MmrNodeStore`; callers use that and never
@@ -90,25 +90,36 @@ pub trait MmrNodeStore {
         positions.iter().map(|pos| self.get_node(*pos)).collect()
     }
 
-    /// Writes all `writes` together.
+    /// Applies `writes` and `deletes` as one batch: every position in `writes`
+    /// is stored and every position in `deletes` is removed.
     ///
-    /// The default loops [`put_node`](Self::put_node); transactional backends
-    /// should override it so a leaf write (leaf + ancestors + leaf-count) is
-    /// committed atomically.
-    fn put_nodes(&self, writes: &[(NodePos, Self::Hash)]) -> Result<(), Self::Error> {
+    /// The derived MMR ops use this as their sole mutation path — a leaf write
+    /// (leaf + ancestors + leaf-count) or a prune (node deletes + watermark/count
+    /// update) is handed to a single `commit` call. Transactional backends should
+    /// override it so the whole batch lands atomically; the default loops
+    /// [`delete_node`](Self::delete_node) then [`put_node`](Self::put_node).
+    ///
+    /// Deletes are applied before writes, which fixes two things callers rely on:
+    ///
+    /// - If a position appears in both `deletes` and `writes`, the write wins —
+    ///   the node ends up stored, not removed. The derived ops never pass
+    ///   overlapping sets, but the resolution is defined rather than left to the
+    ///   backend so an overriding backend stays consistent with the default.
+    /// - The committing metadata write (the watermark or leaf count that finalizes
+    ///   a prune) is in `writes`, so it lands last. A crash in the
+    ///   non-transactional default therefore leaves that marker unchanged and the
+    ///   op re-runs idempotently; a transactional override makes the whole batch
+    ///   atomic and the ordering moot.
+    fn commit(
+        &self,
+        writes: &[(NodePos, Self::Hash)],
+        deletes: &[NodePos],
+    ) -> Result<(), Self::Error> {
+        for pos in deletes {
+            self.delete_node(*pos)?;
+        }
         for (pos, value) in writes {
             self.put_node(*pos, *value)?;
-        }
-        Ok(())
-    }
-
-    /// Removes several nodes in one call.
-    ///
-    /// The default loops [`delete_node`](Self::delete_node); backends with a
-    /// native multi-delete should override it for a single round-trip.
-    fn delete_nodes(&self, positions: &[NodePos]) -> Result<(), Self::Error> {
-        for pos in positions {
-            self.delete_node(*pos)?;
         }
         Ok(())
     }
@@ -170,7 +181,7 @@ where
     /// `leaf_index` may be the current end (an append, which extends the leaf
     /// count) or an existing index (an overwrite). The leaf, its recomputed
     /// ancestors, and any leaf-count bump are written in a single
-    /// [`put_nodes`](MmrNodeStore::put_nodes).
+    /// [`commit`](MmrNodeStore::commit).
     ///
     /// Errors with [`MmrError::LeafGap`] if `leaf_index` is past the append
     /// point (`> leaf_count`), which would skip the leaves in between, with
@@ -218,7 +229,7 @@ where
         if new_count != old_count {
             writes.push((NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(new_count)));
         }
-        self.put_nodes(&writes).map_err(MmrError::Backend)
+        self.commit(&writes, &[]).map_err(MmrError::Backend)
     }
 
     /// Generates an inclusion proof for `leaf_index` against the current MMR
@@ -304,8 +315,11 @@ where
     /// Errors with [`MmrError::LeafOutOfRange`] if `before` is past the append
     /// point (`> leaf_count`).
     ///
-    /// Not a single atomic transaction: the node deletes and the watermark write
-    /// are separate calls, and the watermark is written last, so a crash
+    /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
+    /// deletes and the watermark write are handed to a single `commit`, so a
+    /// transactional backend applies them as one unit. The non-transactional
+    /// default deletes the nodes first and raises the watermark last, so a leaf
+    /// is never reported `Pruned` while its path is still present, and a crash
     /// mid-prune leaves the watermark unchanged and re-running the same call
     /// recomputes the identical (idempotent) delete set and completes.
     fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>> {
@@ -318,18 +332,14 @@ where
             });
         }
         let positions: Vec<NodePos> = iter_prune_before_positions(before_index).collect();
-        self.delete_nodes(&positions).map_err(MmrError::Backend)?;
-        // Raise the watermark last (monotonically), once the nodes are gone, so
-        // a leaf is never reported `Pruned` while its path is still present.
+        // Raise the watermark (monotonically) in the same commit as the deletes.
         let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
-        if before_index > watermark {
-            self.put_nodes(&[(
-                NodePos::meta(PRUNED_BEFORE_TAG),
-                MH::Hash::pack_u64(before_index),
-            )])
-            .map_err(MmrError::Backend)?;
-        }
-        Ok(())
+        let writes: &[(NodePos, MH::Hash)] = &[(
+            NodePos::meta(PRUNED_BEFORE_TAG),
+            MH::Hash::pack_u64(before_index),
+        )];
+        let writes = if before_index > watermark { writes } else { &[] };
+        self.commit(writes, &positions).map_err(MmrError::Backend)
     }
 
     /// Truncates the MMR to its first `after.index()` leaves, removing that leaf
@@ -347,8 +357,10 @@ where
     /// Errors with [`MmrError::LeafOutOfRange`] if `after` is past the append
     /// point (`> leaf_count`).
     ///
-    /// Not a single atomic transaction: the node deletes and the leaf-count
-    /// write are separate calls, and the count is written last, so a crash
+    /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
+    /// deletes and the leaf-count write are handed to a single `commit`, so a
+    /// transactional backend applies them as one unit. The non-transactional
+    /// default deletes the nodes first and lowers the leaf count last, so a crash
     /// mid-prune leaves the count unchanged and re-running the same call
     /// recomputes the identical (idempotent) delete set and completes.
     fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>> {
@@ -364,16 +376,17 @@ where
             return Ok(());
         }
         let positions: Vec<NodePos> = iter_prune_after_positions(keep, leaf_count).collect();
-        self.delete_nodes(&positions).map_err(MmrError::Backend)?;
-        // Lower the leaf count last so an interrupted prune is resumable. Clamp
-        // the watermark to the new count in the same write, since no leaf at or
-        // above `keep` survives to be reported `Pruned`.
-        let mut writes = vec![(NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(keep))];
+        // Clamp the watermark to the new count, since no leaf at or above `keep`
+        // survives to be reported `Pruned`. Order the writes so the leaf count is
+        // the last write: it is the marker that "commits" the truncation, so an
+        // interrupted prune that has not yet lowered it re-runs identically.
+        let mut writes = Vec::with_capacity(2);
         let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
         if watermark > keep {
             writes.push((NodePos::meta(PRUNED_BEFORE_TAG), MH::Hash::pack_u64(keep)));
         }
-        self.put_nodes(&writes).map_err(MmrError::Backend)
+        writes.push((NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(keep)));
+        self.commit(&writes, &positions).map_err(MmrError::Backend)
     }
 
     /// Removes the last leaf and returns its value, or `None` if the MMR is

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -173,10 +173,11 @@ where
     /// [`put_nodes`](MmrNodeStore::put_nodes).
     ///
     /// Errors with [`MmrError::LeafGap`] if `leaf_index` is past the append
-    /// point (`> leaf_count`), which would skip the leaves in between, and with
-    /// [`MmrError::MaxCapacity`] if the store is already at the `u64::MAX` leaf
-    /// ceiling. A [`MmrError::NodeMissing`] instead signals a corrupt store: a
-    /// sibling required by an in-range write is absent.
+    /// point (`> leaf_count`), which would skip the leaves in between, with
+    /// [`MmrError::Pruned`] if it is an overwrite below the prune watermark (see
+    /// below), and with [`MmrError::MaxCapacity`] if the store is already at the
+    /// `u64::MAX` leaf ceiling. A [`MmrError::NodeMissing`] instead signals a
+    /// corrupt store: a sibling required by an in-range write is absent.
     fn put_leaf(&self, leaf_index: u64, value: MH::Hash) -> Result<(), MmrError<Self::Error>> {
         let old_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         // Only an overwrite (`< old_count`) or an append (`== old_count`) is
@@ -188,6 +189,22 @@ where
             return Err(MmrError::LeafGap {
                 index: leaf_index,
                 leaf_count: old_count,
+            });
+        }
+        // Reject an overwrite below the prune watermark. A pruned leaf's node
+        // can physically survive when a later leaf needs it as a sibling cohash:
+        // with 6 leaves, leaf 4 and leaf 5 share peak (1,2), so `prune_before(5)`
+        // keeps leaf 4 even though it marks it pruned. Overwriting leaf 4 would
+        // walk up and recompute (1,2) from the surviving leaf 5, silently
+        // changing the root and leaf 5's proof — yet leaf 5 was never pruned.
+        // An append (`leaf_index == old_count`) is always at or above the
+        // watermark (which never exceeds the leaf count), so this only ever
+        // fires on an overwrite.
+        let pruned_before = <Self as StoredMmr<MH>>::pruned_before(self)?;
+        if leaf_index < pruned_before {
+            return Err(MmrError::Pruned {
+                index: leaf_index,
+                pruned_before,
             });
         }
         // The writable range is `0..=old_count`, so the largest valid index is
@@ -710,6 +727,38 @@ mod tests {
         let reference = reference_mmr(&leaves);
         let proof = proof_at_size(&store, 2, 4);
         assert!(reference.verify::<Sha256Hasher>(&proof, &leaf(2)));
+    }
+
+    /// Overwriting a leaf below the watermark is rejected: `prune_before` keeps
+    /// the pruned leaf's covering peak, so the overwrite would recompute that
+    /// peak from a surviving sibling and corrupt the root/proof of an unpruned
+    /// leaf that shares it (e.g. with 6 leaves, `prune_before(5)` retains leaf 4
+    /// as the sibling that proves leaf 5).
+    #[test]
+    fn put_leaf_below_watermark_is_rejected() {
+        let leaves: Vec<Hash32> = (0..6).map(leaf).collect();
+        let store = MemMmr::<Hash32>::default();
+        for value in &leaves {
+            append(&store, *value);
+        }
+        prune_before(&store, 5);
+        assert_eq!(StoredMmr::<Sha256Hasher>::pruned_before(&store).unwrap(), 5);
+
+        // Leaf 4 is below the watermark but its peak survives to prove leaf 5.
+        assert!(matches!(
+            put(&store, 4, leaf(0xaa)),
+            Err(MmrError::Pruned {
+                index: 4,
+                pruned_before: 5,
+            })
+        ));
+        // Leaf 5 (at/above the watermark) still verifies, unchanged.
+        let reference = reference_mmr(&leaves);
+        assert!(reference.verify::<Sha256Hasher>(&proof_at_size(&store, 5, 6), &leaf(5)));
+
+        // Appending at the end is unaffected by the watermark.
+        append(&store, leaf(6));
+        assert_eq!(count(&store), 7);
     }
 
     /// The watermark only ever rises under `prune_before`, and `prune_after`

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -243,10 +243,22 @@ where
     /// Generates an inclusion proof for `leaf_index` against an MMR of exactly
     /// `at_leaf_count` leaves.
     ///
-    /// Exact for any historical size: stored nodes are immutable under
-    /// append-only use, so the proof path for `leaf_index` in a
-    /// size-`at_leaf_count` MMR walks the same nodes regardless of later
-    /// appends.
+    /// Exact for any retained historical size: a stored node's hash covers a
+    /// fixed leaf range and never changes under appends, so the proof path for
+    /// `leaf_index` in a size-`at_leaf_count` MMR walks the same nodes
+    /// regardless of later appends.
+    ///
+    /// Errors with [`MmrError::LeafOutOfRange`] if `at_leaf_count` exceeds the
+    /// store's current [`leaf_count`](Self::leaf_count): the immutability above
+    /// only holds for sizes the store still retains, and
+    /// [`prune_after`](Self::prune_after) can truncate leaves off the top.
+    /// The hazard this prevents is not a malformed proof but a *valid* one: a
+    /// truncated-away leaf that is a lone peak at `at_leaf_count` has an empty
+    /// proof path, so it slips past the missing-node check below and assembles
+    /// into a proof that still verifies against the (now-abandoned) size-
+    /// `at_leaf_count` root. The store would thus vouch for a leaf it
+    /// deliberately rolled back, with nothing to signal the state is gone. The
+    /// guard makes the store vend proofs only against sizes it still holds.
     ///
     /// Errors with [`MmrError::Pruned`] if `leaf_index` is below the store's
     /// prune watermark (see [`prune_before`](Self::prune_before)): the nodes
@@ -261,6 +273,14 @@ where
             return Err(MmrError::LeafOutOfRange {
                 index: leaf_index,
                 leaf_count: at_leaf_count,
+            });
+        }
+
+        let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
+        if at_leaf_count > leaf_count {
+            return Err(MmrError::LeafOutOfRange {
+                index: at_leaf_count - 1,
+                leaf_count,
             });
         }
 
@@ -875,6 +895,42 @@ mod tests {
         prune_before(&store, 5); // keeps peaks of 5 leaves: (2,0) and (0,4)
         prune_after(&store, 4); // needs (2,0), which is intact
         assert_eq!(count(&store), 4);
+    }
+
+    /// A historical proof against a size the store has truncated away is
+    /// rejected. With 5 leaves, `prune_after(4)` drops leaf 4 (a lone height-0
+    /// peak at size 5), so its proof path is empty; without the size guard
+    /// `generate_proof_at_size(4, 5)` would return a proof for the rolled-back
+    /// leaf instead of erroring.
+    #[test]
+    fn proof_past_truncated_size_is_rejected() {
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..5 {
+            append(&store, leaf(i));
+        }
+        prune_after(&store, 4);
+        assert_eq!(count(&store), 4);
+
+        // Leaf 4 was a lone peak at size 5 (empty proof path), so it slips past
+        // the missing-node check; the size guard must reject it.
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::generate_proof_at_size(&store, 4, 5),
+            Err(MmrError::LeafOutOfRange {
+                index: 4,
+                leaf_count: 4
+            })
+        ));
+        // A still-retained leaf is rejected too when the requested size is gone.
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::generate_proof_at_size(&store, 2, 5),
+            Err(MmrError::LeafOutOfRange {
+                index: 4,
+                leaf_count: 4
+            })
+        ));
+        // Proofs against the retained size still work.
+        let reference = reference_mmr(&(0..4).map(leaf).collect::<Vec<_>>());
+        assert!(reference.verify::<Sha256Hasher>(&proof_at_size(&store, 2, 4), &leaf(2)));
     }
 
     /// `prune_before(leaf_count)` compacts the whole MMR to its current peaks,

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -11,6 +11,11 @@ use super::index::{LeafPos, NodePos};
 /// Reserved metadata tag holding the leaf count (== next leaf index).
 const NEXT_INDEX_TAG: u64 = 0;
 
+/// Reserved metadata tag holding the prune watermark: every leaf below this
+/// index has been discarded by [`prune_before`](StoredMmr::prune_before) and can
+/// no longer be proven. Absent (the default) means `0` — nothing pruned.
+const PRUNED_BEFORE_TAG: u64 = 1;
+
 /// Reversible packing of a `u64` into a hash-sized metadata value.
 ///
 /// The node store keeps its leaf count in a reserved metadata slot that holds a
@@ -95,9 +100,8 @@ pub trait MmrNodeStore {
 ///
 /// Opt-in and separate from [`MmrNodeStore`] so append-only backends (which
 /// cannot delete) are unaffected: an implementor adds only
-/// [`delete_node`](Self::delete_node); [`delete_nodes`](Self::delete_nodes) and
-/// [`prune_commit`](Self::prune_commit) have correct defaults a backend may
-/// override for batching/atomicity.
+/// [`delete_node`](Self::delete_node); [`delete_nodes`](Self::delete_nodes) has
+/// a correct default a backend may override for a single round-trip.
 pub trait PrunableNodeStore: MmrNodeStore {
     /// Removes the node at `pos`.
     ///
@@ -108,26 +112,17 @@ pub trait PrunableNodeStore: MmrNodeStore {
     ///
     /// The default loops [`delete_node`](Self::delete_node); backends with a
     /// native multi-delete should override it for a single round-trip.
+    ///
+    /// The pruning operations pass the whole set of positions a prune removes —
+    /// a count that scales with how far back the cut reaches (a deep
+    /// [`prune_after`](StoredMmr::prune_after), for instance, can delete most of
+    /// the tree). A backend that cannot issue an arbitrarily large delete in one
+    /// go should chunk internally (e.g. `positions.chunks(N)`) to its own limit.
     fn delete_nodes(&self, positions: &[NodePos]) -> Result<(), Self::Error> {
         for pos in positions {
             self.delete_node(*pos)?;
         }
         Ok(())
-    }
-
-    /// Applies `writes` and `deletes` together — the transactional primitive
-    /// for pruning, mirroring [`commit`](MmrNodeStore::commit) for writes.
-    ///
-    /// The default is non-atomic (commit, then delete); transactional backends
-    /// should override it so a truncation's leaf-count bump and node deletions
-    /// land in a single transaction.
-    fn prune_commit(
-        &self,
-        writes: &[(NodePos, Self::Hash)],
-        deletes: &[NodePos],
-    ) -> Result<(), Self::Error> {
-        self.commit(writes)?;
-        self.delete_nodes(deletes)
     }
 }
 
@@ -149,6 +144,19 @@ where
     fn leaf_count(&self) -> Result<u64, MmrError<Self::Error>> {
         Ok(self
             .get_node(NodePos::meta(NEXT_INDEX_TAG))
+            .map_err(MmrError::Backend)?
+            .map(|h| h.unpack_u64())
+            .unwrap_or(0))
+    }
+
+    /// Returns the prune watermark: every leaf with index `< pruned_before` has
+    /// been discarded by [`prune_before`](Self::prune_before) and can no longer
+    /// be proven. `0` (the default) means nothing has been pruned.
+    ///
+    /// `O(1)`: reads the reserved watermark metadata slot.
+    fn pruned_before(&self) -> Result<u64, MmrError<Self::Error>> {
+        Ok(self
+            .get_node(NodePos::meta(PRUNED_BEFORE_TAG))
             .map_err(MmrError::Backend)?
             .map(|h| h.unpack_u64())
             .unwrap_or(0))
@@ -225,6 +233,11 @@ where
     /// append-only use, so the proof path for `leaf_index` in a
     /// size-`at_leaf_count` MMR walks the same nodes regardless of later
     /// appends.
+    ///
+    /// Errors with [`MmrError::Pruned`] if `leaf_index` is below the store's
+    /// prune watermark (see [`prune_before`](Self::prune_before)): the nodes
+    /// were deliberately discarded, so this is reported distinctly from a
+    /// [`MmrError::NodeMissing`] corruption.
     fn generate_proof_at_size(
         &self,
         leaf_index: u64,
@@ -234,6 +247,17 @@ where
             return Err(MmrError::LeafOutOfRange {
                 index: leaf_index,
                 leaf_count: at_leaf_count,
+            });
+        }
+
+        // A leaf below the watermark had its path discarded by `prune_before`;
+        // report that intent rather than letting the missing-node read below
+        // surface as `NodeMissing`, which a caller reads as corruption.
+        let pruned_before = <Self as StoredMmr<MH>>::pruned_before(self)?;
+        if leaf_index < pruned_before {
+            return Err(MmrError::Pruned {
+                index: leaf_index,
+                pruned_before,
             });
         }
 
@@ -262,22 +286,25 @@ where
     }
 
     /// Prunes every node strictly before `before`, retaining only the peaks of
-    /// the first `before.index()` leaves.
+    /// the first `before.index()` leaves, and raises the prune watermark.
     ///
     /// Those peaks are the minimal set still required to prove leaves at or
     /// after `before` and to keep appending, so both continue to work; proofs
-    /// for the *pruned* leaves afterward fail with [`MmrError::NodeMissing`].
-    /// The leaf count is unchanged. A `before` of `0` prunes nothing; one equal
-    /// to the leaf count compacts the whole MMR down to its current peaks.
+    /// for the *pruned* leaves afterward fail with [`MmrError::Pruned`]. The
+    /// leaf count is unchanged. A `before` of `0` prunes nothing; one equal to
+    /// the leaf count compacts the whole MMR down to its current peaks. The
+    /// watermark is monotonic: a `before` at or below the current watermark only
+    /// re-deletes already-pruned nodes and leaves the watermark untouched.
     ///
     /// Errors with [`MmrError::LeafOutOfRange`] if `before` is past the append
     /// point (`> leaf_count`).
     ///
+    /// Not a single atomic transaction: the node deletes and the watermark write
+    /// are separate calls, and the watermark is written last, so a crash
+    /// mid-prune leaves the watermark unchanged and re-running the same call
+    /// recomputes the identical (idempotent) delete set and completes.
+    ///
     /// Requires a [`PrunableNodeStore`] backend.
-    //
-    // TODO: a stored `pruned_before` watermark would let proof generation for a
-    // pruned leaf return a dedicated error instead of `NodeMissing`, which a
-    // caller can't currently tell apart from genuine corruption.
     fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>>
     where
         Self: PrunableNodeStore,
@@ -290,8 +317,19 @@ where
                 leaf_count,
             });
         }
-        let deletes = prune_before_positions(before_index);
-        self.prune_commit(&[], &deletes).map_err(MmrError::Backend)
+        let positions: Vec<NodePos> = prune_before_positions(before_index).collect();
+        self.delete_nodes(&positions).map_err(MmrError::Backend)?;
+        // Raise the watermark last (monotonically), once the nodes are gone, so
+        // a leaf is never reported `Pruned` while its path is still present.
+        let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
+        if before_index > watermark {
+            self.commit(&[(
+                NodePos::meta(PRUNED_BEFORE_TAG),
+                MH::Hash::pack_u64(before_index),
+            )])
+            .map_err(MmrError::Backend)?;
+        }
+        Ok(())
     }
 
     /// Truncates the MMR to its first `after.index()` leaves, removing that leaf
@@ -302,10 +340,17 @@ where
     /// `after.index()` leaves (a surviving node covers the same leaves, so its
     /// stored hash is unchanged), so the truncated store behaves identically to
     /// one that was only ever that size. An `after` equal to the leaf count is a
-    /// no-op (nothing past the end); one of `0` empties the store.
+    /// no-op (nothing past the end); one of `0` empties the store. If a prior
+    /// [`prune_before`](Self::prune_before) left the watermark above the new
+    /// count, it is clamped down to it.
     ///
     /// Errors with [`MmrError::LeafOutOfRange`] if `after` is past the append
     /// point (`> leaf_count`).
+    ///
+    /// Not a single atomic transaction: the node deletes and the leaf-count
+    /// write are separate calls, and the count is written last, so a crash
+    /// mid-prune leaves the count unchanged and re-running the same call
+    /// recomputes the identical (idempotent) delete set and completes.
     ///
     /// Requires a [`PrunableNodeStore`] backend.
     fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>>
@@ -323,10 +368,17 @@ where
         if keep == leaf_count {
             return Ok(());
         }
-        let deletes = prune_after_positions(keep, leaf_count);
-        let count_write = (NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(keep));
-        self.prune_commit(&[count_write], &deletes)
-            .map_err(MmrError::Backend)
+        let positions: Vec<NodePos> = prune_after_positions(keep, leaf_count).collect();
+        self.delete_nodes(&positions).map_err(MmrError::Backend)?;
+        // Lower the leaf count last so an interrupted prune is resumable. Clamp
+        // the watermark to the new count in the same write, since no leaf at or
+        // above `keep` survives to be reported `Pruned`.
+        let mut writes = vec![(NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(keep))];
+        let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
+        if watermark > keep {
+            writes.push((NodePos::meta(PRUNED_BEFORE_TAG), MH::Hash::pack_u64(keep)));
+        }
+        self.commit(&writes).map_err(MmrError::Backend)
     }
 }
 
@@ -597,7 +649,7 @@ mod tests {
                     append(&store, *value);
                 }
 
-                let deletes = prune_before_positions(k);
+                let deletes: Vec<NodePos> = prune_before_positions(k).collect();
                 for pos in &deletes {
                     assert!(
                         store.get_node(*pos).unwrap().is_some(),
@@ -627,8 +679,8 @@ mod tests {
         }
     }
 
-    /// A leaf whose node was pruned by `prune_before` can no longer be proven,
-    /// while a leaf at/after the cut still can.
+    /// A leaf below the watermark left by `prune_before` reports `Pruned`, while
+    /// a leaf at/after the cut still proves.
     #[test]
     fn prune_before_makes_pruned_leaf_unprovable() {
         let leaves: Vec<Hash32> = (0..4).map(leaf).collect();
@@ -638,15 +690,48 @@ mod tests {
         }
         // Peaks of the first 2 leaves are [(1,0)]; this drops leaves 0 and 1.
         prune_before(&store, 2);
+        assert_eq!(StoredMmr::<Sha256Hasher>::pruned_before(&store).unwrap(), 2);
 
-        assert!(matches!(
-            StoredMmr::<Sha256Hasher>::generate_proof_at_size(&store, 0, 4),
-            Err(MmrError::NodeMissing(_))
-        ));
+        for idx in 0..2 {
+            assert!(matches!(
+                StoredMmr::<Sha256Hasher>::generate_proof_at_size(&store, idx, 4),
+                Err(MmrError::Pruned {
+                    index,
+                    pruned_before: 2,
+                }) if index == idx
+            ));
+        }
 
         let reference = reference_mmr(&leaves);
         let proof = proof_at_size(&store, 2, 4);
         assert!(reference.verify::<Sha256Hasher>(&proof, &leaf(2)));
+    }
+
+    /// The watermark only ever rises under `prune_before`, and `prune_after`
+    /// clamps it down to a new, smaller leaf count.
+    #[test]
+    fn prune_watermark_is_monotonic_and_clamped() {
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..8 {
+            append(&store, leaf(i));
+        }
+        let watermark = || StoredMmr::<Sha256Hasher>::pruned_before(&store).unwrap();
+
+        prune_before(&store, 3);
+        assert_eq!(watermark(), 3);
+        // A smaller cut re-deletes already-pruned nodes but never lowers it.
+        prune_before(&store, 1);
+        assert_eq!(watermark(), 3);
+        // A larger cut raises it.
+        prune_before(&store, 5);
+        assert_eq!(watermark(), 5);
+        // Truncating below the watermark clamps it to the surviving leaf count.
+        prune_after(&store, 4);
+        assert_eq!(count(&store), 4);
+        assert_eq!(watermark(), 4);
+        // Emptying resets it.
+        prune_after(&store, 0);
+        assert_eq!(watermark(), 0);
     }
 
     /// `prune_before(leaf_count)` compacts the whole MMR to its current peaks,

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -315,6 +315,14 @@ where
     /// Errors with [`MmrError::LeafOutOfRange`] if `before` is past the append
     /// point (`> leaf_count`).
     ///
+    /// Note: the set of node positions to delete is materialized in full (into a
+    /// `Vec`) before it is handed to [`commit`](MmrNodeStore::commit), so a single
+    /// prune over a long-lived MMR allocates memory proportional to the number of
+    /// removed nodes. The watermark is monotonic and the delete set idempotent, so
+    /// a consumer that needs to bound peak memory can prune in steps — repeated
+    /// calls advancing `before` — and converge to the same state. Bounding it that
+    /// way is left to the consumer.
+    ///
     /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
     /// deletes and the watermark write are handed to a single `commit`, so a
     /// transactional backend applies them as one unit. The non-transactional
@@ -362,6 +370,11 @@ where
     /// have removed them. Truncating onto a missing prefix would leave a store
     /// that reports the right leaf count yet cannot append, so it is rejected;
     /// `keep` at or above the watermark always has its prefix peaks intact.
+    ///
+    /// Note: like [`prune_before`](Self::prune_before), the delete set is
+    /// materialized in full before the [`commit`](MmrNodeStore::commit). A single
+    /// truncation that drops a huge suffix therefore allocates proportionally; a
+    /// consumer bounding peak memory should truncate in steps.
     ///
     /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
     /// deletes and the leaf-count write are handed to a single `commit`, so a

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -2,9 +2,11 @@
 
 use strata_merkle::{MerkleHash, MerkleHasher, MerkleProof};
 
-use super::algorithm::{assemble_proof, proof_positions, write_plan};
+use super::algorithm::{
+    assemble_proof, proof_positions, prune_after_positions, prune_before_positions, write_plan,
+};
 use super::error::MmrError;
-use super::index::NodePos;
+use super::index::{LeafPos, NodePos};
 
 /// Reserved metadata tag holding the leaf count (== next leaf index).
 const NEXT_INDEX_TAG: u64 = 0;
@@ -84,6 +86,48 @@ pub trait MmrNodeStore {
             self.put_node(*pos, *value)?;
         }
         Ok(())
+    }
+}
+
+/// A [`MmrNodeStore`] that can also delete nodes, unlocking the pruning
+/// operations on [`StoredMmr`] ([`prune_before`](StoredMmr::prune_before) /
+/// [`prune_after`](StoredMmr::prune_after)).
+///
+/// Opt-in and separate from [`MmrNodeStore`] so append-only backends (which
+/// cannot delete) are unaffected: an implementor adds only
+/// [`delete_node`](Self::delete_node); [`delete_nodes`](Self::delete_nodes) and
+/// [`prune_commit`](Self::prune_commit) have correct defaults a backend may
+/// override for batching/atomicity.
+pub trait PrunableNodeStore: MmrNodeStore {
+    /// Removes the node at `pos`.
+    ///
+    /// Idempotent: removing a node that is absent is not an error.
+    fn delete_node(&self, pos: NodePos) -> Result<(), Self::Error>;
+
+    /// Removes several nodes in one call.
+    ///
+    /// The default loops [`delete_node`](Self::delete_node); backends with a
+    /// native multi-delete should override it for a single round-trip.
+    fn delete_nodes(&self, positions: &[NodePos]) -> Result<(), Self::Error> {
+        for pos in positions {
+            self.delete_node(*pos)?;
+        }
+        Ok(())
+    }
+
+    /// Applies `writes` and `deletes` together — the transactional primitive
+    /// for pruning, mirroring [`commit`](MmrNodeStore::commit) for writes.
+    ///
+    /// The default is non-atomic (commit, then delete); transactional backends
+    /// should override it so a truncation's leaf-count bump and node deletions
+    /// land in a single transaction.
+    fn prune_commit(
+        &self,
+        writes: &[(NodePos, Self::Hash)],
+        deletes: &[NodePos],
+    ) -> Result<(), Self::Error> {
+        self.commit(writes)?;
+        self.delete_nodes(deletes)
     }
 }
 
@@ -216,6 +260,74 @@ where
         }
         Ok(())
     }
+
+    /// Prunes every node strictly before `before`, retaining only the peaks of
+    /// the first `before.index()` leaves.
+    ///
+    /// Those peaks are the minimal set still required to prove leaves at or
+    /// after `before` and to keep appending, so both continue to work; proofs
+    /// for the *pruned* leaves afterward fail with [`MmrError::NodeMissing`].
+    /// The leaf count is unchanged. A `before` of `0` prunes nothing; one equal
+    /// to the leaf count compacts the whole MMR down to its current peaks.
+    ///
+    /// Errors with [`MmrError::LeafOutOfRange`] if `before` is past the append
+    /// point (`> leaf_count`).
+    ///
+    /// Requires a [`PrunableNodeStore`] backend.
+    //
+    // TODO: a stored `pruned_before` watermark would let proof generation for a
+    // pruned leaf return a dedicated error instead of `NodeMissing`, which a
+    // caller can't currently tell apart from genuine corruption.
+    fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>>
+    where
+        Self: PrunableNodeStore,
+    {
+        let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
+        let before_index = before.index();
+        if before_index > leaf_count {
+            return Err(MmrError::LeafOutOfRange {
+                index: before_index,
+                leaf_count,
+            });
+        }
+        let deletes = prune_before_positions(before_index);
+        self.prune_commit(&[], &deletes).map_err(MmrError::Backend)
+    }
+
+    /// Truncates the MMR to its first `after.index()` leaves, removing that leaf
+    /// and every leaf after it together with their now-unreachable ancestors,
+    /// and updates the stored leaf count.
+    ///
+    /// The retained nodes are exactly those of a freshly built MMR of
+    /// `after.index()` leaves (a surviving node covers the same leaves, so its
+    /// stored hash is unchanged), so the truncated store behaves identically to
+    /// one that was only ever that size. An `after` equal to the leaf count is a
+    /// no-op (nothing past the end); one of `0` empties the store.
+    ///
+    /// Errors with [`MmrError::LeafOutOfRange`] if `after` is past the append
+    /// point (`> leaf_count`).
+    ///
+    /// Requires a [`PrunableNodeStore`] backend.
+    fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>>
+    where
+        Self: PrunableNodeStore,
+    {
+        let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
+        let keep = after.index();
+        if keep > leaf_count {
+            return Err(MmrError::LeafOutOfRange {
+                index: keep,
+                leaf_count,
+            });
+        }
+        if keep == leaf_count {
+            return Ok(());
+        }
+        let deletes = prune_after_positions(keep, leaf_count);
+        let count_write = (NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(keep));
+        self.prune_commit(&[count_write], &deletes)
+            .map_err(MmrError::Backend)
+    }
 }
 
 impl<MH, T> StoredMmr<MH> for T
@@ -262,6 +374,14 @@ mod tests {
 
     fn proof_at_size(store: &MemMmr<Hash32>, index: u64, size: u64) -> MerkleProof<Hash32> {
         StoredMmr::<Sha256Hasher>::generate_proof_at_size(store, index, size).unwrap()
+    }
+
+    fn prune_before(store: &MemMmr<Hash32>, before: u64) {
+        StoredMmr::<Sha256Hasher>::prune_before(store, LeafPos::new(before)).unwrap();
+    }
+
+    fn prune_after(store: &MemMmr<Hash32>, after: u64) {
+        StoredMmr::<Sha256Hasher>::prune_after(store, LeafPos::new(after)).unwrap();
     }
 
     /// Deterministic distinct leaf for the concrete (non-property) tests.
@@ -395,6 +515,227 @@ mod tests {
         assert_eq!(count(&mmr), 8);
     }
 
+    // ---- pruning ----
+
+    /// `prune_after(k)` deletes exactly the out-of-range nodes, leaving a store
+    /// whose surviving nodes and leaf count match a fresh `k`-leaf build, for
+    /// every `(n, k)` in a small exhaustive grid.
+    #[test]
+    fn prune_after_matches_fresh_build() {
+        for n in 1..=16u64 {
+            for k in 0..=n {
+                let leaves: Vec<Hash32> = (0..n).map(leaf).collect();
+
+                let pruned = MemMmr::<Hash32>::default();
+                for value in &leaves {
+                    append(&pruned, *value);
+                }
+                prune_after(&pruned, k);
+
+                let fresh = MemMmr::<Hash32>::default();
+                for value in &leaves[..k as usize] {
+                    append(&fresh, *value);
+                }
+
+                assert_eq!(count(&pruned), k, "leaf_count n={n} k={k}");
+                if k < n {
+                    assert_eq!(read_leaf(&pruned, k), None, "dropped leaf n={n} k={k}");
+                }
+                for idx in 0..k {
+                    assert_eq!(
+                        proof_at_size(&pruned, idx, k).cohashes(),
+                        proof_at_size(&fresh, idx, k).cohashes(),
+                        "n={n} k={k} idx={idx}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Appending after a `prune_after` rolls forward exactly as if the truncated
+    /// leaves had never existed.
+    #[test]
+    fn prune_after_then_append_matches_continuous_build() {
+        let leaves: Vec<Hash32> = (0..10).map(leaf).collect();
+        let store = MemMmr::<Hash32>::default();
+        for value in &leaves {
+            append(&store, *value);
+        }
+        prune_after(&store, 6);
+
+        let extra: Vec<Hash32> = (100..105).map(leaf).collect();
+        for value in &extra {
+            append(&store, *value);
+        }
+
+        let reference = MemMmr::<Hash32>::default();
+        for value in leaves[..6].iter().chain(extra.iter()) {
+            append(&reference, *value);
+        }
+
+        let total = 6 + extra.len() as u64;
+        assert_eq!(count(&store), total);
+        for idx in 0..total {
+            assert_eq!(
+                proof_at_size(&store, idx, total).cohashes(),
+                proof_at_size(&reference, idx, total).cohashes(),
+                "idx={idx}"
+            );
+        }
+    }
+
+    /// `prune_before(k)` removes exactly the descendants of the prefix peaks and
+    /// leaves the rest intact: leaf count is unchanged and every leaf in
+    /// `[k, n)` still verifies against the reference.
+    #[test]
+    fn prune_before_deletes_exactly_the_descendants() {
+        for n in 1..=16u64 {
+            for k in 0..=n {
+                let leaves: Vec<Hash32> = (0..n).map(leaf).collect();
+                let store = MemMmr::<Hash32>::default();
+                for value in &leaves {
+                    append(&store, *value);
+                }
+
+                let deletes = prune_before_positions(k);
+                for pos in &deletes {
+                    assert!(
+                        store.get_node(*pos).unwrap().is_some(),
+                        "pre n={n} k={k} {pos:?}"
+                    );
+                }
+
+                prune_before(&store, k);
+                assert_eq!(count(&store), n, "leaf_count unchanged n={n} k={k}");
+
+                for pos in &deletes {
+                    assert!(
+                        store.get_node(*pos).unwrap().is_none(),
+                        "post n={n} k={k} {pos:?}"
+                    );
+                }
+
+                let reference = reference_mmr(&leaves);
+                for idx in k..n {
+                    let proof = proof_at_size(&store, idx, n);
+                    assert!(
+                        reference.verify::<Sha256Hasher>(&proof, &leaves[idx as usize]),
+                        "verify n={n} k={k} idx={idx}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A leaf whose node was pruned by `prune_before` can no longer be proven,
+    /// while a leaf at/after the cut still can.
+    #[test]
+    fn prune_before_makes_pruned_leaf_unprovable() {
+        let leaves: Vec<Hash32> = (0..4).map(leaf).collect();
+        let store = MemMmr::<Hash32>::default();
+        for value in &leaves {
+            append(&store, *value);
+        }
+        // Peaks of the first 2 leaves are [(1,0)]; this drops leaves 0 and 1.
+        prune_before(&store, 2);
+
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::generate_proof_at_size(&store, 0, 4),
+            Err(MmrError::NodeMissing(_))
+        ));
+
+        let reference = reference_mmr(&leaves);
+        let proof = proof_at_size(&store, 2, 4);
+        assert!(reference.verify::<Sha256Hasher>(&proof, &leaf(2)));
+    }
+
+    /// `prune_before(leaf_count)` compacts the whole MMR to its current peaks,
+    /// and appends afterward still roll forward correctly.
+    #[test]
+    fn prune_before_full_compaction_keeps_only_peaks() {
+        let n = 6u64; // peaks: (2,0), (1,2)
+        let leaves: Vec<Hash32> = (0..n).map(leaf).collect();
+        let store = MemMmr::<Hash32>::default();
+        for value in &leaves {
+            append(&store, *value);
+        }
+        prune_before(&store, n);
+        assert_eq!(count(&store), n);
+
+        for pos in crate::peak_positions(n) {
+            assert!(store.get_node(pos).unwrap().is_some(), "peak {pos:?} kept");
+        }
+        for pos in prune_before_positions(n) {
+            assert!(
+                store.get_node(pos).unwrap().is_none(),
+                "non-peak {pos:?} gone"
+            );
+        }
+
+        let extra = [leaf(100), leaf(101)];
+        for value in &extra {
+            append(&store, *value);
+        }
+        let reference = MemMmr::<Hash32>::default();
+        for value in leaves.iter().chain(extra.iter()) {
+            append(&reference, *value);
+        }
+        let total = n + extra.len() as u64;
+        // Only the newly appended leaves remain provable after full compaction.
+        for idx in n..total {
+            assert_eq!(
+                proof_at_size(&store, idx, total).cohashes(),
+                proof_at_size(&reference, idx, total).cohashes(),
+                "idx={idx}"
+            );
+        }
+    }
+
+    /// Boundary inputs: no-op prunes, emptying, and out-of-range rejection.
+    #[test]
+    fn prune_boundaries() {
+        let leaves: Vec<Hash32> = (0..5).map(leaf).collect();
+        let store = MemMmr::<Hash32>::default();
+        for value in &leaves {
+            append(&store, *value);
+        }
+
+        // prune_before(0) and prune_after(leaf_count) change nothing.
+        prune_before(&store, 0);
+        prune_after(&store, 5);
+        assert_eq!(count(&store), 5);
+        let reference = reference_mmr(&leaves);
+        for idx in 0..5 {
+            assert!(reference.verify::<Sha256Hasher>(&proof_at_size(&store, idx, 5), &leaf(idx)));
+        }
+
+        // prune_after(0) empties the store.
+        prune_after(&store, 0);
+        assert_eq!(count(&store), 0);
+        assert_eq!(read_leaf(&store, 0), None);
+
+        // A cut past the append point is rejected, leaving the store untouched.
+        let store = MemMmr::<Hash32>::default();
+        for value in leaves.iter().take(3) {
+            append(&store, *value);
+        }
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::prune_before(&store, LeafPos::new(4)),
+            Err(MmrError::LeafOutOfRange {
+                index: 4,
+                leaf_count: 3
+            })
+        ));
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::prune_after(&store, LeafPos::new(4)),
+            Err(MmrError::LeafOutOfRange {
+                index: 4,
+                leaf_count: 3
+            })
+        ));
+        assert_eq!(count(&store), 3);
+    }
+
     /// Exhaustive, deterministic parity for small sizes: our proof's cohashes
     /// and index are identical to `strata-merkle`'s replay-based proof, and it
     /// verifies (while a tampered leaf does not). This is the load-bearing
@@ -509,6 +850,50 @@ mod tests {
             }
             let after = proof_at_size(&mmr, index, size);
             prop_assert_eq!(before.cohashes(), after.cohashes());
+        }
+
+        /// `prune_after(k)` leaves a store indistinguishable from a fresh
+        /// `k`-leaf build: same leaf count and same proof for every kept leaf.
+        #[test]
+        fn prune_after_equals_fresh_build((leaves, size, _index) in leaves_and_query(1..64)) {
+            let k = size;
+            let pruned = MemMmr::<Hash32>::default();
+            for value in &leaves {
+                append(&pruned, *value);
+            }
+            prune_after(&pruned, k);
+
+            let fresh = MemMmr::<Hash32>::default();
+            for value in &leaves[..k as usize] {
+                append(&fresh, *value);
+            }
+
+            prop_assert_eq!(count(&pruned), k);
+            for idx in 0..k {
+                let pruned_proof = proof_at_size(&pruned, idx, k);
+                let fresh_proof = proof_at_size(&fresh, idx, k);
+                prop_assert_eq!(pruned_proof.cohashes(), fresh_proof.cohashes());
+            }
+        }
+
+        /// After `prune_before(k)` every leaf in `[k, n)` still verifies against
+        /// the reference and the leaf count is unchanged.
+        #[test]
+        fn prune_before_preserves_suffix_proofs((leaves, size, _index) in leaves_and_query(1..64)) {
+            let n = leaves.len() as u64;
+            let k = size;
+            let store = MemMmr::<Hash32>::default();
+            for value in &leaves {
+                append(&store, *value);
+            }
+            prune_before(&store, k);
+
+            prop_assert_eq!(count(&store), n);
+            let reference = reference_mmr(&leaves);
+            for idx in k..n {
+                let proof = proof_at_size(&store, idx, n);
+                prop_assert!(reference.verify::<Sha256Hasher>(&proof, &leaves[idx as usize]));
+            }
         }
     }
 }

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -3,7 +3,8 @@
 use strata_merkle::{MerkleHash, MerkleHasher, MerkleProof};
 
 use super::algorithm::{
-    assemble_proof, proof_positions, prune_after_positions, prune_before_positions, write_plan,
+    assemble_proof, iter_prune_after_positions, iter_prune_before_positions, proof_positions,
+    write_plan,
 };
 use super::error::MmrError;
 use super::index::{LeafPos, NodePos};
@@ -317,7 +318,7 @@ where
                 leaf_count,
             });
         }
-        let positions: Vec<NodePos> = prune_before_positions(before_index).collect();
+        let positions: Vec<NodePos> = iter_prune_before_positions(before_index).collect();
         self.delete_nodes(&positions).map_err(MmrError::Backend)?;
         // Raise the watermark last (monotonically), once the nodes are gone, so
         // a leaf is never reported `Pruned` while its path is still present.
@@ -368,7 +369,7 @@ where
         if keep == leaf_count {
             return Ok(());
         }
-        let positions: Vec<NodePos> = prune_after_positions(keep, leaf_count).collect();
+        let positions: Vec<NodePos> = iter_prune_after_positions(keep, leaf_count).collect();
         self.delete_nodes(&positions).map_err(MmrError::Backend)?;
         // Lower the leaf count last so an interrupted prune is resumable. Clamp
         // the watermark to the new count in the same write, since no leaf at or
@@ -681,7 +682,7 @@ mod tests {
                     append(&store, *value);
                 }
 
-                let deletes: Vec<NodePos> = prune_before_positions(k).collect();
+                let deletes: Vec<NodePos> = iter_prune_before_positions(k).collect();
                 for pos in &deletes {
                     assert!(
                         store.get_node(*pos).unwrap().is_some(),
@@ -782,7 +783,7 @@ mod tests {
         for pos in crate::peak_positions(n) {
             assert!(store.get_node(pos).unwrap().is_some(), "peak {pos:?} kept");
         }
-        for pos in prune_before_positions(n) {
+        for pos in iter_prune_before_positions(n) {
             assert!(
                 store.get_node(pos).unwrap().is_none(),
                 "non-peak {pos:?} gone"

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -52,11 +52,12 @@ impl<const N: usize> MmrMetaPack for [u8; N] {
 
 /// Storage backend for MMR nodes.
 ///
-/// An implementor writes only [`get_node`](Self::get_node) and
-/// [`put_node`](Self::put_node); [`get_nodes`](Self::get_nodes) and
-/// [`commit`](Self::commit) have correct defaults that a backend may override
-/// for batching/atomicity. One backend instance corresponds to one MMR — any
-/// namespacing is the implementor's concern and invisible here.
+/// An implementor writes [`get_node`](Self::get_node),
+/// [`put_node`](Self::put_node), and [`delete_node`](Self::delete_node);
+/// [`get_nodes`](Self::get_nodes), [`put_nodes`](Self::put_nodes), and
+/// [`delete_nodes`](Self::delete_nodes) have correct defaults that a backend may
+/// override for batching/atomicity. One backend instance corresponds to one MMR
+/// — any namespacing is the implementor's concern and invisible here.
 ///
 /// The derived leaf/proof API lives in [`StoredMmr`], which is
 /// blanket-implemented for every `MmrNodeStore`; callers use that and never
@@ -72,7 +73,14 @@ pub trait MmrNodeStore {
     fn get_node(&self, pos: NodePos) -> Result<Option<Self::Hash>, Self::Error>;
 
     /// Stores `value` at `pos`.
+    ///
+    /// Overwriting a node that is already present is not an error.
     fn put_node(&self, pos: NodePos, value: Self::Hash) -> Result<(), Self::Error>;
+
+    /// Removes the node at `pos`.
+    ///
+    /// Idempotent: removing a node that is absent is not an error.
+    fn delete_node(&self, pos: NodePos) -> Result<(), Self::Error>;
 
     /// Reads several nodes in one call.
     ///
@@ -86,39 +94,18 @@ pub trait MmrNodeStore {
     ///
     /// The default loops [`put_node`](Self::put_node); transactional backends
     /// should override it so a leaf write (leaf + ancestors + leaf-count) is
-    /// atomic.
-    fn commit(&self, writes: &[(NodePos, Self::Hash)]) -> Result<(), Self::Error> {
+    /// committed atomically.
+    fn put_nodes(&self, writes: &[(NodePos, Self::Hash)]) -> Result<(), Self::Error> {
         for (pos, value) in writes {
             self.put_node(*pos, *value)?;
         }
         Ok(())
     }
-}
-
-/// A [`MmrNodeStore`] that can also delete nodes, unlocking the pruning
-/// operations on [`StoredMmr`] ([`prune_before`](StoredMmr::prune_before) /
-/// [`prune_after`](StoredMmr::prune_after)).
-///
-/// Opt-in and separate from [`MmrNodeStore`] so append-only backends (which
-/// cannot delete) are unaffected: an implementor adds only
-/// [`delete_node`](Self::delete_node); [`delete_nodes`](Self::delete_nodes) has
-/// a correct default a backend may override for a single round-trip.
-pub trait PrunableNodeStore: MmrNodeStore {
-    /// Removes the node at `pos`.
-    ///
-    /// Idempotent: removing a node that is absent is not an error.
-    fn delete_node(&self, pos: NodePos) -> Result<(), Self::Error>;
 
     /// Removes several nodes in one call.
     ///
     /// The default loops [`delete_node`](Self::delete_node); backends with a
     /// native multi-delete should override it for a single round-trip.
-    ///
-    /// The pruning operations pass the whole set of positions a prune removes —
-    /// a count that scales with how far back the cut reaches (a deep
-    /// [`prune_after`](StoredMmr::prune_after), for instance, can delete most of
-    /// the tree). A backend that cannot issue an arbitrarily large delete in one
-    /// go should chunk internally (e.g. `positions.chunks(N)`) to its own limit.
     fn delete_nodes(&self, positions: &[NodePos]) -> Result<(), Self::Error> {
         for pos in positions {
             self.delete_node(*pos)?;
@@ -183,7 +170,7 @@ where
     /// `leaf_index` may be the current end (an append, which extends the leaf
     /// count) or an existing index (an overwrite). The leaf, its recomputed
     /// ancestors, and any leaf-count bump are written in a single
-    /// [`commit`](MmrNodeStore::commit).
+    /// [`put_nodes`](MmrNodeStore::put_nodes).
     ///
     /// Errors with [`MmrError::LeafGap`] if `leaf_index` is past the append
     /// point (`> leaf_count`), which would skip the leaves in between, and with
@@ -214,7 +201,7 @@ where
         if new_count != old_count {
             writes.push((NodePos::meta(NEXT_INDEX_TAG), MH::Hash::pack_u64(new_count)));
         }
-        self.commit(&writes).map_err(MmrError::Backend)
+        self.put_nodes(&writes).map_err(MmrError::Backend)
     }
 
     /// Generates an inclusion proof for `leaf_index` against the current MMR
@@ -304,12 +291,7 @@ where
     /// are separate calls, and the watermark is written last, so a crash
     /// mid-prune leaves the watermark unchanged and re-running the same call
     /// recomputes the identical (idempotent) delete set and completes.
-    ///
-    /// Requires a [`PrunableNodeStore`] backend.
-    fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>>
-    where
-        Self: PrunableNodeStore,
-    {
+    fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let before_index = before.index();
         if before_index > leaf_count {
@@ -324,7 +306,7 @@ where
         // a leaf is never reported `Pruned` while its path is still present.
         let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
         if before_index > watermark {
-            self.commit(&[(
+            self.put_nodes(&[(
                 NodePos::meta(PRUNED_BEFORE_TAG),
                 MH::Hash::pack_u64(before_index),
             )])
@@ -352,12 +334,7 @@ where
     /// write are separate calls, and the count is written last, so a crash
     /// mid-prune leaves the count unchanged and re-running the same call
     /// recomputes the identical (idempotent) delete set and completes.
-    ///
-    /// Requires a [`PrunableNodeStore`] backend.
-    fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>>
-    where
-        Self: PrunableNodeStore,
-    {
+    fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let keep = after.index();
         if keep > leaf_count {
@@ -379,7 +356,7 @@ where
         if watermark > keep {
             writes.push((NodePos::meta(PRUNED_BEFORE_TAG), MH::Hash::pack_u64(keep)));
         }
-        self.commit(&writes).map_err(MmrError::Backend)
+        self.put_nodes(&writes).map_err(MmrError::Backend)
     }
 
     /// Removes the last leaf and returns its value, or `None` if the MMR is
@@ -395,12 +372,7 @@ where
     /// behind — when a prior [`prune_before(leaf_count)`](Self::prune_before)
     /// full-compaction had already discarded that leaf's hash even though the
     /// count was non-zero; the pop still happens in that case.
-    ///
-    /// Requires a [`PrunableNodeStore`] backend.
-    fn pop_leaf(&self) -> Result<Option<MH::Hash>, MmrError<Self::Error>>
-    where
-        Self: PrunableNodeStore,
-    {
+    fn pop_leaf(&self) -> Result<Option<MH::Hash>, MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let Some(last_index) = leaf_count.checked_sub(1) else {
             return Ok(None);

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -99,17 +99,15 @@ pub trait MmrNodeStore {
     /// override it so the whole batch lands atomically; the default loops
     /// [`delete_node`](Self::delete_node) then [`put_node`](Self::put_node).
     ///
-    /// Deletes are applied before writes, which fixes two things callers rely on:
-    ///
-    /// - If a position appears in both `deletes` and `writes`, the write wins —
-    ///   the node ends up stored, not removed. The derived ops never pass
-    ///   overlapping sets, but the resolution is defined rather than left to the
-    ///   backend so an overriding backend stays consistent with the default.
-    /// - The committing metadata write (the watermark or leaf count that finalizes
-    ///   a prune) is in `writes`, so it lands last. A crash in the
-    ///   non-transactional default therefore leaves that marker unchanged and the
-    ///   op re-runs idempotently; a transactional override makes the whole batch
-    ///   atomic and the ordering moot.
+    /// Durability and atomicity are the backend's concern: a persistent backend
+    /// is expected to override this so the whole batch lands as one unit. The
+    /// in-memory default loops [`delete_node`](Self::delete_node) then
+    /// [`put_node`](Self::put_node) — applying deletes before writes — which
+    /// pins down one thing callers rely on: if a position appears in both
+    /// `deletes` and `writes`, the write wins (the node ends up stored, not
+    /// removed). The derived ops never pass overlapping sets, but defining the
+    /// resolution rather than leaving it to the backend keeps an overriding
+    /// backend consistent with the default.
     fn commit(
         &self,
         writes: &[(NodePos, Self::Hash)],
@@ -323,13 +321,11 @@ where
     /// calls advancing `before` — and converge to the same state. Bounding it that
     /// way is left to the consumer.
     ///
-    /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
-    /// deletes and the watermark write are handed to a single `commit`, so a
-    /// transactional backend applies them as one unit. The non-transactional
-    /// default deletes the nodes first and raises the watermark last, so a leaf
-    /// is never reported `Pruned` while its path is still present, and a crash
-    /// mid-prune leaves the watermark unchanged and re-running the same call
-    /// recomputes the identical (idempotent) delete set and completes.
+    /// The node deletes and the watermark write are handed to a single
+    /// [`commit`](MmrNodeStore::commit), so a transactional backend applies them
+    /// atomically. The operation is also idempotent on its own: the watermark is
+    /// monotonic and the delete set recomputes identically, so re-running the
+    /// same call converges to the same state.
     fn prune_before(&self, before: LeafPos) -> Result<(), MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let before_index = before.index();
@@ -346,7 +342,11 @@ where
             NodePos::meta(PRUNED_BEFORE_TAG),
             MH::Hash::pack_u64(before_index),
         )];
-        let writes = if before_index > watermark { writes } else { &[] };
+        let writes = if before_index > watermark {
+            writes
+        } else {
+            &[]
+        };
         self.commit(writes, &positions).map_err(MmrError::Backend)
     }
 
@@ -376,12 +376,11 @@ where
     /// truncation that drops a huge suffix therefore allocates proportionally; a
     /// consumer bounding peak memory should truncate in steps.
     ///
-    /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
-    /// deletes and the leaf-count write are handed to a single `commit`, so a
-    /// transactional backend applies them as one unit. The non-transactional
-    /// default deletes the nodes first and lowers the leaf count last, so a crash
-    /// mid-prune leaves the count unchanged and re-running the same call
-    /// recomputes the identical (idempotent) delete set and completes.
+    /// The node deletes and the leaf-count write are handed to a single
+    /// [`commit`](MmrNodeStore::commit), so a transactional backend applies them
+    /// atomically. The operation is also idempotent on its own: the delete set
+    /// recomputes identically and the count and watermark settle to the same
+    /// values, so re-running the same call converges to the same state.
     fn prune_after(&self, after: LeafPos) -> Result<(), MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let keep = after.index();

--- a/crates/merkle-store/src/store.rs
+++ b/crates/merkle-store/src/store.rs
@@ -7,7 +7,7 @@ use super::algorithm::{
     write_plan,
 };
 use super::error::MmrError;
-use super::index::{LeafPos, NodePos};
+use super::index::{LeafPos, NodePos, peak_positions};
 
 /// Reserved metadata tag holding the leaf count (== next leaf index).
 const NEXT_INDEX_TAG: u64 = 0;
@@ -355,7 +355,13 @@ where
     /// count, it is clamped down to it.
     ///
     /// Errors with [`MmrError::LeafOutOfRange`] if `after` is past the append
-    /// point (`> leaf_count`).
+    /// point (`> leaf_count`), and with [`MmrError::Pruned`] if `keep` falls
+    /// inside a prefix an earlier `prune_before` already discarded: the new MMR
+    /// would need the peaks of its first `keep` leaves to stay appendable, and
+    /// `prune_before` keeps only the peaks of *its own* cut, so a deeper cut can
+    /// have removed them. Truncating onto a missing prefix would leave a store
+    /// that reports the right leaf count yet cannot append, so it is rejected;
+    /// `keep` at or above the watermark always has its prefix peaks intact.
     ///
     /// Atomicity follows the backend's [`commit`](MmrNodeStore::commit): the node
     /// deletes and the leaf-count write are handed to a single `commit`, so a
@@ -375,13 +381,29 @@ where
         if keep == leaf_count {
             return Ok(());
         }
+        // The truncated store must still be appendable, which needs the peaks of
+        // a `keep`-leaf MMR. A `prune_before` past `keep` can have discarded some
+        // of them, so a `keep` below the watermark may have no intact prefix to
+        // truncate onto; probe those peaks and reject the truncation if any is
+        // gone, rather than commit an unappendable store. At or above the
+        // watermark the peaks are always retained, so skip the probe.
+        let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
+        if keep < watermark {
+            let peaks: Vec<NodePos> = peak_positions(keep).collect();
+            let present = self.get_nodes(&peaks).map_err(MmrError::Backend)?;
+            if present.iter().any(Option::is_none) {
+                return Err(MmrError::Pruned {
+                    index: keep,
+                    pruned_before: watermark,
+                });
+            }
+        }
         let positions: Vec<NodePos> = iter_prune_after_positions(keep, leaf_count).collect();
         // Clamp the watermark to the new count, since no leaf at or above `keep`
         // survives to be reported `Pruned`. Order the writes so the leaf count is
         // the last write: it is the marker that "commits" the truncation, so an
         // interrupted prune that has not yet lowered it re-runs identically.
         let mut writes = Vec::with_capacity(2);
-        let watermark = <Self as StoredMmr<MH>>::pruned_before(self)?;
         if watermark > keep {
             writes.push((NodePos::meta(PRUNED_BEFORE_TAG), MH::Hash::pack_u64(keep)));
         }
@@ -399,9 +421,17 @@ where
     ///
     /// The returned value is the leaf hash read just before removal. It is `None`
     /// when the store is empty, but also — distinct only by the count it leaves
-    /// behind — when a prior [`prune_before(leaf_count)`](Self::prune_before)
-    /// full-compaction had already discarded that leaf's hash even though the
-    /// count was non-zero; the pop still happens in that case.
+    /// behind — when a prior [`prune_before`](Self::prune_before) had already
+    /// discarded that leaf's hash (folded into a surviving peak) even though the
+    /// count is non-zero; the pop still happens in that case.
+    ///
+    /// Errors with [`MmrError::Pruned`] (from [`prune_after`](Self::prune_after))
+    /// when removing the last leaf would truncate onto a prefix whose peaks an
+    /// earlier `prune_before` discarded: the shorter MMR could not be appended to,
+    /// so the pop is refused rather than left to corrupt the store. Whether it
+    /// errors depends on the cut's shape, not merely on a leaf hash being gone —
+    /// a pop can still succeed (returning `None`) when the shorter prefix's peaks
+    /// happen to survive.
     fn pop_leaf(&self) -> Result<Option<MH::Hash>, MmrError<Self::Error>> {
         let leaf_count = <Self as StoredMmr<MH>>::leaf_count(self)?;
         let Some(last_index) = leaf_count.checked_sub(1) else {
@@ -801,6 +831,40 @@ mod tests {
         assert_eq!(watermark(), 0);
     }
 
+    /// Truncating onto a prefix that `prune_before` already discarded is
+    /// rejected: with 4 leaves, `prune_before(4)` keeps only peak `(2,0)`, so
+    /// `prune_after(3)` — which would need the peaks of a 3-leaf MMR (`(1,0)` and
+    /// `(0,2)`, both gone) to stay appendable — fails with `Pruned` and leaves
+    /// the store untouched. A truncation whose prefix peaks survive (here
+    /// `prune_after(4)` after `prune_before(5)`, peak `(2,0)` intact) still works.
+    #[test]
+    fn prune_after_into_pruned_prefix_is_rejected() {
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..4 {
+            append(&store, leaf(i));
+        }
+        prune_before(&store, 4);
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::prune_after(&store, LeafPos::new(3)),
+            Err(MmrError::Pruned {
+                index: 3,
+                pruned_before: 4
+            })
+        ));
+        // Rejected before any mutation: count and watermark are unchanged.
+        assert_eq!(count(&store), 4);
+        assert_eq!(StoredMmr::<Sha256Hasher>::pruned_before(&store).unwrap(), 4);
+
+        // A cut whose prefix peaks survived the earlier `prune_before` is allowed.
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..8 {
+            append(&store, leaf(i));
+        }
+        prune_before(&store, 5); // keeps peaks of 5 leaves: (2,0) and (0,4)
+        prune_after(&store, 4); // needs (2,0), which is intact
+        assert_eq!(count(&store), 4);
+    }
+
     /// `prune_before(leaf_count)` compacts the whole MMR to its current peaks,
     /// and appends afterward still roll forward correctly.
     #[test]
@@ -924,19 +988,40 @@ mod tests {
         assert_eq!(pop(&store), None);
     }
 
-    /// After a full `prune_before` compaction the last leaf's hash is gone, so
-    /// `pop_leaf` reports `None` yet still removes the leaf (count drops).
+    /// After a full `prune_before` compaction, popping the last leaf would
+    /// truncate onto a prefix whose peaks are gone, leaving an unappendable
+    /// store, so `pop_leaf` refuses with `Pruned` instead of dropping the count.
+    /// But a pop whose shorter prefix peaks survive still succeeds: compacting 3
+    /// leaves keeps peak `(1,0)`, which is exactly what a 2-leaf MMR needs, so the
+    /// pop goes through (returning leaf 2's retained hash).
     #[test]
-    fn pop_leaf_after_full_compaction_drops_count() {
+    fn pop_leaf_into_pruned_prefix_is_rejected() {
         let store = MemMmr::<Hash32>::default();
         for i in 0..4 {
             append(&store, leaf(i));
         }
-        // Leaf 3 is a descendant of peak (1,2), so compaction discards its hash.
+        // Compaction keeps only peak (2,0); a 3-leaf MMR needs (1,0) and (0,2),
+        // both discarded, so the pop down to 3 leaves cannot leave an appendable
+        // store.
         prune_before(&store, 4);
         assert_eq!(read_leaf(&store, 3), None);
-        assert_eq!(pop(&store), None);
-        assert_eq!(count(&store), 3);
+        assert!(matches!(
+            StoredMmr::<Sha256Hasher>::pop_leaf(&store),
+            Err(MmrError::Pruned {
+                index: 3,
+                pruned_before: 4
+            })
+        ));
+        assert_eq!(count(&store), 4);
+
+        // A pop whose shorter prefix survives compaction is still allowed.
+        let store = MemMmr::<Hash32>::default();
+        for i in 0..3 {
+            append(&store, leaf(i));
+        }
+        prune_before(&store, 3); // keeps peaks of 3 leaves: (1,0) and (0,2)
+        assert_eq!(pop(&store), Some(leaf(2))); // 2-leaf MMR needs (1,0), intact
+        assert_eq!(count(&store), 2);
     }
 
     /// Exhaustive, deterministic parity for small sizes: our proof's cohashes
@@ -1077,6 +1162,35 @@ mod tests {
                 let fresh_proof = proof_at_size(&fresh, idx, k);
                 prop_assert_eq!(pruned_proof.cohashes(), fresh_proof.cohashes());
             }
+        }
+
+        /// `pop_leaf` unwinds an MMR leaf-by-leaf: each pop returns the last
+        /// appended value, drops the count by one, and leaves a store whose proofs
+        /// match a fresh build of the surviving prefix — down to empty, after
+        /// which it keeps returning `None`.
+        #[test]
+        fn pop_leaf_unwinds_to_fresh_builds((leaves, _size, _index) in leaves_and_query(1..32)) {
+            let n = leaves.len() as u64;
+            let store = MemMmr::<Hash32>::default();
+            for value in &leaves {
+                append(&store, *value);
+            }
+            for k in (0..n).rev() {
+                prop_assert_eq!(pop(&store), Some(leaves[k as usize]));
+                prop_assert_eq!(count(&store), k);
+
+                let fresh = MemMmr::<Hash32>::default();
+                for value in &leaves[..k as usize] {
+                    append(&fresh, *value);
+                }
+                for idx in 0..k {
+                    let popped_proof = proof_at_size(&store, idx, k);
+                    let fresh_proof = proof_at_size(&fresh, idx, k);
+                    prop_assert_eq!(popped_proof.cohashes(), fresh_proof.cohashes());
+                }
+            }
+            prop_assert_eq!(pop(&store), None);
+            prop_assert_eq!(pop(&store), None);
         }
 
         /// After `prune_before(k)` every leaf in `[k, n)` still verifies against


### PR DESCRIPTION
## Description

The node-storing MMR (`node_store` feature, added in #107) only ever grew: every node was retained forever, so a long-lived store had no way to bound its size or roll back. This PR adds pruning, keyed by leaf position.

- **`prune_before`** forgets old history: it keeps only the peaks of the leading prefix (the minimal set still needed to prove later leaves and to keep appending) and drops their descendants. The leaf count is left intact, and a monotonic `pruned_before` watermark is recorded so that proof generation below it returns the new `MmrError::Pruned` rather than `NodeMissing` (which signals a corrupt store).
- **`prune_after`** truncates the MMR to a prefix: it deletes a leaf and everything after it, updates the stored leaf count, and clamps the watermark down to the surviving leaf count. An earlier `prune_before` can have discarded the prefix peaks a truncation would need to stay appendable, so a cut below the watermark is probed and rejected with `MmrError::Pruned` rather than committing an unappendable store.
- **`pop_leaf`** removes just the last leaf and returns its value, the inverse of `append_leaf`. It is a thin convenience over `prune_after` at `leaf_count - 1`, so stack-like consumers can undo the most recent append without computing the index themselves.

Deletion is folded into `MmrNodeStore`: a backend now implements a third method, `delete_node`, and `commit` is widened to take both writes and deletes. A prune (node deletes + watermark/count update) then goes through the same single mutation path as a leaf write, so a transactional backend can make the whole batch atomic in one place.

Durability and atomicity are delegated to the backend's `commit`. Independently of that, the prune operations are idempotent: the watermark is monotonic, the delete sets recompute identically, and the count/watermark settle to the same values, so a consumer that re-runs a prune converges to the same state.

This is **not** bounded-memory pruning: each `prune_*` materializes its full delete set into a `Vec` before handing it to `commit`, so a single prune over a long-lived MMR allocates memory proportional to the number of nodes removed. Because the operations are idempotent, a consumer that needs to bound peak memory can prune in steps (advancing `before`, or truncating in chunks) and converge to the same state; bounding it that way is left to the consumer.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] New or updated tests

## Notes to Reviewers

Intended use: `prune_before` reclaims storage by forgetting old history, `prune_after` removes entries on a reorg by truncating the MMR back to a known-good prefix, and `pop_leaf` undoes a single append.

Note that `MmrNodeStore` is now a three-method contract (`get_node` / `put_node` / `delete_node`) and `commit` takes `(writes, deletes)`, so any existing backend implementation needs updating. `MemMmr` is the only implementor in this repo.

Builds on #107. Suggested reading order:

1. `error.rs` — the new `MmrError::Pruned` variant.
2. `store.rs` — the widened `MmrNodeStore` (`delete_node` plus `commit(writes, deletes)`) and the `prune_before` / `prune_after` / `pop_leaf` methods.
3. `algorithm.rs` — `iter_prune_before_positions` / `iter_prune_after_positions`, which compute what to keep vs. drop.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Builds on #107.
