### PR TITLE
feat(ol-logs): add crate owning the OL log payload layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-ol-logs"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "ssz",
+ "ssz_codegen",
+ "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
+ "strata-codec",
+ "strata-identifiers",
+ "strata-msg-fmt",
+ "thiserror 2.0.18",
+ "tree_hash",
+ "tree_hash_derive",
+]
+
+[[package]]
 name = "strata-predicate"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "crates/merkle",
   "crates/merkle-store",
   "crates/msg-fmt",
+  "crates/ol-logs",
   "crates/predicate",
   "crates/service",
   "crates/ssz-tests",
@@ -36,6 +37,7 @@ strata-merkle = { path = "crates/merkle" }
 strata-merkle-node-store = { path = "crates/merkle-store" }
 strata-metrics = { path = "crates/metrics" }
 strata-msg-fmt = { path = "crates/msg-fmt" }
+strata-ol-logs = { path = "crates/ol-logs" }
 strata-predicate = { path = "crates/predicate" }
 strata-service = { path = "crates/service" }
 strata-ssz-tests = { path = "crates/ssz-tests" }

--- a/crates/ol-logs/Cargo.toml
+++ b/crates/ol-logs/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "strata-ol-logs"
+version = "0.1.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+strata-codec = { workspace = true, features = ["derive"] }
+strata-identifiers.workspace = true
+strata-msg-fmt.workspace = true
+
+ssz.workspace = true
+ssz_derive.workspace = true
+ssz_primitives.workspace = true
+ssz_types.workspace = true
+tree_hash.workspace = true
+tree_hash_derive.workspace = true
+
+thiserror.workspace = true
+
+[build-dependencies]
+ssz_codegen.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/ol-logs/build.rs
+++ b/crates/ol-logs/build.rs
@@ -1,0 +1,25 @@
+//! Build script generating the SSZ `OLLog` container from `ssz/log.ssz`.
+
+use std::path::Path;
+
+use ssz_codegen::{ModuleGeneration, build_ssz_files};
+
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set by cargo");
+    let output_path = Path::new(&out_dir).join("generated_ssz.rs");
+
+    let entry_points = ["log.ssz"];
+    // External crates whose SSZ modules are imported by `log.ssz`.
+    let crates = ["strata_identifiers"];
+
+    build_ssz_files(
+        &entry_points,
+        "ssz/",
+        &crates,
+        output_path.to_str().expect("utf8 path"),
+        ModuleGeneration::NestedModules,
+    )
+    .expect("Failed to generate SSZ types");
+
+    println!("cargo:rerun-if-changed=ssz/log.ssz");
+}

--- a/crates/ol-logs/src/envelope.rs
+++ b/crates/ol-logs/src/envelope.rs
@@ -152,9 +152,10 @@ mod tests {
     }
 
     fn snark_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
+        // Full snark `extra_data` bound (1024); the envelope stays within `MAX_LOG_PAYLOAD_LEN`.
         (
             any::<u64>(),
-            prop::collection::vec(any::<u8>(), 0..=400usize),
+            prop::collection::vec(any::<u8>(), 0..=1024usize),
         )
             .prop_map(|(new_msg_idx, extra_data)| {
                 SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
@@ -169,6 +170,15 @@ mod tests {
             (account_strategy(), snark_strategy()).prop_map(|(serial, s)| Entry::Snark(serial, s)),
             account_strategy().prop_map(Entry::Empty),
         ]
+    }
+
+    /// `decode_log` surfaces a malformed (here, empty) envelope as `LogDecodeError::Envelope`,
+    /// rather than a codec error or type mismatch. This is the reconciled superset variant.
+    #[test]
+    fn decode_log_reports_envelope_error_on_malformed_input() {
+        let err = SimpleWithdrawalIntentLogData::decode_log(&[])
+            .expect_err("empty input is not a valid envelope");
+        assert!(matches!(err, LogDecodeError::Envelope(_)));
     }
 
     proptest! {

--- a/crates/ol-logs/src/envelope.rs
+++ b/crates/ol-logs/src/envelope.rs
@@ -1,0 +1,217 @@
+//! Envelope codec and typed dispatch for OL log payloads.
+
+use std::iter;
+
+use strata_codec::{Codec, CodecError, decode_buf_exact};
+use strata_identifiers::AccountSerial;
+use strata_msg_fmt::{self as msg_fmt, Msg, MsgRef, TypeId, try_encode_into_buf};
+
+use crate::OLLog;
+
+/// Error decoding a typed OL log payload from its `strata_msg_fmt` envelope.
+///
+/// The variants reconcile the two former per-repo error types into one superset: asm's
+/// `OLLogDecodeError` (which surfaced envelope-parse failures via `Envelope`) and strata's
+/// 2-variant `LogDecodeError` (which did not).
+#[derive(Debug, thiserror::Error)]
+pub enum LogDecodeError {
+    /// The envelope's type id did not match the requested log type.
+    #[error("ol log type mismatch: expected {expected}, found {found}")]
+    TypeMismatch {
+        /// Type id requested by the caller.
+        expected: TypeId,
+        /// Type id found in the envelope.
+        found: TypeId,
+    },
+
+    /// Failed to decode the log body via the codec.
+    #[error("codec: {0}")]
+    Codec(#[from] CodecError),
+
+    /// Failed to parse the msg-fmt envelope.
+    #[error("msgfmt: {0:?}")]
+    Envelope(#[from] msg_fmt::Error),
+}
+
+/// A typed orchestration-layer log payload.
+///
+/// Each impl carries a [`TypeId`] tagging it within an OL log payload, encoded as a
+/// `strata_msg_fmt` envelope (type prefix + codec body). Consumers parse the payload once and
+/// dispatch on the type id rather than guessing the concrete type from raw bytes.
+pub trait OLLogType: Codec + Sized {
+    /// The msg-fmt type id identifying this log payload.
+    const LOG_TYPE_ID: TypeId;
+
+    /// Encodes this payload into a msg-fmt envelope (type prefix followed by the codec body).
+    fn encode_log(&self) -> Result<Vec<u8>, CodecError> {
+        let mut buf = Vec::new();
+        // Write the msg-fmt type prefix, then encode the body directly into the same buffer to
+        // avoid a separate allocation and copy of the body.
+        try_encode_into_buf(Self::LOG_TYPE_ID, iter::empty(), &mut buf)
+            .expect("ol log: type id must be within msg-fmt bounds");
+        self.encode(&mut buf)?;
+        Ok(buf)
+    }
+
+    /// Decodes this payload from an already-parsed msg-fmt message.
+    ///
+    /// Returns [`LogDecodeError::TypeMismatch`] if the message's type id does not match
+    /// [`Self::LOG_TYPE_ID`], or [`LogDecodeError::Codec`] if the body fails to decode.
+    fn try_decode_log(msg: &MsgRef<'_>) -> Result<Self, LogDecodeError> {
+        let found = msg.ty();
+        if found != Self::LOG_TYPE_ID {
+            return Err(LogDecodeError::TypeMismatch {
+                expected: Self::LOG_TYPE_ID,
+                found,
+            });
+        }
+        Ok(decode_buf_exact(msg.body())?)
+    }
+
+    /// Decodes this payload directly from raw envelope bytes.
+    ///
+    /// Parses the msg-fmt envelope (surfacing [`LogDecodeError::Envelope`] on a malformed
+    /// envelope) and then delegates to [`Self::try_decode_log`]. This is the convenience asm's
+    /// inherent `OLLog::try_into_log` is reimplemented on top of.
+    fn decode_log(payload: &[u8]) -> Result<Self, LogDecodeError> {
+        let msg = MsgRef::try_from(payload)?;
+        Self::try_decode_log(&msg)
+    }
+}
+
+/// Filters and decodes typed OL log payloads from a slice of [`OLLog`] entries.
+///
+/// Yields successfully-decoded payloads of type `T`, skipping entries that don't match the optional
+/// `account_guard`, don't carry `T`'s type id, or whose envelope/body fails to decode. This is the
+/// shared "filter by type id (+ optional emitting account), decode the envelope body" pattern used
+/// by both asm's checkpoint verifier and strata's checkpoint consumers; the caller applies any
+/// further domain mapping (and hard-erroring) to the yielded payloads.
+pub fn decode_typed_logs<'a, T: OLLogType>(
+    logs: &'a [OLLog],
+    account_guard: Option<AccountSerial>,
+) -> impl Iterator<Item = T> + 'a {
+    logs.iter().filter_map(move |log| {
+        if account_guard.is_some_and(|guard| guard != log.account_serial()) {
+            return None;
+        }
+        T::decode_log(log.payload()).ok()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::{SimpleWithdrawalIntentLogData, SnarkAccountUpdateLogData};
+
+    /// One of the accounts logs are generated from; `BRIDGE` is the one the guard filters for.
+    const BRIDGE: AccountSerial = AccountSerial::one();
+
+    /// A generated log entry, tagged with how `decode_typed_logs::<SimpleWithdrawalIntentLogData>`
+    /// should treat it so the expected output can be computed independently of the implementation.
+    #[derive(Debug, Clone)]
+    enum Entry {
+        /// A well-formed withdrawal envelope — kept iff it passes the account guard.
+        Withdrawal(AccountSerial, SimpleWithdrawalIntentLogData),
+        /// A well-formed snark envelope — always dropped (wrong type id).
+        Snark(AccountSerial, SnarkAccountUpdateLogData),
+        /// An empty payload — always dropped (not a valid envelope).
+        Empty(AccountSerial),
+    }
+
+    impl Entry {
+        fn to_log(&self) -> OLLog {
+            match self {
+                Entry::Withdrawal(serial, w) => OLLog::from_log(*serial, w).unwrap(),
+                Entry::Snark(serial, s) => OLLog::from_log(*serial, s).unwrap(),
+                Entry::Empty(serial) => OLLog::new(*serial, Vec::new()),
+            }
+        }
+    }
+
+    fn account_strategy() -> impl Strategy<Value = AccountSerial> {
+        prop::sample::select(vec![
+            AccountSerial::zero(),
+            AccountSerial::one(),
+            AccountSerial::new(2),
+        ])
+    }
+
+    fn withdrawal_strategy() -> impl Strategy<Value = SimpleWithdrawalIntentLogData> {
+        // Bounded so the encoded envelope stays within `MAX_LOG_PAYLOAD_LEN`.
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=255usize),
+            any::<u32>(),
+        )
+            .prop_map(|(amt, dest, selected_operator)| {
+                SimpleWithdrawalIntentLogData::new(amt, dest, selected_operator)
+                    .expect("dest within bounds")
+            })
+    }
+
+    fn snark_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=400usize),
+        )
+            .prop_map(|(new_msg_idx, extra_data)| {
+                SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
+                    .expect("extra within bounds")
+            })
+    }
+
+    fn entry_strategy() -> impl Strategy<Value = Entry> {
+        prop_oneof![
+            (account_strategy(), withdrawal_strategy())
+                .prop_map(|(serial, w)| Entry::Withdrawal(serial, w)),
+            (account_strategy(), snark_strategy()).prop_map(|(serial, s)| Entry::Snark(serial, s)),
+            account_strategy().prop_map(Entry::Empty),
+        ]
+    }
+
+    proptest! {
+        /// With a guard, only well-formed withdrawal logs from the guard account survive, in order.
+        #[test]
+        fn decode_typed_logs_respects_type_and_account_guard(
+            entries in prop::collection::vec(entry_strategy(), 0..16),
+        ) {
+            let logs: Vec<OLLog> = entries.iter().map(Entry::to_log).collect();
+
+            let expected: Vec<SimpleWithdrawalIntentLogData> = entries
+                .iter()
+                .filter_map(|e| match e {
+                    Entry::Withdrawal(serial, w) if *serial == BRIDGE => Some(w.clone()),
+                    _ => None,
+                })
+                .collect();
+
+            let actual: Vec<SimpleWithdrawalIntentLogData> =
+                decode_typed_logs(&logs, Some(BRIDGE)).collect();
+
+            prop_assert_eq!(actual, expected);
+        }
+
+        /// Without a guard, every well-formed withdrawal log survives regardless of account.
+        #[test]
+        fn decode_typed_logs_without_guard_keeps_all_withdrawals(
+            entries in prop::collection::vec(entry_strategy(), 0..16),
+        ) {
+            let logs: Vec<OLLog> = entries.iter().map(Entry::to_log).collect();
+
+            let expected: Vec<SimpleWithdrawalIntentLogData> = entries
+                .iter()
+                .filter_map(|e| match e {
+                    Entry::Withdrawal(_, w) => Some(w.clone()),
+                    _ => None,
+                })
+                .collect();
+
+            let actual: Vec<SimpleWithdrawalIntentLogData> =
+                decode_typed_logs(&logs, None).collect();
+
+            prop_assert_eq!(actual, expected);
+        }
+    }
+}

--- a/crates/ol-logs/src/envelope.rs
+++ b/crates/ol-logs/src/envelope.rs
@@ -85,8 +85,8 @@ pub trait OLLogType: Codec + Sized {
 /// id: `Ok(payload)` on success, or `Err` if that matching log's envelope/body fails to decode.
 /// Entries that don't match the guard or carry a different type id are skipped silently — they are
 /// genuinely "not a `T`". A matching log that fails to decode is *not* skipped: a truncated or
-/// otherwise malformed withdrawal log must surface as an error so checkpoint verifiers can hard-fail
-/// rather than silently drop the intent (treating a malformed log as an absent one).
+/// otherwise malformed withdrawal log must surface as an error so checkpoint verifiers can
+/// hard-fail rather than silently drop the intent (treating a malformed log as an absent one).
 ///
 /// This is the shared "filter by type id (+ optional emitting account), decode the envelope body"
 /// pattern used by both asm's checkpoint verifier and strata's checkpoint consumers; the caller

--- a/crates/ol-logs/src/envelope.rs
+++ b/crates/ol-logs/src/envelope.rs
@@ -81,20 +81,30 @@ pub trait OLLogType: Codec + Sized {
 
 /// Filters and decodes typed OL log payloads from a slice of [`OLLog`] entries.
 ///
-/// Yields successfully-decoded payloads of type `T`, skipping entries that don't match the optional
-/// `account_guard`, don't carry `T`'s type id, or whose envelope/body fails to decode. This is the
-/// shared "filter by type id (+ optional emitting account), decode the envelope body" pattern used
-/// by both asm's checkpoint verifier and strata's checkpoint consumers; the caller applies any
-/// further domain mapping (and hard-erroring) to the yielded payloads.
+/// Yields one item per entry that matches the optional `account_guard` **and** carries `T`'s type
+/// id: `Ok(payload)` on success, or `Err` if that matching log's envelope/body fails to decode.
+/// Entries that don't match the guard or carry a different type id are skipped silently — they are
+/// genuinely "not a `T`". A matching log that fails to decode is *not* skipped: a truncated or
+/// otherwise malformed withdrawal log must surface as an error so checkpoint verifiers can hard-fail
+/// rather than silently drop the intent (treating a malformed log as an absent one).
+///
+/// This is the shared "filter by type id (+ optional emitting account), decode the envelope body"
+/// pattern used by both asm's checkpoint verifier and strata's checkpoint consumers; the caller
+/// applies any further domain mapping to the yielded payloads.
 pub fn decode_typed_logs<'a, T: OLLogType>(
     logs: &'a [OLLog],
     account_guard: Option<AccountSerial>,
-) -> impl Iterator<Item = T> + 'a {
+) -> impl Iterator<Item = Result<T, LogDecodeError>> + 'a {
     logs.iter().filter_map(move |log| {
         if account_guard.is_some_and(|guard| guard != log.account_serial()) {
             return None;
         }
-        T::decode_log(log.payload()).ok()
+        match T::decode_log(log.payload()) {
+            // A different type id means this log simply isn't a `T`; skip it.
+            Err(LogDecodeError::TypeMismatch { .. }) => None,
+            // Success, or a malformed envelope/body on a type-matching log — surface both.
+            other => Some(other),
+        }
     })
 }
 
@@ -181,47 +191,103 @@ mod tests {
         assert!(matches!(err, LogDecodeError::Envelope(_)));
     }
 
+    /// A log whose msg-fmt prefix matches `T`'s type id but whose body is truncated must surface as
+    /// an `Err` from `decode_typed_logs`, not be silently dropped — otherwise a checkpoint verifier
+    /// cannot distinguish a malformed withdrawal log from an absent one and drops the intent.
+    #[test]
+    fn decode_typed_logs_surfaces_malformed_matching_log() {
+        let withdrawal = SimpleWithdrawalIntentLogData::new(1_000, vec![0xaa; 4], 7)
+            .expect("dest within bounds");
+        // Keep the type-id prefix (0x01, single byte) intact but lop a byte off the body so the
+        // envelope still parses as a withdrawal yet fails codec decoding.
+        let mut envelope = withdrawal.encode_log().expect("encode withdrawal envelope");
+        envelope.truncate(envelope.len() - 1);
+        let logs = [OLLog::new(BRIDGE, envelope)];
+
+        let results: Vec<Result<SimpleWithdrawalIntentLogData, _>> =
+            decode_typed_logs(&logs, Some(BRIDGE)).collect();
+
+        assert_eq!(results.len(), 1, "the matching log must not be skipped");
+        assert!(matches!(results[0], Err(LogDecodeError::Codec(_))));
+    }
+
+    /// Expected outcome of running `decode_typed_logs::<SimpleWithdrawalIntentLogData>` over one
+    /// [`Entry`], computed independently of the implementation.
+    #[derive(Debug, Clone)]
+    enum Expect {
+        /// Yields `Ok` with this decoded withdrawal payload.
+        Decoded(SimpleWithdrawalIntentLogData),
+        /// Yields `Err` — a guard-passing log that fails envelope/body decoding (an empty payload).
+        Error,
+        /// Yields nothing — filtered by the account guard or a non-matching type id.
+        Skipped,
+    }
+
+    /// Asserts the `Result`-yielding `decode_typed_logs` output matches the per-entry expectation,
+    /// in order. `Err` variants are compared by presence only (`LogDecodeError` isn't `PartialEq`).
+    fn assert_matches_expected(
+        actual: &[Result<SimpleWithdrawalIntentLogData, LogDecodeError>],
+        expected: &[Expect],
+    ) -> Result<(), TestCaseError> {
+        let expected: Vec<&Expect> = expected
+            .iter()
+            .filter(|e| !matches!(e, Expect::Skipped))
+            .collect();
+        prop_assert_eq!(actual.len(), expected.len());
+        for (got, want) in actual.iter().zip(expected) {
+            match (got, want) {
+                (Ok(w), Expect::Decoded(ew)) => prop_assert_eq!(w, ew),
+                (Err(_), Expect::Error) => {}
+                _ => prop_assert!(false, "outcome mismatch: {:?} vs {:?}", got, want),
+            }
+        }
+        Ok(())
+    }
+
     proptest! {
-        /// With a guard, only well-formed withdrawal logs from the guard account survive, in order.
+        /// With a guard, only well-formed withdrawal logs from the guard account decode; logs of a
+        /// different type id are skipped, while a malformed (empty) guard-account log surfaces as an
+        /// error rather than being silently dropped.
         #[test]
         fn decode_typed_logs_respects_type_and_account_guard(
             entries in prop::collection::vec(entry_strategy(), 0..16),
         ) {
             let logs: Vec<OLLog> = entries.iter().map(Entry::to_log).collect();
 
-            let expected: Vec<SimpleWithdrawalIntentLogData> = entries
+            let expected: Vec<Expect> = entries
                 .iter()
-                .filter_map(|e| match e {
-                    Entry::Withdrawal(serial, w) if *serial == BRIDGE => Some(w.clone()),
-                    _ => None,
+                .map(|e| match e {
+                    Entry::Withdrawal(serial, w) if *serial == BRIDGE => Expect::Decoded(w.clone()),
+                    Entry::Empty(serial) if *serial == BRIDGE => Expect::Error,
+                    _ => Expect::Skipped,
                 })
                 .collect();
 
-            let actual: Vec<SimpleWithdrawalIntentLogData> =
-                decode_typed_logs(&logs, Some(BRIDGE)).collect();
+            let actual: Vec<_> = decode_typed_logs(&logs, Some(BRIDGE)).collect();
 
-            prop_assert_eq!(actual, expected);
+            assert_matches_expected(&actual, &expected)?;
         }
 
-        /// Without a guard, every well-formed withdrawal log survives regardless of account.
+        /// Without a guard, every well-formed withdrawal log decodes regardless of account; snark
+        /// logs are skipped (type mismatch) and malformed (empty) logs surface as errors.
         #[test]
         fn decode_typed_logs_without_guard_keeps_all_withdrawals(
             entries in prop::collection::vec(entry_strategy(), 0..16),
         ) {
             let logs: Vec<OLLog> = entries.iter().map(Entry::to_log).collect();
 
-            let expected: Vec<SimpleWithdrawalIntentLogData> = entries
+            let expected: Vec<Expect> = entries
                 .iter()
-                .filter_map(|e| match e {
-                    Entry::Withdrawal(_, w) => Some(w.clone()),
-                    _ => None,
+                .map(|e| match e {
+                    Entry::Withdrawal(_, w) => Expect::Decoded(w.clone()),
+                    Entry::Snark(..) => Expect::Skipped,
+                    Entry::Empty(_) => Expect::Error,
                 })
                 .collect();
 
-            let actual: Vec<SimpleWithdrawalIntentLogData> =
-                decode_typed_logs(&logs, None).collect();
+            let actual: Vec<_> = decode_typed_logs(&logs, None).collect();
 
-            prop_assert_eq!(actual, expected);
+            assert_matches_expected(&actual, &expected)?;
         }
     }
 }

--- a/crates/ol-logs/src/lib.rs
+++ b/crates/ol-logs/src/lib.rs
@@ -1,0 +1,22 @@
+//! Shared orchestration-layer (OL) log payload types.
+//!
+//! OL log payload layer carried in checkpoint sidecars: the typed payload structs
+//! ([`SimpleWithdrawalIntentLogData`], [`SnarkAccountUpdateLogData`]), their type-id namespace, the
+//! [`OLLogType`] envelope codec, [`LogDecodeError`], and the [`decode_typed_logs`] filter/decode
+//! helper.
+
+#[allow(unreachable_pub, missing_docs, reason = "generated code")]
+mod ssz_generated {
+    include!(concat!(env!("OUT_DIR"), "/generated_ssz.rs"));
+}
+
+mod envelope;
+mod log;
+mod payloads;
+
+pub use envelope::{LogDecodeError, OLLogType, decode_typed_logs};
+pub use log::{MAX_LOG_PAYLOAD_LEN, OLLog, OLLogRef};
+pub use payloads::{
+    DestinationBufVec, ExtraDataBufVec, SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID,
+    SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID, SimpleWithdrawalIntentLogData, SnarkAccountUpdateLogData,
+};

--- a/crates/ol-logs/src/log.rs
+++ b/crates/ol-logs/src/log.rs
@@ -93,15 +93,76 @@ mod tests {
     }
 
     fn snark_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
-        // `extra_data` is bounded so the encoded envelope stays within `MAX_LOG_PAYLOAD_LEN`.
+        // Exercises the full snark `extra_data` bound (1024); the envelope stays within
+        // `MAX_LOG_PAYLOAD_LEN` (4096).
         (
             any::<u64>(),
-            prop::collection::vec(any::<u8>(), 0..=400usize),
+            prop::collection::vec(any::<u8>(), 0..=1024usize),
         )
             .prop_map(|(new_msg_idx, extra_data)| {
                 SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
                     .expect("extra within bounds")
             })
+    }
+
+    /// A payload of exactly `MAX_LOG_PAYLOAD_LEN` bytes is accepted.
+    #[test]
+    fn new_accepts_payload_at_max_len() {
+        let log = OLLog::new(AccountSerial::zero(), vec![0u8; MAX_LOG_PAYLOAD_LEN as usize]);
+        assert_eq!(log.payload().len(), MAX_LOG_PAYLOAD_LEN as usize);
+    }
+
+    /// A payload one byte over the cap panics in `OLLog::new`.
+    #[test]
+    #[should_panic(expected = "payload too large")]
+    fn new_panics_above_max_len() {
+        let _ = OLLog::new(AccountSerial::zero(), vec![0u8; MAX_LOG_PAYLOAD_LEN as usize + 1]);
+    }
+
+    /// A maximally-sized `SnarkAccountUpdateLogData` (the largest valid typed payload) fits within
+    /// `MAX_LOG_PAYLOAD_LEN`, so `from_log` succeeds rather than panicking on the envelope length.
+    ///
+    /// This guards the bound relationship the `1 << 12` cap is sized for: the snark `extra_data`
+    /// bound (1024) plus envelope overhead must stay under `MAX_LOG_PAYLOAD_LEN`.
+    #[test]
+    fn from_log_fits_max_snark_payload() {
+        let snark =
+            SnarkAccountUpdateLogData::new(u64::MAX, vec![0xff; 1024]).expect("within snark bound");
+        let log = OLLog::from_log(AccountSerial::zero(), &snark).expect("max snark envelope fits");
+
+        let decoded: SnarkAccountUpdateLogData =
+            log.try_into_log().expect("round-trips back");
+        assert_eq!(decoded, snark);
+    }
+
+    /// A payload that is not a valid msg-fmt envelope has no type and decodes to an envelope error.
+    #[test]
+    fn non_envelope_payload_has_no_type() {
+        let log = OLLog::new(AccountSerial::zero(), Vec::new());
+        assert!(log.try_as_msg().is_none());
+        assert_eq!(log.ty(), None);
+
+        let err = log
+            .try_into_log::<SimpleWithdrawalIntentLogData>()
+            .expect_err("empty payload is not a valid envelope");
+        assert!(matches!(err, LogDecodeError::Envelope(_)));
+    }
+
+    /// The commitment binds both fields: differing payloads or account serials hash differently.
+    #[test]
+    fn hash_commitment_distinguishes_logs() {
+        let base = OLLog::new(AccountSerial::zero(), vec![1, 2, 3]);
+        let other_payload = OLLog::new(AccountSerial::zero(), vec![1, 2, 4]);
+        let other_serial = OLLog::new(AccountSerial::new(1), vec![1, 2, 3]);
+
+        assert_ne!(
+            base.compute_hash_commitment(),
+            other_payload.compute_hash_commitment()
+        );
+        assert_ne!(
+            base.compute_hash_commitment(),
+            other_serial.compute_hash_commitment()
+        );
     }
 
     proptest! {

--- a/crates/ol-logs/src/log.rs
+++ b/crates/ol-logs/src/log.rs
@@ -1,0 +1,158 @@
+//! The [`OLLog`] checkpoint log-entry container and its envelope helpers.
+
+use ssz_types::VariableList;
+use strata_codec::CodecError;
+use strata_identifiers::{AccountSerial, Buf32};
+use strata_msg_fmt::{Msg, MsgRef, TypeId};
+use tree_hash::{Sha256Hasher, TreeHash};
+
+pub use crate::ssz_generated::ssz::log::{MAX_LOG_PAYLOAD_LEN, OLLog, OLLogRef};
+use crate::{LogDecodeError, OLLogType};
+
+impl OLLog {
+    /// Creates a log entry from a raw payload.
+    ///
+    /// Panics if `payload` exceeds [`MAX_LOG_PAYLOAD_LEN`]. Use [`OLLog::from_log`] to build one
+    /// from a typed payload via the msg-fmt envelope.
+    pub fn new(account_serial: AccountSerial, payload: Vec<u8>) -> Self {
+        Self {
+            account_serial,
+            payload: VariableList::new(payload).expect("ol log: payload too large"),
+        }
+    }
+
+    /// The account serial this log relates to.
+    pub fn account_serial(&self) -> AccountSerial {
+        self.account_serial
+    }
+
+    /// The raw payload bytes (a msg-fmt envelope).
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Builds a log whose payload is the msg-fmt envelope for a typed OL log.
+    ///
+    /// The payload is `TypeId(T::LOG_TYPE_ID) ++ codec(log)`, so consumers dispatch on the log type
+    /// via [`OLLog::try_into_log`].
+    pub fn from_log<T: OLLogType>(
+        account_serial: AccountSerial,
+        log: &T,
+    ) -> Result<Self, CodecError> {
+        Ok(Self::new(account_serial, log.encode_log()?))
+    }
+
+    /// Interprets the payload as a msg-fmt message, if it is a valid envelope.
+    pub fn try_as_msg(&self) -> Option<MsgRef<'_>> {
+        MsgRef::try_from(self.payload()).ok()
+    }
+
+    /// The envelope type id, if the payload is a valid msg-fmt message.
+    pub fn ty(&self) -> Option<TypeId> {
+        self.try_as_msg().map(|msg| msg.ty())
+    }
+
+    /// Decodes the payload as a specific typed OL log.
+    ///
+    /// Parses the msg-fmt envelope, checks the type id matches `T::LOG_TYPE_ID`, and decodes the
+    /// body — returning [`LogDecodeError::TypeMismatch`] when the envelope carries a different log
+    /// type.
+    pub fn try_into_log<T: OLLogType>(&self) -> Result<T, LogDecodeError> {
+        T::decode_log(self.payload())
+    }
+
+    /// Computes the SSZ tree-hash commitment of this log.
+    pub fn compute_hash_commitment(&self) -> Buf32 {
+        let root = TreeHash::tree_hash_root::<Sha256Hasher>(self);
+        Buf32::from(root.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::{SimpleWithdrawalIntentLogData, SnarkAccountUpdateLogData};
+
+    fn serial_strategy() -> impl Strategy<Value = AccountSerial> {
+        any::<u32>().prop_map(AccountSerial::new)
+    }
+
+    fn withdrawal_strategy() -> impl Strategy<Value = SimpleWithdrawalIntentLogData> {
+        // `dest` is bounded so the encoded envelope stays within `MAX_LOG_PAYLOAD_LEN`.
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=255usize),
+            any::<u32>(),
+        )
+            .prop_map(|(amt, dest, selected_operator)| {
+                SimpleWithdrawalIntentLogData::new(amt, dest, selected_operator)
+                    .expect("dest within bounds")
+            })
+    }
+
+    fn snark_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
+        // `extra_data` is bounded so the encoded envelope stays within `MAX_LOG_PAYLOAD_LEN`.
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=400usize),
+        )
+            .prop_map(|(new_msg_idx, extra_data)| {
+                SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
+                    .expect("extra within bounds")
+            })
+    }
+
+    proptest! {
+        #[test]
+        fn from_log_round_trips_withdrawal(
+            serial in serial_strategy(),
+            payload in withdrawal_strategy(),
+        ) {
+            let log = OLLog::from_log(serial, &payload).expect("from_log should succeed");
+
+            prop_assert_eq!(log.account_serial(), serial);
+            prop_assert_eq!(log.ty(), Some(SimpleWithdrawalIntentLogData::LOG_TYPE_ID));
+
+            let decoded: SimpleWithdrawalIntentLogData =
+                log.try_into_log().expect("try_into_log should succeed");
+            prop_assert_eq!(decoded, payload);
+        }
+
+        #[test]
+        fn from_log_round_trips_snark(
+            serial in serial_strategy(),
+            payload in snark_strategy(),
+        ) {
+            let log = OLLog::from_log(serial, &payload).expect("from_log should succeed");
+
+            prop_assert_eq!(log.account_serial(), serial);
+            prop_assert_eq!(log.ty(), Some(SnarkAccountUpdateLogData::LOG_TYPE_ID));
+
+            let decoded: SnarkAccountUpdateLogData =
+                log.try_into_log().expect("try_into_log should succeed");
+            prop_assert_eq!(decoded, payload);
+        }
+
+        /// Decoding a log as the wrong typed payload reports an error rather than succeeding.
+        #[test]
+        fn try_into_log_wrong_type_fails(
+            serial in serial_strategy(),
+            payload in withdrawal_strategy(),
+        ) {
+            let log = OLLog::from_log(serial, &payload).expect("from_log should succeed");
+            prop_assert!(log.try_into_log::<SnarkAccountUpdateLogData>().is_err());
+        }
+
+        #[test]
+        fn hash_commitment_matches_for_equal_logs(
+            serial in serial_strategy(),
+            bytes in prop::collection::vec(any::<u8>(), 0..=MAX_LOG_PAYLOAD_LEN as usize),
+        ) {
+            let a = OLLog::new(serial, bytes.clone());
+            let b = OLLog::new(serial, bytes);
+            prop_assert_eq!(a.compute_hash_commitment(), b.compute_hash_commitment());
+        }
+    }
+}

--- a/crates/ol-logs/src/log.rs
+++ b/crates/ol-logs/src/log.rs
@@ -12,13 +12,23 @@ use crate::{LogDecodeError, OLLogType};
 impl OLLog {
     /// Creates a log entry from a raw payload.
     ///
-    /// Panics if `payload` exceeds [`MAX_LOG_PAYLOAD_LEN`]. Use [`OLLog::from_log`] to build one
-    /// from a typed payload via the msg-fmt envelope.
-    pub fn new(account_serial: AccountSerial, payload: Vec<u8>) -> Self {
-        Self {
+    /// Returns [`CodecError::OverflowContainer`] if `payload` exceeds [`MAX_LOG_PAYLOAD_LEN`]. Use
+    /// [`OLLog::from_log`] to build one from a typed payload via the msg-fmt envelope.
+    pub fn try_new(account_serial: AccountSerial, payload: Vec<u8>) -> Result<Self, CodecError> {
+        let payload = VariableList::new(payload).map_err(|_| CodecError::OverflowContainer)?;
+        Ok(Self {
             account_serial,
-            payload: VariableList::new(payload).expect("ol log: payload too large"),
-        }
+            payload,
+        })
+    }
+
+    /// Creates a log entry from a raw payload.
+    ///
+    /// Panics if `payload` exceeds [`MAX_LOG_PAYLOAD_LEN`]; use [`OLLog::try_new`] to handle the
+    /// oversize case gracefully. Use [`OLLog::from_log`] to build one from a typed payload via the
+    /// msg-fmt envelope.
+    pub fn new(account_serial: AccountSerial, payload: Vec<u8>) -> Self {
+        Self::try_new(account_serial, payload).expect("ol log: payload too large")
     }
 
     /// The account serial this log relates to.
@@ -34,12 +44,13 @@ impl OLLog {
     /// Builds a log whose payload is the msg-fmt envelope for a typed OL log.
     ///
     /// The payload is `TypeId(T::LOG_TYPE_ID) ++ codec(log)`, so consumers dispatch on the log type
-    /// via [`OLLog::try_into_log`].
+    /// via [`OLLog::try_into_log`]. Returns [`CodecError::OverflowContainer`] if the encoded
+    /// envelope exceeds [`MAX_LOG_PAYLOAD_LEN`].
     pub fn from_log<T: OLLogType>(
         account_serial: AccountSerial,
         log: &T,
     ) -> Result<Self, CodecError> {
-        Ok(Self::new(account_serial, log.encode_log()?))
+        Self::try_new(account_serial, log.encode_log()?)
     }
 
     /// Interprets the payload as a msg-fmt message, if it is a valid envelope.
@@ -123,6 +134,17 @@ mod tests {
             AccountSerial::zero(),
             vec![0u8; MAX_LOG_PAYLOAD_LEN as usize + 1],
         );
+    }
+
+    /// A payload over the cap surfaces as an error from `try_new` rather than panicking.
+    #[test]
+    fn try_new_rejects_payload_above_max_len() {
+        let err = OLLog::try_new(
+            AccountSerial::zero(),
+            vec![0u8; MAX_LOG_PAYLOAD_LEN as usize + 1],
+        )
+        .expect_err("payload over the cap should be rejected");
+        assert!(matches!(err, CodecError::OverflowContainer));
     }
 
     /// A maximally-sized `SnarkAccountUpdateLogData` (the largest valid typed payload) fits within

--- a/crates/ol-logs/src/log.rs
+++ b/crates/ol-logs/src/log.rs
@@ -108,7 +108,10 @@ mod tests {
     /// A payload of exactly `MAX_LOG_PAYLOAD_LEN` bytes is accepted.
     #[test]
     fn new_accepts_payload_at_max_len() {
-        let log = OLLog::new(AccountSerial::zero(), vec![0u8; MAX_LOG_PAYLOAD_LEN as usize]);
+        let log = OLLog::new(
+            AccountSerial::zero(),
+            vec![0u8; MAX_LOG_PAYLOAD_LEN as usize],
+        );
         assert_eq!(log.payload().len(), MAX_LOG_PAYLOAD_LEN as usize);
     }
 
@@ -116,7 +119,10 @@ mod tests {
     #[test]
     #[should_panic(expected = "payload too large")]
     fn new_panics_above_max_len() {
-        let _ = OLLog::new(AccountSerial::zero(), vec![0u8; MAX_LOG_PAYLOAD_LEN as usize + 1]);
+        let _ = OLLog::new(
+            AccountSerial::zero(),
+            vec![0u8; MAX_LOG_PAYLOAD_LEN as usize + 1],
+        );
     }
 
     /// A maximally-sized `SnarkAccountUpdateLogData` (the largest valid typed payload) fits within
@@ -130,8 +136,7 @@ mod tests {
             SnarkAccountUpdateLogData::new(u64::MAX, vec![0xff; 1024]).expect("within snark bound");
         let log = OLLog::from_log(AccountSerial::zero(), &snark).expect("max snark envelope fits");
 
-        let decoded: SnarkAccountUpdateLogData =
-            log.try_into_log().expect("round-trips back");
+        let decoded: SnarkAccountUpdateLogData = log.try_into_log().expect("round-trips back");
         assert_eq!(decoded, snark);
     }
 

--- a/crates/ol-logs/src/payloads.rs
+++ b/crates/ol-logs/src/payloads.rs
@@ -1,0 +1,361 @@
+//! Typed OL log payload structs and their type-id namespace.
+
+use strata_codec::{Codec, VarVec};
+use strata_msg_fmt::TypeId;
+
+use crate::OLLogType;
+
+/// Maximum byte length for a withdrawal destination BOSD descriptor.
+const MAX_DEST_BYTES: u32 = 255;
+
+/// Maximum byte length for snark account update extra data.
+///
+/// Matches `SAU_MAX_EXTRA_DATA_BYTES` from strata's OL transaction SSZ spec. The bound is a
+/// compile-time cap only; it does not affect the wire encoding (the `VarVec` length prefix encodes
+/// the actual length), so an asm-side `VarVec<u8>` and this bounded alias are byte-identical.
+const MAX_EXTRA_DATA_BYTES: u32 = 1024;
+
+/// Bounded [`VarVec`] holding a withdrawal intent destination BOSD.
+pub type DestinationBufVec = VarVec<u8, { MAX_DEST_BYTES }>;
+
+/// Bounded [`VarVec`] holding SAU extra data.
+pub type ExtraDataBufVec = VarVec<u8, { MAX_EXTRA_DATA_BYTES }>;
+
+/// msg-fmt type id for [`SimpleWithdrawalIntentLogData`].
+///
+/// This is a **wire contract** shared by strata (producer) and asm (consumer): if this value or
+/// the field layout of [`SimpleWithdrawalIntentLogData`] drifts, withdrawal intents silently vanish
+/// from checkpoints (funds burned on L2, unwithdrawable on L1). This crate is the single source of
+/// truth for both sides.
+///
+/// Note: this is a *different* namespace from the SPS-52 ASM log ids in `strata-asm-logs`; do not
+/// reuse those.
+pub const SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID: TypeId = 0x01;
+
+/// msg-fmt type id for [`SnarkAccountUpdateLogData`].
+pub const SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID: TypeId = 0x02;
+
+/// Payload for a simple withdrawal intent log.
+///
+/// Emitted by the OL STF when a withdrawal message is processed at the bridge
+/// gateway account.
+#[derive(Debug, Clone, PartialEq, Eq, Codec)]
+pub struct SimpleWithdrawalIntentLogData {
+    /// Amount being withdrawn (sats).
+    pub amt: u64,
+
+    /// Destination BOSD.
+    pub dest: DestinationBufVec,
+
+    /// User's selected operator index for withdrawal assignment.
+    // TODO(STR-1861): encode as varint to reduce DA cost in checkpoint payloads.
+    pub selected_operator: u32,
+}
+
+impl SimpleWithdrawalIntentLogData {
+    /// Create a new simple withdrawal intent log data instance.
+    ///
+    /// Returns `None` if `dest` exceeds the [`DestinationBufVec`] bound.
+    pub fn new(amt: u64, dest: Vec<u8>, selected_operator: u32) -> Option<Self> {
+        let dest = VarVec::from_vec(dest)?;
+        Some(Self {
+            amt,
+            dest,
+            selected_operator,
+        })
+    }
+
+    /// Get the withdrawal amount.
+    pub fn amt(&self) -> u64 {
+        self.amt
+    }
+
+    /// Get the destination as bytes.
+    pub fn dest(&self) -> &[u8] {
+        self.dest.as_ref()
+    }
+}
+
+impl OLLogType for SimpleWithdrawalIntentLogData {
+    const LOG_TYPE_ID: TypeId = SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID;
+}
+
+/// Payload for a snark account update log.
+///
+/// This log is emitted when a snark account is updated through a transaction.
+/// It contains the new message index (sequence number) and any extra data
+/// from the update operation.
+#[derive(Debug, Clone, PartialEq, Eq, Codec)]
+pub struct SnarkAccountUpdateLogData {
+    /// The new message index (sequence number) after the update.
+    pub new_msg_idx: u64,
+
+    /// Extra data from the update operation.
+    pub extra_data: ExtraDataBufVec,
+}
+
+impl SnarkAccountUpdateLogData {
+    /// Create a new snark account update log data instance.
+    ///
+    /// Returns `None` if `extra_data` exceeds the [`ExtraDataBufVec`] bound.
+    pub fn new(new_msg_idx: u64, extra_data: Vec<u8>) -> Option<Self> {
+        VarVec::from_vec(extra_data).map(|extra_data| Self {
+            new_msg_idx,
+            extra_data,
+        })
+    }
+
+    /// Get the new message index.
+    pub fn new_msg_idx(&self) -> u64 {
+        self.new_msg_idx
+    }
+
+    /// Get the extra data as bytes.
+    pub fn extra_data(&self) -> &[u8] {
+        self.extra_data.as_ref()
+    }
+}
+
+impl OLLogType for SnarkAccountUpdateLogData {
+    const LOG_TYPE_ID: TypeId = SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID;
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use strata_codec::{decode_buf_exact, encode_to_vec};
+    use strata_msg_fmt::{Msg, MsgRef};
+
+    use super::*;
+    use crate::LogDecodeError;
+
+    fn withdrawal_strategy() -> impl Strategy<Value = SimpleWithdrawalIntentLogData> {
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=MAX_DEST_BYTES as usize),
+            any::<u32>(),
+        )
+            .prop_map(|(amt, dest, selected_operator)| {
+                SimpleWithdrawalIntentLogData::new(amt, dest, selected_operator)
+                    .expect("dest within bounds")
+            })
+    }
+
+    fn snark_update_strategy() -> impl Strategy<Value = SnarkAccountUpdateLogData> {
+        (
+            any::<u64>(),
+            prop::collection::vec(any::<u8>(), 0..=MAX_EXTRA_DATA_BYTES as usize),
+        )
+            .prop_map(|(new_msg_idx, extra_data)| {
+                SnarkAccountUpdateLogData::new(new_msg_idx, extra_data)
+                    .expect("extra data within bounds")
+            })
+    }
+
+    /// Byte-level conformance lock for the withdrawal-intent log envelope.
+    ///
+    /// This pins the exact `encode_log` output for a fixed payload so the wire contract cannot
+    /// drift silently while the duplicated copies in asm/strata are being deleted during the
+    /// three-repo rollout. If this assertion changes, the wire format changed: do NOT delete any
+    /// downstream copy until the divergence is understood.
+    #[test]
+    fn test_withdrawal_log_wire_conformance() {
+        let log = SimpleWithdrawalIntentLogData::new(
+            0x0102_0304_0506_0708,
+            b"dest".to_vec(),
+            0x0a0b_0c0d,
+        )
+        .expect("dest within bounds");
+
+        let envelope = log.encode_log().expect("encode_log should succeed");
+
+        // type-id prefix (0x01) ++ codec(amt u64) ++ codec(dest VarVec) ++ codec(selected u32).
+        // Integers are big-endian; the VarVec is a varint length prefix followed by its bytes.
+        let expected: &[u8] = &[
+            0x01, // msg-fmt type id
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // amt (BE u64)
+            0x04, // dest length (varint)
+            b'd', b'e', b's', b't', // dest bytes
+            0x0a, 0x0b, 0x0c, 0x0d, // selected_operator (BE u32)
+        ];
+        assert_eq!(envelope.as_slice(), expected);
+    }
+
+    #[test]
+    fn test_simple_withdrawal_intent_log_data_codec() {
+        let log_data = SimpleWithdrawalIntentLogData {
+            amt: 100_000_000, // 1 BTC
+            dest: VarVec::from_vec(b"bc1qtest123456789".to_vec()).unwrap(),
+            selected_operator: 42,
+        };
+
+        let encoded = encode_to_vec(&log_data).unwrap();
+        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
+
+        assert_eq!(decoded.amt, log_data.amt);
+        assert_eq!(decoded.dest.as_ref(), log_data.dest.as_ref());
+        assert_eq!(decoded.selected_operator, log_data.selected_operator);
+    }
+
+    #[test]
+    fn test_simple_withdrawal_intent_empty_dest() {
+        let log_data = SimpleWithdrawalIntentLogData {
+            amt: 50_000,
+            dest: VarVec::from_vec(vec![]).unwrap(),
+            selected_operator: 0,
+        };
+
+        let encoded = encode_to_vec(&log_data).unwrap();
+        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
+
+        assert_eq!(decoded.amt, 50_000);
+        assert!(decoded.dest.is_empty());
+    }
+
+    #[test]
+    fn test_simple_withdrawal_intent_max_values() {
+        let log_data = SimpleWithdrawalIntentLogData {
+            amt: u64::MAX,
+            dest: VarVec::from_vec(vec![255u8; 200]).unwrap(),
+            selected_operator: u32::MAX,
+        };
+
+        let encoded = encode_to_vec(&log_data).unwrap();
+        let decoded: SimpleWithdrawalIntentLogData = decode_buf_exact(&encoded).unwrap();
+
+        assert_eq!(decoded.amt, u64::MAX);
+        assert_eq!(decoded.dest.len(), 200);
+        assert_eq!(decoded.dest.as_ref(), &vec![255u8; 200][..]);
+    }
+
+    #[test]
+    fn test_snark_account_update_log_data_codec() {
+        let log_data = SnarkAccountUpdateLogData {
+            new_msg_idx: 12345,
+            extra_data: VarVec::from_vec(b"extra_test_data".to_vec()).unwrap(),
+        };
+
+        let encoded = encode_to_vec(&log_data).unwrap();
+        let decoded: SnarkAccountUpdateLogData = decode_buf_exact(&encoded).unwrap();
+
+        assert_eq!(decoded.new_msg_idx, log_data.new_msg_idx);
+        assert_eq!(decoded.extra_data.as_ref(), log_data.extra_data.as_ref());
+    }
+
+    #[test]
+    fn test_snark_account_update_max_values() {
+        let log_data = SnarkAccountUpdateLogData {
+            new_msg_idx: u64::MAX,
+            extra_data: VarVec::from_vec(vec![255u8; 250]).unwrap(),
+        };
+
+        let encoded = encode_to_vec(&log_data).unwrap();
+        let decoded: SnarkAccountUpdateLogData = decode_buf_exact(&encoded).unwrap();
+
+        assert_eq!(decoded.new_msg_idx, u64::MAX);
+        assert_eq!(decoded.extra_data.len(), 250);
+        assert_eq!(decoded.extra_data.as_ref(), &vec![255u8; 250][..]);
+    }
+
+    #[test]
+    fn test_log_envelope_round_trip() {
+        let snark = SnarkAccountUpdateLogData {
+            new_msg_idx: 7,
+            extra_data: VarVec::from_vec(b"abc".to_vec()).unwrap(),
+        };
+        let encoded = snark.encode_log().unwrap();
+
+        // Envelope carries the type id prefix.
+        let msg = MsgRef::try_from(encoded.as_slice()).unwrap();
+        assert_eq!(msg.ty(), SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID);
+
+        let decoded = SnarkAccountUpdateLogData::try_decode_log(&msg).unwrap();
+        assert_eq!(decoded, snark);
+    }
+
+    #[test]
+    fn test_log_decode_type_mismatch() {
+        let withdrawal = SimpleWithdrawalIntentLogData {
+            amt: 10,
+            dest: VarVec::from_vec(b"d".to_vec()).unwrap(),
+            selected_operator: 1,
+        };
+        let encoded = withdrawal.encode_log().unwrap();
+        let msg = MsgRef::try_from(encoded.as_slice()).unwrap();
+
+        // Decoding as the wrong log type reports a type mismatch rather than a spurious decode.
+        let err = SnarkAccountUpdateLogData::try_decode_log(&msg).unwrap_err();
+        assert!(matches!(
+            err,
+            LogDecodeError::TypeMismatch {
+                expected: SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID,
+                found,
+            } if found == SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID
+        ));
+
+        // And decoding as the right type still works.
+        SimpleWithdrawalIntentLogData::try_decode_log(&msg).unwrap();
+    }
+
+    proptest! {
+        #[test]
+        fn test_withdrawal_log_envelope_round_trip(log_data in withdrawal_strategy()) {
+            let encoded = log_data.encode_log().expect("encode_log should succeed");
+
+            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
+            prop_assert_eq!(msg.ty(), SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID);
+
+            let decoded = SimpleWithdrawalIntentLogData::try_decode_log(&msg)
+                .expect("try_decode_log should succeed");
+            prop_assert_eq!(decoded, log_data);
+        }
+
+        #[test]
+        fn test_snark_update_log_envelope_round_trip(log_data in snark_update_strategy()) {
+            let encoded = log_data.encode_log().expect("encode_log should succeed");
+
+            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
+            prop_assert_eq!(msg.ty(), SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID);
+
+            let decoded = SnarkAccountUpdateLogData::try_decode_log(&msg)
+                .expect("try_decode_log should succeed");
+            prop_assert_eq!(decoded, log_data);
+        }
+
+        /// Decoding a withdrawal envelope as a snark update (and vice versa) reports a type
+        /// mismatch rather than a spurious decode.
+        #[test]
+        fn test_withdrawal_log_decode_type_mismatch(log_data in withdrawal_strategy()) {
+            let encoded = log_data.encode_log().expect("encode_log should succeed");
+            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
+
+            let err = SnarkAccountUpdateLogData::try_decode_log(&msg)
+                .expect_err("decoding as the wrong type should fail");
+            let is_expected_mismatch = matches!(
+                err,
+                LogDecodeError::TypeMismatch {
+                    expected: SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID,
+                    found,
+                } if found == SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID
+            );
+            prop_assert!(is_expected_mismatch);
+        }
+
+        #[test]
+        fn test_snark_update_log_decode_type_mismatch(log_data in snark_update_strategy()) {
+            let encoded = log_data.encode_log().expect("encode_log should succeed");
+            let msg = MsgRef::try_from(encoded.as_slice()).expect("envelope should parse");
+
+            let err = SimpleWithdrawalIntentLogData::try_decode_log(&msg)
+                .expect_err("decoding as the wrong type should fail");
+            let is_expected_mismatch = matches!(
+                err,
+                LogDecodeError::TypeMismatch {
+                    expected: SIMPLE_WITHDRAWAL_INTENT_LOG_TYPE_ID,
+                    found,
+                } if found == SNARK_ACCOUNT_UPDATE_LOG_TYPE_ID
+            );
+            prop_assert!(is_expected_mismatch);
+        }
+    }
+}

--- a/crates/ol-logs/ssz/log.ssz
+++ b/crates/ol-logs/ssz/log.ssz
@@ -1,6 +1,6 @@
 import strata_identifiers
 
-MAX_LOG_PAYLOAD_LEN = 1 << 9
+MAX_LOG_PAYLOAD_LEN = 1 << 12
 
 ### OL log entry emitted during block execution.
 class OLLog(Container):

--- a/crates/ol-logs/ssz/log.ssz
+++ b/crates/ol-logs/ssz/log.ssz
@@ -1,0 +1,11 @@
+import strata_identifiers
+
+MAX_LOG_PAYLOAD_LEN = 1 << 9
+
+### OL log entry emitted during block execution.
+class OLLog(Container):
+    ### Account serial number this log relates to
+    account_serial: strata_identifiers.AccountSerial
+
+    ### Opaque log payload
+    payload: List[uint8, MAX_LOG_PAYLOAD_LEN]


### PR DESCRIPTION
## Description

Adds `crates/ol-logs` (`strata-ol-logs`) as the single source of truth for the orchestration-layer (OL) log layer that was previously duplicated and hand-synced between asm (`strata-asm-proto-checkpoint-types`) and strata (`strata-ol-chain-types-new`). strata-common is the common ancestor of both, so it is the right home for types that must stay byte-identical across the producer (strata OL) / consumer (asm verification) boundary — the two copies had already drifted despite "MUST stay in sync" comments, and divergence here silently drops withdrawal intents from checkpoints.

The crate owns: the typed payload structs (`SimpleWithdrawalIntentLogData`, `SnarkAccountUpdateLogData`) and their type-id namespace (`0x01`/`0x02`); the `OLLog` SSZ container with its `from_log`/`try_into_log`/`compute_hash_commitment` helpers; the reconciled `OLLogType` envelope codec; the unified `LogDecodeError`; and a `decode_typed_logs` filter/decode helper over `&[OLLog]`.

### Type of Change

- [x] Refactor
- [x] New or updated tests

## Notes to Reviewers

Four things worth an explicit look:

1. **Scope is narrower than [STR-3629](https://alpenlabs.atlassian.net/browse/STR-3629).** This ships only the urgent, funds-at-risk piece — the duplicated OL-log layer, which depends solely on `strata-codec`/`strata-msg-fmt`/`strata-identifiers` (no `AsmManifestRangeHash`, no dependency cycle). Relocating the checkpoint *payload* containers (`CheckpointPayload`/`Sidecar`/`Claim`/…) is deferred: only `CheckpointClaim` pulls in asm-domain manifest types, and we chose not to drag those into strata-common as a side effect of a log-layer fix. Crate is `strata-ol-logs`, not the ticket's `strata-checkpoint-types`.

2. **`MAX_LOG_PAYLOAD_LEN` raised to `1 << 12` (4096) — a wire-format decision; please confirm.** The original 512 cap was unsafe: a valid `SnarkAccountUpdateLogData` carries `extra_data` up to 1024 bytes, whose envelope (≈1035 bytes) exceeds 512. 4096 fits the largest valid payload with headroom; `from_log_fits_max_snark_payload` pins it.

3. **`OLLog::from_log` is now fallible on oversize, not just dependent on the cap.** It previously built the payload via the panicking `OLLog::new`, so an over-cap envelope aborted (`VariableList::new(...).expect(...)`) despite `from_log`'s `Result` signature. Oversize now routes through the new fallible `OLLog::try_new` and surfaces as `CodecError::OverflowContainer`, so the `Result` is honoured even if a future payload type outgrows the cap; `new` stays a thin panicking convenience for the infallible callers.

4. **`decode_typed_logs` yields `Result<T, LogDecodeError>` per matching entry, not bare `T`.** A log whose msg-fmt prefix matches `T`'s type id but whose body is malformed/truncated surfaces as `Err` instead of being silently skipped, so checkpoint verifiers can hard-fail rather than treat a corrupt withdrawal log as an absent intent (the silent-drop failure mode this whole PR exists to kill). Only `TypeMismatch` (genuinely "not a `T`") and account-guard misses are skipped, so callers must handle the `Err` arm.

This is **Phase 1** of a coordinated three-repo rollout. Follow-ups (separate PRs, after a strata-common tag): asm points `payload.ssz` at the imported `OLLog` and reimplements `extract_withdrawal_intents` on `decode_typed_logs`; strata bumps the pin and deletes its copy. The wire contract holds until all three land. `test_withdrawal_log_wire_conformance` pins the exact envelope encoding so the format can't drift while the copies are removed (it already caught a big-endian/little-endian bug during development).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3629


[STR-3629]: https://alpenlabs.atlassian.net/browse/STR-3629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

