### PR TITLE
chore(deps): bump zkaleido to v0.1-beta.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
 dependencies = [
  "bincode",
  "borsh",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.4#5ea37d52d253ff890efbfbd1422aad4c3def58f7"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
 dependencies = [
  "blake3",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 zeroize = { version = "1.8.1", features = ["derive"] }
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.4" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"


### PR DESCRIPTION
## Description

Bumps the `zkaleido` and `zkaleido-sp1-groth16-verifier` git dependencies from `v0.1-beta.4` to `v0.1-beta.5` to keep the workspace in sync with the latest upstream release.

### Type of Change

- [x] Dependency update

## Notes to Reviewers

Mechanical version bump only — `Cargo.toml` tags updated and `Cargo.lock` regenerated.

## Checklist

- [x] I have performed a self-review of my code.
- [x] New and existing tests pass with my changes.

## Related Issues

