### PR TITLE
Add `#[gen_proxy]` attr macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4058,6 +4058,8 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,6 +4051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-db-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tokio",
+]
+
+[[package]]
 name = "strata-identifiers"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/codec-tests",
   "crates/codec-utils",
   "crates/crypto",
+  "crates/db-macros",
   "crates/identifiers",
   "crates/l1proto/envelope-fmt",
   "crates/l1proto/txfmt",
@@ -29,6 +30,7 @@ strata-codec-derive = { path = "crates/codec-derive" }
 strata-codec-tests = { path = "crates/codec-tests" }
 strata-codec-utils = { path = "crates/codec-utils" }
 strata-crypto = { path = "crates/crypto" }
+strata-db-macros = { path = "crates/db-macros" }
 strata-identifiers = { path = "crates/identifiers" }
 strata-l1-txfmt = { path = "crates/l1proto/txfmt" }
 strata-logging = { path = "crates/logging" }

--- a/crates/db-macros/Cargo.toml
+++ b/crates/db-macros/Cargo.toml
@@ -14,6 +14,8 @@ syn = { version = "2.0", features = ["full", "derive"] }
 
 [dev-dependencies]
 tokio = { version = "1.37", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 
 [lints]
 workspace = true

--- a/crates/db-macros/Cargo.toml
+++ b/crates/db-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "strata-db-macros"
+version = "0.1.0"
+edition = "2024"
+description = "Procedural macro generating async/blocking proxy handles for DB traits"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full", "derive"] }
+
+[dev-dependencies]
+tokio = { version = "1.37", features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/db-macros/README.md
+++ b/crates/db-macros/README.md
@@ -1,0 +1,52 @@
+# strata-db-macros
+
+Procedural macros for generating async/blocking proxy handles around database traits.
+
+## `#[gen_proxy]`
+
+Attach `#[gen_proxy(error = <ErrorType>)]` to a trait `Foo` to generate:
+
+- a `FooProxy` handle that owns a [`tokio::runtime::Handle`] and an
+  `Arc<dyn Foo + Send + Sync + 'static>`, and
+- a `FooRecv<T, E>` wrapper around the spawned task's join handle.
+
+For each qualifying trait method `foo(&self, args..) -> Result<T, E>`, the proxy
+exposes three variants:
+
+| Variant            | Behavior                                                            |
+| ------------------ | ------------------------------------------------------------------- |
+| `foo_blocking`     | Calls the underlying method inline on the current thread.           |
+| `foo_async`        | Offloads the call to a blocking task via `spawn_blocking`, awaited.  |
+| `foo_chan`         | Spawns the blocking task and returns a `FooRecv` to await later.     |
+
+```rust
+use std::sync::Arc;
+
+use strata_db_macros::gen_proxy;
+use tokio::runtime::Handle;
+
+type DbResult<T> = Result<T, DbError>;
+
+#[gen_proxy(error = DbError)]
+pub trait TaskDb: Send + Sync + 'static {
+    fn get_task(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
+    fn count_tasks(&self) -> DbResult<usize>;
+}
+
+// let proxy = TaskDbProxy::new(Handle::current(), db);
+// let n = proxy.count_tasks_async().await?;
+```
+
+## Requirements & constraints
+
+- The `error = ...` type must implement `From<tokio::task::JoinError>` (a panic in
+  the blocking task surfaces as that error from the `_async`/`_chan` variants).
+- The consuming crate must depend on `tokio` (the generated code references
+  `::tokio`).
+- The trait must be object-safe (the proxy holds a `dyn Foo`). Non-`&self` helper
+  methods need `where Self: Sized`.
+- Only methods that take `&self`, are non-`async`, have no method-level generics,
+  use plain identifier argument patterns, and return a `Result`-shaped type get
+  proxy variants. Other methods remain trait-only.
+- For the `_async`/`_chan` variants, arguments and the success type must be
+  `Send + 'static` (a `spawn_blocking` requirement). `_blocking` has no such bound.

--- a/crates/db-macros/README.md
+++ b/crates/db-macros/README.md
@@ -70,5 +70,7 @@ requires the consuming crate to depend on `tracing`.
 - Only methods that take `&self`, are non-`async`, have no method-level generics,
   use plain identifier argument patterns, and return a `Result`-shaped type get
   proxy variants. Other methods remain trait-only.
+- Annotate a method with `#[gen_proxy(skip)]` to explicitly leave it trait-only even
+  if it would otherwise qualify; the marker is stripped from the emitted trait.
 - For the `_async`/`_chan` variants, arguments and the success type must be
   `Send + 'static` (a `spawn_blocking` requirement). `_blocking` has no such bound.

--- a/crates/db-macros/README.md
+++ b/crates/db-macros/README.md
@@ -37,6 +37,28 @@ pub trait TaskDb: Send + Sync + 'static {
 // let n = proxy.count_tasks_async().await?;
 ```
 
+## Tracing instrumentation
+
+Pass an optional `tracing_component = <string>` argument to instrument each call:
+
+```rust
+#[gen_proxy(error = DbError, tracing_component = "storage:task")]
+pub trait TaskDb: Send + Sync + 'static {
+    fn get_task(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
+}
+```
+
+When set, the underlying call is routed through a private, instrumented shim
+(`#[tracing::instrument(level = "trace", fields(component = "storage:task"))]`), so
+a span is produced for every variant, recording the method arguments and the
+component field — mirroring the legacy `inst_ops` shim instrumentation.
+
+For the `_async`/`_chan` variants the shim runs on a `spawn_blocking` thread, so the
+caller's current span (`tracing::Span::current()`) is captured and re-entered inside
+the task. The method's span is therefore parented to the async task that issued the
+call rather than orphaned on the blocking thread. Setting `tracing_component`
+requires the consuming crate to depend on `tracing`.
+
 ## Requirements & constraints
 
 - The `error = ...` type must implement `From<tokio::task::JoinError>` (a panic in

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -189,7 +189,7 @@ fn is_self_sized_predicate(pred: &syn::WherePredicate) -> bool {
         tb.path
             .segments
             .last()
-            .map_or(false, |s| s.ident == "Sized")
+            .is_some_and(|s| s.ident == "Sized")
     })
 }
 
@@ -210,11 +210,10 @@ fn should_proxy_method(method: &TraitItemFn) -> bool {
     if sig.asyncness.is_some() || !sig.generics.params.is_empty() {
         return false;
     }
-    if let Some(wc) = &sig.generics.where_clause {
-        if wc.predicates.iter().any(is_self_sized_predicate) {
+    if let Some(wc) = &sig.generics.where_clause
+        && wc.predicates.iter().any(is_self_sized_predicate) {
             return false;
         }
-    }
     match sig.inputs.iter().next() {
         Some(FnArg::Receiver(recv)) if recv.reference.is_some() && recv.mutability.is_none() => {}
         _ => return false,

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -2,10 +2,59 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
 use syn::{
     Attribute, FnArg, GenericArgument, ItemTrait, LitStr, Pat, PatType, Path, PathArguments,
-    ReturnType, TraitItem, TraitItemFn, Type,
+    ReturnType, Token, TraitItem, TraitItemFn, Type,
 };
+
+/// Parsed arguments for the [`macro@gen_proxy`] attribute.
+pub(crate) struct GenProxyArgs {
+    /// Required `error = <Path>`: the error type used by the trait's methods.
+    pub(crate) error: Path,
+    /// Optional `tracing_component = <string>`: instruments each method's blocking work.
+    pub(crate) tracing_component: Option<LitStr>,
+}
+
+impl Parse for GenProxyArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let mut error: Option<Path> = None;
+        let mut tracing_component: Option<LitStr> = None;
+
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            if key == "error" {
+                error = Some(input.parse()?);
+            } else if key == "tracing_component" {
+                tracing_component = Some(input.parse()?);
+            } else {
+                return Err(syn::Error::new(
+                    key.span(),
+                    "expected `error` or `tracing_component`",
+                ));
+            }
+
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+
+        let error = error.ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`#[gen_proxy]` requires an `error = <Type>` argument",
+            )
+        })?;
+
+        Ok(Self {
+            error,
+            tracing_component,
+        })
+    }
+}
 
 /// Expands the annotated trait into the original trait plus its proxy and receiver
 /// types.

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -3,8 +3,8 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    FnArg, GenericArgument, ItemTrait, LitStr, Pat, PatType, Path, PathArguments, ReturnType,
-    TraitItem, TraitItemFn, Type,
+    Attribute, FnArg, GenericArgument, ItemTrait, LitStr, Pat, PatType, Path, PathArguments,
+    ReturnType, TraitItem, TraitItemFn, Type,
 };
 
 /// Expands the annotated trait into the original trait plus its proxy and receiver
@@ -39,6 +39,16 @@ pub(crate) fn expand(
             )
         {
             methods.extend(tokens);
+        }
+    }
+
+    // Re-emit the trait with any `#[gen_proxy(skip)]` helper attributes stripped from its
+    // methods. These are inert markers consumed above; leaving them in place would make the
+    // compiler try to resolve `gen_proxy` as an attribute macro on the trait method and fail.
+    let mut item = item.clone();
+    for trait_item in &mut item.items {
+        if let TraitItem::Fn(method) = trait_item {
+            method.attrs.retain(|attr| !is_skip_attr(attr));
         }
     }
 
@@ -119,6 +129,11 @@ fn gen_method(
     tracing_component: Option<&LitStr>,
     vis: &syn::Visibility,
 ) -> Option<TokenStream> {
+    // An explicit `#[gen_proxy(skip)]` opts the method out of proxying entirely.
+    if method.attrs.iter().any(is_skip_attr) {
+        return None;
+    }
+
     let sig = &method.sig;
 
     // Only plain, non-generic, synchronous methods are proxied.
@@ -245,6 +260,21 @@ fn gen_method(
             self.#chan(#(#arg_names),*).recv().await
         }
     })
+}
+
+/// Returns `true` if `attr` is the `#[gen_proxy(skip)]` opt-out marker.
+fn is_skip_attr(attr: &Attribute) -> bool {
+    if !attr.path().is_ident("gen_proxy") {
+        return false;
+    }
+    let mut is_skip = false;
+    let _ = attr.parse_nested_meta(|meta| {
+        if meta.path.is_ident("skip") {
+            is_skip = true;
+        }
+        Ok(())
+    });
+    is_skip
 }
 
 /// Returns the first generic type argument of the last path segment of `ty`, used to

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -1,0 +1,193 @@
+//! Code generation for the [`gen_proxy`](crate::gen_proxy) attribute.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    FnArg, GenericArgument, ItemTrait, Pat, PatType, Path, PathArguments, ReturnType, TraitItem,
+    TraitItemFn, Type,
+};
+
+/// Expands the annotated trait into the original trait plus its proxy and receiver
+/// types.
+pub(crate) fn expand(error_ty: &Path, item: &ItemTrait) -> syn::Result<TokenStream> {
+    if !item.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &item.generics,
+            "`#[gen_proxy]` does not support generic traits",
+        ));
+    }
+
+    let trait_ident = &item.ident;
+    let vis = &item.vis;
+    let proxy_ident = format_ident!("{}Proxy", trait_ident);
+    let recv_ident = format_ident!("{}Recv", trait_ident);
+
+    let mut methods = TokenStream::new();
+    for trait_item in &item.items {
+        if let TraitItem::Fn(method) = trait_item
+            && let Some(tokens) = gen_method(method, trait_ident, &recv_ident, error_ty, vis)
+        {
+            methods.extend(tokens);
+        }
+    }
+
+    let proxy_doc = format!(
+        "Async/blocking proxy handle for the `{trait_ident}` trait.\n\n\
+         Each method is offloaded onto a Tokio blocking task via `spawn_blocking`."
+    );
+    let new_doc = "Creates a new proxy from a runtime handle and a shared trait object.";
+    let recv_doc =
+        format!("Pending result of a `{proxy_ident}` call, awaitable via its `recv` method.");
+    let recv_method_doc = "Awaits the spawned blocking task and returns its result, mapping a join failure \
+         (for example a panic in the task) through `From<JoinError>`.";
+
+    let expanded = quote! {
+        #item
+
+        #[doc = #proxy_doc]
+        #[derive(Clone)]
+        #vis struct #proxy_ident {
+            handle: ::tokio::runtime::Handle,
+            inner: ::std::sync::Arc<
+                dyn #trait_ident + ::core::marker::Send + ::core::marker::Sync + 'static,
+            >,
+        }
+
+        impl ::core::fmt::Debug for #proxy_ident {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.debug_struct(::core::stringify!(#proxy_ident)).finish_non_exhaustive()
+            }
+        }
+
+        impl #proxy_ident {
+            #[doc = #new_doc]
+            #vis fn new(
+                handle: ::tokio::runtime::Handle,
+                inner: ::std::sync::Arc<
+                    dyn #trait_ident + ::core::marker::Send + ::core::marker::Sync + 'static,
+                >,
+            ) -> Self {
+                Self { handle, inner }
+            }
+
+            #methods
+        }
+
+        #[doc = #recv_doc]
+        #[derive(Debug)]
+        #vis struct #recv_ident<T, E> {
+            inner: ::tokio::task::JoinHandle<::core::result::Result<T, E>>,
+        }
+
+        impl<T, E> #recv_ident<T, E>
+        where
+            E: ::core::convert::From<::tokio::task::JoinError>,
+        {
+            #[doc = #recv_method_doc]
+            #vis async fn recv(self) -> ::core::result::Result<T, E> {
+                match self.inner.await {
+                    ::core::result::Result::Ok(v) => v,
+                    ::core::result::Result::Err(join_err) => ::core::result::Result::Err(
+                        <E as ::core::convert::From<::tokio::task::JoinError>>::from(join_err),
+                    ),
+                }
+            }
+        }
+    };
+
+    Ok(expanded)
+}
+
+/// Generates the `_blocking`, `_chan`, and `_async` proxy methods for a single trait
+/// method, or [`None`] if the method does not qualify for proxying.
+fn gen_method(
+    method: &TraitItemFn,
+    trait_ident: &syn::Ident,
+    recv_ident: &syn::Ident,
+    error_ty: &Path,
+    vis: &syn::Visibility,
+) -> Option<TokenStream> {
+    let sig = &method.sig;
+
+    // Only plain, non-generic, synchronous methods are proxied.
+    if sig.asyncness.is_some() || !sig.generics.params.is_empty() {
+        return None;
+    }
+
+    let mut inputs = sig.inputs.iter();
+
+    // The receiver must be `&self`.
+    match inputs.next() {
+        Some(FnArg::Receiver(recv)) if recv.reference.is_some() && recv.mutability.is_none() => {}
+        _ => return None,
+    }
+
+    // Collect the remaining arguments, requiring simple identifier patterns.
+    let mut arg_names = Vec::new();
+    let mut arg_decls = Vec::new();
+    for arg in inputs {
+        let FnArg::Typed(PatType { pat, ty, .. }) = arg else {
+            return None;
+        };
+        let Pat::Ident(pat_ident) = pat.as_ref() else {
+            return None;
+        };
+        let ident = &pat_ident.ident;
+        arg_names.push(ident.clone());
+        arg_decls.push(quote! { #ident: #ty });
+    }
+
+    // The return type must be a `Result`-shaped path; extract its success type.
+    let ReturnType::Type(_, ret_ty) = &sig.output else {
+        return None;
+    };
+    let success_ty = first_generic_type(ret_ty)?;
+
+    let name = &sig.ident;
+    let blocking = format_ident!("{}_blocking", name);
+    let chan = format_ident!("{}_chan", name);
+    let asyncf = format_ident!("{}_async", name);
+
+    let blocking_doc = format!("Blocking variant of `{trait_ident}::{name}`; runs inline.");
+    let chan_doc = format!(
+        "Spawns `{trait_ident}::{name}` on a blocking task, returning a `{recv_ident}` handle."
+    );
+    let async_doc =
+        format!("Async variant of `{trait_ident}::{name}`; awaits a spawned blocking task.");
+
+    Some(quote! {
+        #[doc = #blocking_doc]
+        #vis fn #blocking(&self, #(#arg_decls),*) -> #ret_ty {
+            self.inner.#name(#(#arg_names),*)
+        }
+
+        #[doc = #chan_doc]
+        #vis fn #chan(&self, #(#arg_decls),*) -> #recv_ident<#success_ty, #error_ty> {
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            #recv_ident {
+                inner: self.handle.spawn_blocking(move || inner.#name(#(#arg_names),*)),
+            }
+        }
+
+        #[doc = #async_doc]
+        #vis async fn #asyncf(&self, #(#arg_decls),*) -> #ret_ty {
+            self.#chan(#(#arg_names),*).recv().await
+        }
+    })
+}
+
+/// Returns the first generic type argument of the last path segment of `ty`, used to
+/// recover the success type `T` from a `Result<T, E>` / `DbResult<T>` return type.
+fn first_generic_type(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    args.args.iter().find_map(|arg| match arg {
+        GenericArgument::Type(inner) => Some(inner),
+        _ => None,
+    })
+}

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -73,7 +73,7 @@ pub(crate) fn expand(
     let trait_ident = &item.ident;
     let vis = &item.vis;
     let proxy_ident = format_ident!("{}Proxy", trait_ident);
-    let recv_ident = format_ident!("{}Recv", trait_ident);
+    let recv_ident = format_ident!("{}Fut", trait_ident);
 
     let mut methods = TokenStream::new();
     for trait_item in &item.items {
@@ -225,7 +225,7 @@ fn should_proxy_method(method: &TraitItemFn) -> bool {
     get_first_generic_type(ret_ty).is_some()
 }
 
-/// Generates the `_blocking`, `_chan`, and `_async` proxy methods for a single trait
+/// Generates the `_blocking`, `_fut`, and `_async` proxy methods for a single trait
 /// method, or [`None`] if the method does not qualify for proxying.
 fn gen_method(
     method: &TraitItemFn,
@@ -266,11 +266,11 @@ fn gen_method(
 
     let name = &sig.ident;
     let blocking = format_ident!("{}_blocking", name);
-    let chan = format_ident!("{}_chan", name);
+    let fut = format_ident!("{}_fut", name);
     let asyncf = format_ident!("{}_async", name);
 
     let blocking_doc = format!("Blocking variant of `{trait_ident}::{name}`; runs inline.");
-    let chan_doc = format!(
+    let fut_doc = format!(
         "Spawns `{trait_ident}::{name}` on a blocking task, returning a `{recv_ident}` handle."
     );
     let async_doc =
@@ -290,7 +290,7 @@ fn gen_method(
     let name_str = name.to_string();
     let shim_ident = format_ident!("__{}_shim", name);
 
-    let (shim_fn, blocking_body, chan_body) = if let Some(component) = tracing_component {
+    let (shim_fn, blocking_body, fut_body) = if let Some(component) = tracing_component {
         let shim_fn = quote! {
             #[::tracing::instrument(
                 level = "trace",
@@ -310,7 +310,7 @@ fn gen_method(
             Self::#shim_ident(self.inner.as_ref(), #(#arg_names),*)
         };
 
-        let chan_body = quote! {
+        let fut_body = quote! {
             let inner = ::std::sync::Arc::clone(&self.inner);
             let parent_span = ::tracing::Span::current();
             #recv_ident {
@@ -320,20 +320,20 @@ fn gen_method(
             }
         };
 
-        (Some(shim_fn), blocking_body, chan_body)
+        (Some(shim_fn), blocking_body, fut_body)
     } else {
         let blocking_body = quote! {
             self.inner.#name(#(#arg_names),*)
         };
 
-        let chan_body = quote! {
+        let fut_body = quote! {
             let inner = ::std::sync::Arc::clone(&self.inner);
             #recv_ident {
                 inner: self.handle.spawn_blocking(move || inner.#name(#(#arg_names),*)),
             }
         };
 
-        (None, blocking_body, chan_body)
+        (None, blocking_body, fut_body)
     };
 
     Some(quote! {
@@ -344,14 +344,14 @@ fn gen_method(
             #blocking_body
         }
 
-        #[doc = #chan_doc]
-        #vis fn #chan(&self, #(#arg_decls),*) -> #recv_ident<#success_ty, #error_ty> {
-            #chan_body
+        #[doc = #fut_doc]
+        #vis fn #fut(&self, #(#arg_decls),*) -> #recv_ident<#success_ty, #error_ty> {
+            #fut_body
         }
 
         #[doc = #async_doc]
         #vis async fn #asyncf(&self, #(#arg_decls),*) -> #ret_ty {
-            self.#chan(#(#arg_names),*).recv().await
+            self.#fut(#(#arg_names),*).recv().await
         }
     })
 }

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -186,10 +186,7 @@ fn is_self_sized_predicate(pred: &syn::WherePredicate) -> bool {
         let syn::TypeParamBound::Trait(tb) = b else {
             return false;
         };
-        tb.path
-            .segments
-            .last()
-            .is_some_and(|s| s.ident == "Sized")
+        tb.path.segments.last().is_some_and(|s| s.ident == "Sized")
     })
 }
 
@@ -211,9 +208,10 @@ fn should_proxy_method(method: &TraitItemFn) -> bool {
         return false;
     }
     if let Some(wc) = &sig.generics.where_clause
-        && wc.predicates.iter().any(is_self_sized_predicate) {
-            return false;
-        }
+        && wc.predicates.iter().any(is_self_sized_predicate)
+    {
+        return false;
+    }
     match sig.inputs.iter().next() {
         Some(FnArg::Receiver(recv)) if recv.reference.is_some() && recv.mutability.is_none() => {}
         _ => return false,

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -3,13 +3,17 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    FnArg, GenericArgument, ItemTrait, Pat, PatType, Path, PathArguments, ReturnType, TraitItem,
-    TraitItemFn, Type,
+    FnArg, GenericArgument, ItemTrait, LitStr, Pat, PatType, Path, PathArguments, ReturnType,
+    TraitItem, TraitItemFn, Type,
 };
 
 /// Expands the annotated trait into the original trait plus its proxy and receiver
 /// types.
-pub(crate) fn expand(error_ty: &Path, item: &ItemTrait) -> syn::Result<TokenStream> {
+pub(crate) fn expand(
+    error_ty: &Path,
+    tracing_component: Option<&LitStr>,
+    item: &ItemTrait,
+) -> syn::Result<TokenStream> {
     if !item.generics.params.is_empty() {
         return Err(syn::Error::new_spanned(
             &item.generics,
@@ -25,7 +29,14 @@ pub(crate) fn expand(error_ty: &Path, item: &ItemTrait) -> syn::Result<TokenStre
     let mut methods = TokenStream::new();
     for trait_item in &item.items {
         if let TraitItem::Fn(method) = trait_item
-            && let Some(tokens) = gen_method(method, trait_ident, &recv_ident, error_ty, vis)
+            && let Some(tokens) = gen_method(
+                method,
+                trait_ident,
+                &recv_ident,
+                error_ty,
+                tracing_component,
+                vis,
+            )
         {
             methods.extend(tokens);
         }
@@ -105,6 +116,7 @@ fn gen_method(
     trait_ident: &syn::Ident,
     recv_ident: &syn::Ident,
     error_ty: &Path,
+    tracing_component: Option<&LitStr>,
     vis: &syn::Visibility,
 ) -> Option<TokenStream> {
     let sig = &method.sig;
@@ -155,18 +167,77 @@ fn gen_method(
     let async_doc =
         format!("Async variant of `{trait_ident}::{name}`; awaits a spawned blocking task.");
 
-    Some(quote! {
-        #[doc = #blocking_doc]
-        #vis fn #blocking(&self, #(#arg_decls),*) -> #ret_ty {
-            self.inner.#name(#(#arg_names),*)
-        }
+    // Both the blocking and channel variants invoke the underlying trait method on the
+    // `dyn` instance. When a component is configured, that call goes through a private,
+    // instrumented shim (associated function taking `&dyn Trait`) so a span is produced
+    // for every variant while recording the method arguments and component field —
+    // mirroring the legacy `inst_ops` shims. When not instrumented, the call is made
+    // directly and `::tracing` is never referenced, keeping it an optional dependency.
+    //
+    // For the channel/async paths the shim runs on a `spawn_blocking` thread, so the
+    // caller's current span is captured and re-entered inside the task, parenting the
+    // method's span to the issuing async task rather than orphaning it on the blocking
+    // thread.
+    let name_str = name.to_string();
+    let shim_ident = format_ident!("__{}_shim", name);
 
-        #[doc = #chan_doc]
-        #vis fn #chan(&self, #(#arg_decls),*) -> #recv_ident<#success_ty, #error_ty> {
+    let (shim_fn, blocking_body, chan_body) = if let Some(component) = tracing_component {
+        let shim_fn = quote! {
+            #[::tracing::instrument(
+                level = "trace",
+                name = #name_str,
+                skip(inner),
+                fields(component = #component),
+            )]
+            fn #shim_ident(
+                inner: &(dyn #trait_ident + ::core::marker::Send + ::core::marker::Sync),
+                #(#arg_decls),*
+            ) -> #ret_ty {
+                inner.#name(#(#arg_names),*)
+            }
+        };
+
+        let blocking_body = quote! {
+            Self::#shim_ident(self.inner.as_ref(), #(#arg_names),*)
+        };
+
+        let chan_body = quote! {
+            let inner = ::std::sync::Arc::clone(&self.inner);
+            let parent_span = ::tracing::Span::current();
+            #recv_ident {
+                inner: self.handle.spawn_blocking(move || {
+                    parent_span.in_scope(move || Self::#shim_ident(inner.as_ref(), #(#arg_names),*))
+                }),
+            }
+        };
+
+        (Some(shim_fn), blocking_body, chan_body)
+    } else {
+        let blocking_body = quote! {
+            self.inner.#name(#(#arg_names),*)
+        };
+
+        let chan_body = quote! {
             let inner = ::std::sync::Arc::clone(&self.inner);
             #recv_ident {
                 inner: self.handle.spawn_blocking(move || inner.#name(#(#arg_names),*)),
             }
+        };
+
+        (None, blocking_body, chan_body)
+    };
+
+    Some(quote! {
+        #shim_fn
+
+        #[doc = #blocking_doc]
+        #vis fn #blocking(&self, #(#arg_decls),*) -> #ret_ty {
+            #blocking_body
+        }
+
+        #[doc = #chan_doc]
+        #vis fn #chan(&self, #(#arg_decls),*) -> #recv_ident<#success_ty, #error_ty> {
+            #chan_body
         }
 
         #[doc = #async_doc]

--- a/crates/db-macros/src/expand.rs
+++ b/crates/db-macros/src/expand.rs
@@ -119,6 +119,63 @@ pub(crate) fn expand(
     Ok(expanded)
 }
 
+/// Returns `true` if `pred` is a `where Self: Sized` predicate.
+fn is_self_sized_predicate(pred: &syn::WherePredicate) -> bool {
+    let syn::WherePredicate::Type(pt) = pred else {
+        return false;
+    };
+    let syn::Type::Path(tp) = &pt.bounded_ty else {
+        return false;
+    };
+    if tp.qself.is_some() || tp.path.segments.len() != 1 {
+        return false;
+    }
+    if tp.path.segments[0].ident != "Self" {
+        return false;
+    }
+    pt.bounds.iter().any(|b| {
+        let syn::TypeParamBound::Trait(tb) = b else {
+            return false;
+        };
+        tb.path
+            .segments
+            .last()
+            .map_or(false, |s| s.ident == "Sized")
+    })
+}
+
+/// Returns `true` if `method` qualifies for proxy generation.
+///
+/// A method qualifies when all of the following hold:
+/// - no `#[gen_proxy(skip)]` attribute
+/// - not `async`
+/// - no method-level generic parameters
+/// - no `where Self: Sized` constraint (such methods cannot be dispatched through `dyn Trait`)
+/// - first parameter is `&self`
+/// - return type is a path with at least one generic type argument (i.e. `Result`-shaped)
+fn should_proxy_method(method: &TraitItemFn) -> bool {
+    if method.attrs.iter().any(is_skip_attr) {
+        return false;
+    }
+    let sig = &method.sig;
+    if sig.asyncness.is_some() || !sig.generics.params.is_empty() {
+        return false;
+    }
+    if let Some(wc) = &sig.generics.where_clause {
+        if wc.predicates.iter().any(is_self_sized_predicate) {
+            return false;
+        }
+    }
+    match sig.inputs.iter().next() {
+        Some(FnArg::Receiver(recv)) if recv.reference.is_some() && recv.mutability.is_none() => {}
+        _ => return false,
+    }
+    let ReturnType::Type(_, ret_ty) = &sig.output else {
+        return false;
+    };
+    get_first_generic_type(ret_ty).is_some()
+}
+
 /// Generates the `_blocking`, `_chan`, and `_async` proxy methods for a single trait
 /// method, or [`None`] if the method does not qualify for proxying.
 fn gen_method(
@@ -129,25 +186,13 @@ fn gen_method(
     tracing_component: Option<&LitStr>,
     vis: &syn::Visibility,
 ) -> Option<TokenStream> {
-    // An explicit `#[gen_proxy(skip)]` opts the method out of proxying entirely.
-    if method.attrs.iter().any(is_skip_attr) {
+    if !should_proxy_method(method) {
         return None;
     }
 
     let sig = &method.sig;
-
-    // Only plain, non-generic, synchronous methods are proxied.
-    if sig.asyncness.is_some() || !sig.generics.params.is_empty() {
-        return None;
-    }
-
     let mut inputs = sig.inputs.iter();
-
-    // The receiver must be `&self`.
-    match inputs.next() {
-        Some(FnArg::Receiver(recv)) if recv.reference.is_some() && recv.mutability.is_none() => {}
-        _ => return None,
-    }
+    inputs.next(); // skip `&self` receiver, already validated by `should_proxy_method`
 
     // Collect the remaining arguments, requiring simple identifier patterns.
     let mut arg_names = Vec::new();
@@ -168,7 +213,7 @@ fn gen_method(
     let ReturnType::Type(_, ret_ty) = &sig.output else {
         return None;
     };
-    let success_ty = first_generic_type(ret_ty)?;
+    let success_ty = get_first_generic_type(ret_ty)?;
 
     let name = &sig.ident;
     let blocking = format_ident!("{}_blocking", name);
@@ -279,7 +324,7 @@ fn is_skip_attr(attr: &Attribute) -> bool {
 
 /// Returns the first generic type argument of the last path segment of `ty`, used to
 /// recover the success type `T` from a `Result<T, E>` / `DbResult<T>` return type.
-fn first_generic_type(ty: &Type) -> Option<&Type> {
+fn get_first_generic_type(ty: &Type) -> Option<&Type> {
     let Type::Path(type_path) = ty else {
         return None;
     };

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -59,8 +59,7 @@
 //!   from the emitted trait.
 
 use proc_macro::TokenStream;
-use syn::parse::{Parse, ParseStream};
-use syn::{ItemTrait, LitStr, Path, Token, parse_macro_input};
+use syn::{ItemTrait, parse_macro_input};
 // `tokio`/`tracing`/`tracing-subscriber` are dev-dependencies used only by the `tests/`
 // integration target; these keep the workspace `unused_crate_dependencies` lint happy for
 // the lib-test build.
@@ -68,6 +67,8 @@ use syn::{ItemTrait, LitStr, Path, Token, parse_macro_input};
 use {tokio as _, tracing as _, tracing_subscriber as _};
 
 mod expand;
+
+use expand::GenProxyArgs;
 
 /// Generates a `FooProxy` handle (and `FooRecv` result wrapper) for the annotated
 /// trait `Foo`.
@@ -83,52 +84,4 @@ pub fn gen_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     expand::expand(&args.error, args.tracing_component.as_ref(), &item_trait)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
-}
-
-/// Parsed arguments for the [`macro@gen_proxy`] attribute.
-struct GenProxyArgs {
-    /// Required `error = <Path>`: the error type used by the trait's methods.
-    error: Path,
-    /// Optional `tracing_component = <string>`: instruments each method's blocking work.
-    tracing_component: Option<LitStr>,
-}
-
-impl Parse for GenProxyArgs {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let mut error: Option<Path> = None;
-        let mut tracing_component: Option<LitStr> = None;
-
-        while !input.is_empty() {
-            let key: syn::Ident = input.parse()?;
-            input.parse::<Token![=]>()?;
-
-            if key == "error" {
-                error = Some(input.parse()?);
-            } else if key == "tracing_component" {
-                tracing_component = Some(input.parse()?);
-            } else {
-                return Err(syn::Error::new(
-                    key.span(),
-                    "expected `error` or `tracing_component`",
-                ));
-            }
-
-            if input.is_empty() {
-                break;
-            }
-            input.parse::<Token![,]>()?;
-        }
-
-        let error = error.ok_or_else(|| {
-            syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "`#[gen_proxy]` requires an `error = <Type>` argument",
-            )
-        })?;
-
-        Ok(Self {
-            error,
-            tracing_component,
-        })
-    }
 }

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -3,7 +3,7 @@
 //! The [`macro@gen_proxy`] attribute is attached to a trait `Foo` and generates a
 //! `FooProxy` handle that offloads each trait method onto a Tokio blocking task via
 //! `tokio::runtime::Handle::spawn_blocking`, exposing async, blocking, and
-//! channel-style variants of every method.
+//! future-style variants of every method.
 //!
 //! # Example
 //!
@@ -23,13 +23,13 @@
 //!
 //! // Generated:
 //! //   pub struct TaskDbProxy { /* Handle + Arc<dyn TaskDb> */ }
-//! //   pub struct TaskDbRecv<T, E> { /* wraps a JoinHandle */ }
+//! //   pub struct TaskDbFut<T, E> { /* wraps a JoinHandle */ }
 //! //
 //! //   impl TaskDbProxy {
 //! //       pub fn new(handle: Handle, inner: Arc<dyn TaskDb + Send + Sync + 'static>) -> Self;
 //! //       pub async fn get_task_async(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
 //! //       pub fn get_task_blocking(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
-//! //       pub fn get_task_chan(&self, key: Vec<u8>) -> TaskDbRecv<Option<Vec<u8>>, DbError>;
+//! //       pub fn get_task_fut(&self, key: Vec<u8>) -> TaskDbFut<Option<Vec<u8>>, DbError>;
 //! //       // ...same trio for count_tasks
 //! //   }
 //! ```
@@ -70,7 +70,7 @@ mod expand;
 
 use expand::GenProxyArgs;
 
-/// Generates a `FooProxy` handle (and `FooRecv` result wrapper) for the annotated
+/// Generates a `FooProxy` handle (and `FooFut` result wrapper) for the annotated
 /// trait `Foo`.
 ///
 /// Takes a required `error = <Path>` argument naming the error type used by the trait's

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -55,6 +55,9 @@
 //!   identifier argument patterns, and return a `Result`-shaped type (a path such as `Result<T, E>`
 //!   or `DbResult<T>` carrying at least one generic type argument) get proxy variants. Other
 //!   methods remain trait-only.
+//! - A qualifying method can be explicitly opted out of proxying by annotating it with
+//!   `#[gen_proxy(skip)]`; the method then remains trait-only and the marker attribute is stripped
+//!   from the emitted trait.
 
 use proc_macro::TokenStream;
 use syn::parse::{Parse, ParseStream};

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The [`macro@gen_proxy`] attribute is attached to a trait `Foo` and generates a
 //! `FooProxy` handle that offloads each trait method onto a Tokio blocking task via
-//! [`tokio::runtime::Handle::spawn_blocking`], exposing async, blocking, and
+//! `tokio::runtime::Handle::spawn_blocking`, exposing async, blocking, and
 //! channel-style variants of every method.
 //!
 //! # Example
@@ -40,15 +40,14 @@
 //! - `tracing_component = <string>` (optional): when set, each method's blocking work is wrapped in
 //!   a `#[tracing::instrument(level = "trace", fields(component = <string>))]` span (mirroring the
 //!   legacy `inst_ops` shim instrumentation). For the async and channel variants, the caller's
-//!   current span ([`tracing::Span::current`]) is captured and re-entered inside the
-//!   `spawn_blocking` task, so the method's span is parented to the async task that issued the call
-//!   rather than orphaned on the blocking thread. Requires the consuming crate to depend on
-//!   `tracing`.
+//!   current span (`tracing::Span::current`) is captured and re-entered inside the `spawn_blocking`
+//!   task, so the method's span is parented to the async task that issued the call rather than
+//!   orphaned on the blocking thread. Requires the consuming crate to depend on `tracing`.
 //!
 //! # Requirements
 //!
-//! - The error type passed to `error = ...` must implement `From<`[`tokio::task::JoinError`]`>`
-//!   (this surfaces a panic in the blocking task as an error from the async/channel variants).
+//! - The error type passed to `error = ...` must implement `From<tokio::task::JoinError>` (this
+//!   surfaces a panic in the blocking task as an error from the async/channel variants).
 //! - The generated code references `::tokio`, so the consuming crate must depend on `tokio`. When
 //!   `tracing_component` is set, it also references `::tracing`.
 //! - Only methods that take `&self`, are non-`async`, have no method-level generics, use plain

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -1,0 +1,105 @@
+//! Procedural macro for generating async/blocking proxy handles around database traits.
+//!
+//! The [`macro@gen_proxy`] attribute is attached to a trait `Foo` and generates a
+//! `FooProxy` handle that offloads each trait method onto a Tokio blocking task via
+//! [`tokio::runtime::Handle::spawn_blocking`], exposing async, blocking, and
+//! channel-style variants of every method.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//!
+//! use strata_db_macros::gen_proxy;
+//! use tokio::runtime::Handle;
+//!
+//! type DbResult<T> = Result<T, DbError>;
+//!
+//! #[gen_proxy(error = DbError)]
+//! pub trait TaskDb: Send + Sync + 'static {
+//!     fn get_task(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
+//!     fn count_tasks(&self) -> DbResult<usize>;
+//! }
+//!
+//! // Generated:
+//! //   pub struct TaskDbProxy { /* Handle + Arc<dyn TaskDb> */ }
+//! //   pub struct TaskDbRecv<T, E> { /* wraps a JoinHandle */ }
+//! //
+//! //   impl TaskDbProxy {
+//! //       pub fn new(handle: Handle, inner: Arc<dyn TaskDb + Send + Sync + 'static>) -> Self;
+//! //       pub async fn get_task_async(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
+//! //       pub fn get_task_blocking(&self, key: Vec<u8>) -> DbResult<Option<Vec<u8>>>;
+//! //       pub fn get_task_chan(&self, key: Vec<u8>) -> TaskDbRecv<Option<Vec<u8>>, DbError>;
+//! //       // ...same trio for count_tasks
+//! //   }
+//! ```
+//!
+//! # Requirements
+//!
+//! - The error type passed to `error = ...` must implement `From<`[`tokio::task::JoinError`]`>`
+//!   (this surfaces a panic in the blocking task as an error from the async/channel variants).
+//! - The generated code references `::tokio`, so the consuming crate must depend on `tokio`.
+//! - Only methods that take `&self`, are non-`async`, have no method-level generics, use plain
+//!   identifier argument patterns, and return a `Result`-shaped type (a path such as `Result<T, E>`
+//!   or `DbResult<T>` carrying at least one generic type argument) get proxy variants. Other
+//!   methods remain trait-only.
+
+use proc_macro::TokenStream;
+use syn::parse::{Parse, ParseStream};
+use syn::{ItemTrait, Path, Token, parse_macro_input};
+// `tokio` is a dev-dependency used only by the `tests/` integration target; this
+// keeps the workspace `unused_crate_dependencies` lint happy for the lib-test build.
+#[cfg(test)]
+use tokio as _;
+
+mod expand;
+
+/// Generates a `FooProxy` handle (and `FooRecv` result wrapper) for the annotated
+/// trait `Foo`.
+///
+/// Takes a single required argument, `error = <Path>`, naming the error type used by
+/// the trait's methods. See the [crate-level docs](crate) for details and an example.
+#[proc_macro_attribute]
+pub fn gen_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as GenProxyArgs);
+    let item_trait = parse_macro_input!(item as ItemTrait);
+
+    expand::expand(&args.error, &item_trait)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+/// Parsed arguments for the [`macro@gen_proxy`] attribute: `error = <Path>`.
+struct GenProxyArgs {
+    error: Path,
+}
+
+impl Parse for GenProxyArgs {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        if input.is_empty() {
+            return Err(input.error("`#[gen_proxy]` requires an `error = <Type>` argument"));
+        }
+
+        let key: syn::Ident = input.parse()?;
+        if key != "error" {
+            return Err(syn::Error::new(
+                key.span(),
+                "expected `error = <Type>` argument",
+            ));
+        }
+
+        input.parse::<Token![=]>()?;
+        let error: Path = input.parse()?;
+
+        // Tolerate an optional trailing comma.
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+        }
+
+        if !input.is_empty() {
+            return Err(input.error("unexpected tokens after `error = <Type>`"));
+        }
+
+        Ok(Self { error })
+    }
+}

--- a/crates/db-macros/src/lib.rs
+++ b/crates/db-macros/src/lib.rs
@@ -34,11 +34,23 @@
 //! //   }
 //! ```
 //!
+//! # Arguments
+//!
+//! - `error = <Path>` (required): the error type used by the trait's methods.
+//! - `tracing_component = <string>` (optional): when set, each method's blocking work is wrapped in
+//!   a `#[tracing::instrument(level = "trace", fields(component = <string>))]` span (mirroring the
+//!   legacy `inst_ops` shim instrumentation). For the async and channel variants, the caller's
+//!   current span ([`tracing::Span::current`]) is captured and re-entered inside the
+//!   `spawn_blocking` task, so the method's span is parented to the async task that issued the call
+//!   rather than orphaned on the blocking thread. Requires the consuming crate to depend on
+//!   `tracing`.
+//!
 //! # Requirements
 //!
 //! - The error type passed to `error = ...` must implement `From<`[`tokio::task::JoinError`]`>`
 //!   (this surfaces a panic in the blocking task as an error from the async/channel variants).
-//! - The generated code references `::tokio`, so the consuming crate must depend on `tokio`.
+//! - The generated code references `::tokio`, so the consuming crate must depend on `tokio`. When
+//!   `tracing_component` is set, it also references `::tracing`.
 //! - Only methods that take `&self`, are non-`async`, have no method-level generics, use plain
 //!   identifier argument patterns, and return a `Result`-shaped type (a path such as `Result<T, E>`
 //!   or `DbResult<T>` carrying at least one generic type argument) get proxy variants. Other
@@ -46,60 +58,75 @@
 
 use proc_macro::TokenStream;
 use syn::parse::{Parse, ParseStream};
-use syn::{ItemTrait, Path, Token, parse_macro_input};
-// `tokio` is a dev-dependency used only by the `tests/` integration target; this
-// keeps the workspace `unused_crate_dependencies` lint happy for the lib-test build.
+use syn::{ItemTrait, LitStr, Path, Token, parse_macro_input};
+// `tokio`/`tracing`/`tracing-subscriber` are dev-dependencies used only by the `tests/`
+// integration target; these keep the workspace `unused_crate_dependencies` lint happy for
+// the lib-test build.
 #[cfg(test)]
-use tokio as _;
+use {tokio as _, tracing as _, tracing_subscriber as _};
 
 mod expand;
 
 /// Generates a `FooProxy` handle (and `FooRecv` result wrapper) for the annotated
 /// trait `Foo`.
 ///
-/// Takes a single required argument, `error = <Path>`, naming the error type used by
-/// the trait's methods. See the [crate-level docs](crate) for details and an example.
+/// Takes a required `error = <Path>` argument naming the error type used by the trait's
+/// methods, and an optional `tracing_component = <string>` argument that instruments each
+/// method's blocking work. See the [crate-level docs](crate) for details and an example.
 #[proc_macro_attribute]
 pub fn gen_proxy(attr: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(attr as GenProxyArgs);
     let item_trait = parse_macro_input!(item as ItemTrait);
 
-    expand::expand(&args.error, &item_trait)
+    expand::expand(&args.error, args.tracing_component.as_ref(), &item_trait)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
 
-/// Parsed arguments for the [`macro@gen_proxy`] attribute: `error = <Path>`.
+/// Parsed arguments for the [`macro@gen_proxy`] attribute.
 struct GenProxyArgs {
+    /// Required `error = <Path>`: the error type used by the trait's methods.
     error: Path,
+    /// Optional `tracing_component = <string>`: instruments each method's blocking work.
+    tracing_component: Option<LitStr>,
 }
 
 impl Parse for GenProxyArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        if input.is_empty() {
-            return Err(input.error("`#[gen_proxy]` requires an `error = <Type>` argument"));
-        }
+        let mut error: Option<Path> = None;
+        let mut tracing_component: Option<LitStr> = None;
 
-        let key: syn::Ident = input.parse()?;
-        if key != "error" {
-            return Err(syn::Error::new(
-                key.span(),
-                "expected `error = <Type>` argument",
-            ));
-        }
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
 
-        input.parse::<Token![=]>()?;
-        let error: Path = input.parse()?;
+            if key == "error" {
+                error = Some(input.parse()?);
+            } else if key == "tracing_component" {
+                tracing_component = Some(input.parse()?);
+            } else {
+                return Err(syn::Error::new(
+                    key.span(),
+                    "expected `error` or `tracing_component`",
+                ));
+            }
 
-        // Tolerate an optional trailing comma.
-        if input.peek(Token![,]) {
+            if input.is_empty() {
+                break;
+            }
             input.parse::<Token![,]>()?;
         }
 
-        if !input.is_empty() {
-            return Err(input.error("unexpected tokens after `error = <Type>`"));
-        }
+        let error = error.ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`#[gen_proxy]` requires an `error = <Type>` argument",
+            )
+        })?;
 
-        Ok(Self { error })
+        Ok(Self {
+            error,
+            tracing_component,
+        })
     }
 }

--- a/crates/db-macros/tests/instrumentation.rs
+++ b/crates/db-macros/tests/instrumentation.rs
@@ -67,7 +67,7 @@ async fn instrumented_variants_agree() {
 
     assert_eq!(proxy.record_blocking(5).unwrap(), 5);
     assert_eq!(proxy.record_async(3).await.unwrap(), 8);
-    assert_eq!(proxy.total_chan().recv().await.unwrap(), 8);
+    assert_eq!(proxy.total_fut().recv().await.unwrap(), 8);
 }
 
 // Captures `(span name, parent span name)` for every span created under the global
@@ -123,11 +123,11 @@ async fn instrumented_span_is_parented_to_caller() {
 
     let proxy = metric_proxy();
 
-    // Issue the call from within a known parent span. `record_chan` captures the current
+    // Issue the call from within a known parent span. `record_fut` captures the current
     // span synchronously (here, `caller_parent`); the spawned shim re-enters it before
     // creating the `record` span on the blocking thread.
     let parent = tracing::info_span!("caller_parent");
-    let pending = parent.in_scope(|| proxy.record_chan(5));
+    let pending = parent.in_scope(|| proxy.record_fut(5));
     assert_eq!(pending.recv().await.unwrap(), 5);
 
     assert_record_span_parented_to("caller_parent");
@@ -145,12 +145,12 @@ async fn instrumented_span_generated_for_every_entrypoint() {
     // span is created directly under the ambient current span.
     tracing::info_span!("caller_blocking").in_scope(|| proxy.record_blocking(1).unwrap());
 
-    // `_chan` captures the current span synchronously and re-enters it on the blocking thread.
-    let pending = tracing::info_span!("caller_chan").in_scope(|| proxy.record_chan(1));
+    // `_fut` captures the current span synchronously and re-enters it on the blocking thread.
+    let pending = tracing::info_span!("caller_fut").in_scope(|| proxy.record_fut(1));
     pending.recv().await.unwrap();
 
-    // `_async` delegates to `_chan`, but the captured span must survive across the await:
-    // instrument the future so the caller span is entered when the inner `_chan` call reads
+    // `_async` delegates to `_fut`, but the captured span must survive across the await:
+    // instrument the future so the caller span is entered when the inner `_fut` call reads
     // `Span::current()`.
     proxy
         .record_async(1)
@@ -159,7 +159,7 @@ async fn instrumented_span_generated_for_every_entrypoint() {
         .unwrap();
 
     // Every entrypoint must have produced a `record` span parented to its own caller.
-    for caller in ["caller_blocking", "caller_chan", "caller_async"] {
+    for caller in ["caller_blocking", "caller_fut", "caller_async"] {
         assert_record_span_parented_to(caller);
     }
 }

--- a/crates/db-macros/tests/instrumentation.rs
+++ b/crates/db-macros/tests/instrumentation.rs
@@ -1,0 +1,165 @@
+//! Integration tests for the `tracing_component` instrumentation of `#[gen_proxy]`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use strata_db_macros::gen_proxy;
+use tokio::runtime::Handle;
+// `proc_macro2`/`quote`/`syn` are normal dependencies of `strata-db-macros` (the
+// proc-macro crate) and are visible to — but unused by — this integration target;
+// silence the workspace `unused_crate_dependencies` lint.
+use {proc_macro2 as _, quote as _, syn as _};
+
+/// Result alias mirroring the `DbResult<T>` shape used by real database traits.
+type DbResult<T> = Result<T, DbError>;
+
+/// Error type that can absorb a blocking-task join failure.
+#[derive(Debug)]
+enum DbError {
+    // The payload is only surfaced via `Debug`; no test in this file inspects it.
+    #[expect(dead_code, reason = "join detail only read through Debug")]
+    Join(String),
+}
+
+impl From<tokio::task::JoinError> for DbError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        DbError::Join(err.to_string())
+    }
+}
+
+// An instrumented trait: the `tracing_component` argument wraps each method's blocking
+// work in a tracing span. This exercises that the instrumented codegen compiles and
+// behaves identically to the uninstrumented variant.
+#[gen_proxy(error = DbError, tracing_component = "test:metric")]
+trait MetricDb: Send + Sync + 'static {
+    /// Records a value and returns the running total.
+    fn record(&self, value: u64) -> DbResult<u64>;
+
+    /// Returns the running total.
+    fn total(&self) -> DbResult<u64>;
+}
+
+/// In-memory counter backing the trait.
+struct MemCounter {
+    value: AtomicU64,
+}
+
+impl MetricDb for MemCounter {
+    fn record(&self, value: u64) -> DbResult<u64> {
+        Ok(self.value.fetch_add(value, Ordering::SeqCst) + value)
+    }
+
+    fn total(&self) -> DbResult<u64> {
+        Ok(self.value.load(Ordering::SeqCst))
+    }
+}
+
+fn metric_proxy() -> MetricDbProxy {
+    let db = Arc::new(MemCounter {
+        value: AtomicU64::new(0),
+    });
+    MetricDbProxy::new(Handle::current(), db)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instrumented_variants_agree() {
+    let proxy = metric_proxy();
+
+    assert_eq!(proxy.record_blocking(5).unwrap(), 5);
+    assert_eq!(proxy.record_async(3).await.unwrap(), 8);
+    assert_eq!(proxy.total_chan().recv().await.unwrap(), 8);
+}
+
+// Captures `(span name, parent span name)` for every span created under the global
+// subscriber, used to assert cross-thread span parenting.
+static CAPTURED_SPANS: std::sync::Mutex<Vec<(String, Option<String>)>> =
+    std::sync::Mutex::new(Vec::new());
+
+struct CaptureLayer;
+
+impl<S> tracing_subscriber::Layer<S> for CaptureLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let name = span.name().to_string();
+            let parent = span.parent().map(|p| p.name().to_string());
+            CAPTURED_SPANS.lock().unwrap().push((name, parent));
+        }
+    }
+}
+
+/// Installs the global `CaptureLayer` subscriber so spans created on `spawn_blocking`
+/// threads are recorded too. Idempotent across tests: only the first call wins, but once
+/// installed the layer captures spans process-wide.
+fn install_capturing_subscriber() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer);
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+/// Asserts that a `record` span parented to `parent_name` was captured. Uses `any` so it is
+/// robust to spans emitted by other concurrently-running tests sharing `CAPTURED_SPANS`.
+fn assert_record_span_parented_to(parent_name: &str) {
+    let captured = CAPTURED_SPANS.lock().unwrap();
+    assert!(
+        captured
+            .iter()
+            .any(|(name, parent)| name == "record" && parent.as_deref() == Some(parent_name)),
+        "expected a `record` span parented to `{parent_name}`, got: {captured:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instrumented_span_is_parented_to_caller() {
+    install_capturing_subscriber();
+
+    let proxy = metric_proxy();
+
+    // Issue the call from within a known parent span. `record_chan` captures the current
+    // span synchronously (here, `caller_parent`); the spawned shim re-enters it before
+    // creating the `record` span on the blocking thread.
+    let parent = tracing::info_span!("caller_parent");
+    let pending = parent.in_scope(|| proxy.record_chan(5));
+    assert_eq!(pending.recv().await.unwrap(), 5);
+
+    assert_record_span_parented_to("caller_parent");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instrumented_span_generated_for_every_entrypoint() {
+    use tracing::Instrument;
+
+    install_capturing_subscriber();
+
+    let proxy = metric_proxy();
+
+    // `_blocking` runs the instrumented shim inline on the calling thread, so its `record`
+    // span is created directly under the ambient current span.
+    tracing::info_span!("caller_blocking").in_scope(|| proxy.record_blocking(1).unwrap());
+
+    // `_chan` captures the current span synchronously and re-enters it on the blocking thread.
+    let pending = tracing::info_span!("caller_chan").in_scope(|| proxy.record_chan(1));
+    pending.recv().await.unwrap();
+
+    // `_async` delegates to `_chan`, but the captured span must survive across the await:
+    // instrument the future so the caller span is entered when the inner `_chan` call reads
+    // `Span::current()`.
+    proxy
+        .record_async(1)
+        .instrument(tracing::info_span!("caller_async"))
+        .await
+        .unwrap();
+
+    // Every entrypoint must have produced a `record` span parented to its own caller.
+    for caller in ["caller_blocking", "caller_chan", "caller_async"] {
+        assert_record_span_parented_to(caller);
+    }
+}

--- a/crates/db-macros/tests/proxy.rs
+++ b/crates/db-macros/tests/proxy.rs
@@ -45,7 +45,7 @@ trait CounterDb: Send + Sync + 'static {
     fn boom(&self) -> DbResult<u64>;
 
     /// Qualifies for proxying but is explicitly opted out via `#[gen_proxy(skip)]`,
-    /// so only the trait method exists (no `*_blocking`/`*_async`/`*_chan` variants).
+    /// so only the trait method exists (no `*_blocking`/`*_async`/`*_fut` variants).
     #[gen_proxy(skip)]
     #[expect(dead_code, reason = "skipped and unused")]
     fn skipped(&self) -> DbResult<u64>;
@@ -102,7 +102,7 @@ fn proxy() -> CounterDbProxy {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn blocking_async_and_chan_variants_agree() {
+async fn blocking_async_and_fut_variants_agree() {
     let proxy = proxy();
 
     // Blocking runs inline on the calling thread.
@@ -111,8 +111,8 @@ async fn blocking_async_and_chan_variants_agree() {
     // Async offloads to a blocking task and awaits it.
     assert_eq!(proxy.increment_async(3).await.unwrap(), 8);
 
-    // Channel variant returns a handle awaited via `recv`.
-    let pending = proxy.get_chan();
+    // Future variant returns a handle awaited via `recv`.
+    let pending = proxy.get_fut();
     assert_eq!(pending.recv().await.unwrap(), 8);
 }
 
@@ -130,7 +130,7 @@ async fn domain_error_propagates() {
     let proxy = proxy();
     assert!(matches!(proxy.fail_async().await, Err(DbError::NotFound)));
     assert!(matches!(
-        proxy.fail_chan().recv().await,
+        proxy.fail_fut().recv().await,
         Err(DbError::NotFound)
     ));
 }

--- a/crates/db-macros/tests/proxy.rs
+++ b/crates/db-macros/tests/proxy.rs
@@ -43,6 +43,12 @@ trait CounterDb: Send + Sync + 'static {
     /// Panics (exercises the `JoinError` mapping path).
     fn boom(&self) -> DbResult<u64>;
 
+    /// Qualifies for proxying but is explicitly opted out via `#[gen_proxy(skip)]`,
+    /// so only the trait method exists (no `*_blocking`/`*_async`/`*_chan` variants).
+    #[gen_proxy(skip)]
+    #[expect(dead_code, reason = "skipped and unused")]
+    fn skipped(&self) -> DbResult<u64>;
+
     /// A non-`&self` method that should be left trait-only, not proxied.
     ///
     /// It carries `where Self: Sized` so the trait stays object-safe (the proxy
@@ -80,6 +86,10 @@ impl CounterDb for MemCounter {
 
     fn boom(&self) -> DbResult<u64> {
         panic!("boom")
+    }
+
+    fn skipped(&self) -> DbResult<u64> {
+        Ok(42)
     }
 }
 

--- a/crates/db-macros/tests/proxy.rs
+++ b/crates/db-macros/tests/proxy.rs
@@ -147,3 +147,93 @@ fn non_self_method_is_not_proxied() {
     // `describe` has no `&self` receiver, so only the trait method exists.
     assert_eq!(<MemCounter as CounterDb>::describe(), "counter");
 }
+
+// An instrumented trait: the `tracing_component` argument wraps each method's blocking
+// work in a tracing span. This exercises that the instrumented codegen compiles and
+// behaves identically to the uninstrumented variant.
+#[gen_proxy(error = DbError, tracing_component = "test:metric")]
+trait MetricDb: Send + Sync + 'static {
+    /// Records a value and returns the running total.
+    fn record(&self, value: u64) -> DbResult<u64>;
+
+    /// Returns the running total.
+    fn total(&self) -> DbResult<u64>;
+}
+
+impl MetricDb for MemCounter {
+    fn record(&self, value: u64) -> DbResult<u64> {
+        Ok(self.value.fetch_add(value, Ordering::SeqCst) + value)
+    }
+
+    fn total(&self) -> DbResult<u64> {
+        Ok(self.value.load(Ordering::SeqCst))
+    }
+}
+
+fn metric_proxy() -> MetricDbProxy {
+    let db = Arc::new(MemCounter {
+        value: AtomicU64::new(0),
+    });
+    MetricDbProxy::new(Handle::current(), db)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instrumented_variants_agree() {
+    let proxy = metric_proxy();
+
+    assert_eq!(proxy.record_blocking(5).unwrap(), 5);
+    assert_eq!(proxy.record_async(3).await.unwrap(), 8);
+    assert_eq!(proxy.total_chan().recv().await.unwrap(), 8);
+}
+
+// Captures `(span name, parent span name)` for every span created under the global
+// subscriber, used to assert cross-thread span parenting.
+static CAPTURED_SPANS: std::sync::Mutex<Vec<(String, Option<String>)>> =
+    std::sync::Mutex::new(Vec::new());
+
+struct CaptureLayer;
+
+impl<S> tracing_subscriber::Layer<S> for CaptureLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            let name = span.name().to_string();
+            let parent = span.parent().map(|p| p.name().to_string());
+            CAPTURED_SPANS.lock().unwrap().push((name, parent));
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn instrumented_span_is_parented_to_caller() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    // Install a global subscriber so spans created on the `spawn_blocking` thread are
+    // recorded too. Only this test sets one; ignore the error if it is already set.
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer);
+    let _ = tracing::subscriber::set_global_default(subscriber);
+
+    let proxy = metric_proxy();
+
+    // Issue the call from within a known parent span. `record_chan` captures the current
+    // span synchronously (here, `caller_parent`); the spawned shim re-enters it before
+    // creating the `record` span on the blocking thread.
+    let parent = tracing::info_span!("caller_parent");
+    let pending = parent.in_scope(|| proxy.record_chan(5));
+    assert_eq!(pending.recv().await.unwrap(), 5);
+
+    let captured = CAPTURED_SPANS.lock().unwrap();
+    assert!(
+        captured
+            .iter()
+            .any(|(name, parent)| name == "record" && parent.as_deref() == Some("caller_parent")),
+        "expected a `record` span parented to `caller_parent`, got: {captured:?}",
+    );
+}

--- a/crates/db-macros/tests/proxy.rs
+++ b/crates/db-macros/tests/proxy.rs
@@ -1,0 +1,149 @@
+//! Integration tests for the `#[gen_proxy]` attribute macro.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use strata_db_macros::gen_proxy;
+use tokio::runtime::Handle;
+// `proc_macro2`/`quote`/`syn` are normal dependencies of `strata-db-macros` (the
+// proc-macro crate) and are visible to — but unused by — this integration target;
+// silence the workspace `unused_crate_dependencies` lint.
+use {proc_macro2 as _, quote as _, syn as _};
+
+/// Result alias mirroring the `DbResult<T>` shape used by real database traits.
+type DbResult<T> = Result<T, DbError>;
+
+/// Error type that can absorb a blocking-task join failure.
+#[derive(Debug)]
+enum DbError {
+    NotFound,
+    Join(String),
+}
+
+impl From<tokio::task::JoinError> for DbError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        DbError::Join(err.to_string())
+    }
+}
+
+#[gen_proxy(error = DbError)]
+trait CounterDb: Send + Sync + 'static {
+    /// Adds `by` to the counter and returns the new value.
+    fn increment(&self, by: u64) -> DbResult<u64>;
+
+    /// Returns the current counter value.
+    fn get(&self) -> DbResult<u64>;
+
+    /// Resets the counter to zero (exercises the unit-success path).
+    fn reset(&self) -> DbResult<()>;
+
+    /// Always fails (exercises the domain-error path).
+    fn fail(&self) -> DbResult<u64>;
+
+    /// Panics (exercises the `JoinError` mapping path).
+    fn boom(&self) -> DbResult<u64>;
+
+    /// A non-`&self` method that should be left trait-only, not proxied.
+    ///
+    /// It carries `where Self: Sized` so the trait stays object-safe (the proxy
+    /// holds a `dyn CounterDb`).
+    fn describe() -> &'static str
+    where
+        Self: Sized,
+    {
+        "counter"
+    }
+}
+
+/// In-memory counter backing the trait.
+struct MemCounter {
+    value: AtomicU64,
+}
+
+impl CounterDb for MemCounter {
+    fn increment(&self, by: u64) -> DbResult<u64> {
+        Ok(self.value.fetch_add(by, Ordering::SeqCst) + by)
+    }
+
+    fn get(&self) -> DbResult<u64> {
+        Ok(self.value.load(Ordering::SeqCst))
+    }
+
+    fn reset(&self) -> DbResult<()> {
+        self.value.store(0, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn fail(&self) -> DbResult<u64> {
+        Err(DbError::NotFound)
+    }
+
+    fn boom(&self) -> DbResult<u64> {
+        panic!("boom")
+    }
+}
+
+fn proxy() -> CounterDbProxy {
+    let db = Arc::new(MemCounter {
+        value: AtomicU64::new(0),
+    });
+    CounterDbProxy::new(Handle::current(), db)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocking_async_and_chan_variants_agree() {
+    let proxy = proxy();
+
+    // Blocking runs inline on the calling thread.
+    assert_eq!(proxy.increment_blocking(5).unwrap(), 5);
+
+    // Async offloads to a blocking task and awaits it.
+    assert_eq!(proxy.increment_async(3).await.unwrap(), 8);
+
+    // Channel variant returns a handle awaited via `recv`.
+    let pending = proxy.get_chan();
+    assert_eq!(pending.recv().await.unwrap(), 8);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unit_success_path() {
+    let proxy = proxy();
+    proxy.increment_blocking(7).unwrap();
+
+    proxy.reset_async().await.unwrap();
+    assert_eq!(proxy.get_blocking().unwrap(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn domain_error_propagates() {
+    let proxy = proxy();
+    assert!(matches!(proxy.fail_async().await, Err(DbError::NotFound)));
+    assert!(matches!(
+        proxy.fail_chan().recv().await,
+        Err(DbError::NotFound)
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn task_panic_maps_to_join_error() {
+    let proxy = proxy();
+    match proxy.boom_async().await {
+        Err(DbError::Join(msg)) => assert!(!msg.is_empty()),
+        other => panic!("expected a join error, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn clone_shares_underlying_state() {
+    let proxy = proxy();
+    let clone = proxy.clone();
+
+    clone.increment_blocking(10).unwrap();
+    assert_eq!(proxy.get_async().await.unwrap(), 10);
+}
+
+#[test]
+fn non_self_method_is_not_proxied() {
+    // `describe` has no `&self` receiver, so only the trait method exists.
+    assert_eq!(<MemCounter as CounterDb>::describe(), "counter");
+}

--- a/crates/db-macros/tests/proxy.rs
+++ b/crates/db-macros/tests/proxy.rs
@@ -5,10 +5,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use strata_db_macros::gen_proxy;
 use tokio::runtime::Handle;
-// `proc_macro2`/`quote`/`syn` are normal dependencies of `strata-db-macros` (the
-// proc-macro crate) and are visible to — but unused by — this integration target;
-// silence the workspace `unused_crate_dependencies` lint.
-use {proc_macro2 as _, quote as _, syn as _};
+// `proc_macro2`/`quote`/`syn` (normal deps of the proc-macro crate) and the
+// `tracing`/`tracing-subscriber` dev-deps (exercised by `tests/instrumentation.rs`) are
+// visible to — but unused by — this integration target; silence the workspace
+// `unused_crate_dependencies` lint.
+use {proc_macro2 as _, quote as _, syn as _, tracing as _, tracing_subscriber as _};
 
 /// Result alias mirroring the `DbResult<T>` shape used by real database traits.
 type DbResult<T> = Result<T, DbError>;
@@ -156,94 +157,4 @@ async fn clone_shares_underlying_state() {
 fn non_self_method_is_not_proxied() {
     // `describe` has no `&self` receiver, so only the trait method exists.
     assert_eq!(<MemCounter as CounterDb>::describe(), "counter");
-}
-
-// An instrumented trait: the `tracing_component` argument wraps each method's blocking
-// work in a tracing span. This exercises that the instrumented codegen compiles and
-// behaves identically to the uninstrumented variant.
-#[gen_proxy(error = DbError, tracing_component = "test:metric")]
-trait MetricDb: Send + Sync + 'static {
-    /// Records a value and returns the running total.
-    fn record(&self, value: u64) -> DbResult<u64>;
-
-    /// Returns the running total.
-    fn total(&self) -> DbResult<u64>;
-}
-
-impl MetricDb for MemCounter {
-    fn record(&self, value: u64) -> DbResult<u64> {
-        Ok(self.value.fetch_add(value, Ordering::SeqCst) + value)
-    }
-
-    fn total(&self) -> DbResult<u64> {
-        Ok(self.value.load(Ordering::SeqCst))
-    }
-}
-
-fn metric_proxy() -> MetricDbProxy {
-    let db = Arc::new(MemCounter {
-        value: AtomicU64::new(0),
-    });
-    MetricDbProxy::new(Handle::current(), db)
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn instrumented_variants_agree() {
-    let proxy = metric_proxy();
-
-    assert_eq!(proxy.record_blocking(5).unwrap(), 5);
-    assert_eq!(proxy.record_async(3).await.unwrap(), 8);
-    assert_eq!(proxy.total_chan().recv().await.unwrap(), 8);
-}
-
-// Captures `(span name, parent span name)` for every span created under the global
-// subscriber, used to assert cross-thread span parenting.
-static CAPTURED_SPANS: std::sync::Mutex<Vec<(String, Option<String>)>> =
-    std::sync::Mutex::new(Vec::new());
-
-struct CaptureLayer;
-
-impl<S> tracing_subscriber::Layer<S> for CaptureLayer
-where
-    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
-{
-    fn on_new_span(
-        &self,
-        _attrs: &tracing::span::Attributes<'_>,
-        id: &tracing::span::Id,
-        ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
-        if let Some(span) = ctx.span(id) {
-            let name = span.name().to_string();
-            let parent = span.parent().map(|p| p.name().to_string());
-            CAPTURED_SPANS.lock().unwrap().push((name, parent));
-        }
-    }
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn instrumented_span_is_parented_to_caller() {
-    use tracing_subscriber::layer::SubscriberExt;
-
-    // Install a global subscriber so spans created on the `spawn_blocking` thread are
-    // recorded too. Only this test sets one; ignore the error if it is already set.
-    let subscriber = tracing_subscriber::registry().with(CaptureLayer);
-    let _ = tracing::subscriber::set_global_default(subscriber);
-
-    let proxy = metric_proxy();
-
-    // Issue the call from within a known parent span. `record_chan` captures the current
-    // span synchronously (here, `caller_parent`); the spawned shim re-enters it before
-    // creating the `record` span on the blocking thread.
-    let parent = tracing::info_span!("caller_parent");
-    let pending = parent.in_scope(|| proxy.record_chan(5));
-    assert_eq!(pending.recv().await.unwrap(), 5);
-
-    let captured = CAPTURED_SPANS.lock().unwrap();
-    assert!(
-        captured
-            .iter()
-            .any(|(name, parent)| name == "record" && parent.as_deref() == Some("caller_parent")),
-        "expected a `record` span parented to `caller_parent`, got: {captured:?}",
-    );
 }


### PR DESCRIPTION
## Description

This PR creates a `strata-db-macros` crate which exposes the `gen_proxy` attribute macro.  It generates a "proxy" type with associated code in a similar style to the objects created by the `inst_ops!` family of declaritive macros.  This flexibility allows for a more streamlined design that removes the "context" indirection and uses a type based on `JoinHandle` instead of a `tokio::sync::oneshot` channel to return values from blocking tasks.

In a future PR I will rework the storage and db crates in the main Strata repo to use this macro (defining them in the db-types crate and then reexporting from the storage crate with the `Ops` suffix.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
