### PR TITLE
chore(deps): bump zkaleido to v0.3.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5381,7 +5381,7 @@ dependencies = [
 [[package]]
 name = "zkaleido"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "bincode",
  "borsh",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "zkaleido-sp1-groth16-verifier"
 version = "0.1.0"
-source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.1-beta.5#0ee0c39cd1a05a79db91266126550f9aa61b4524"
+source = "git+https://github.com/alpenlabs/zkaleido?tag=v0.3.0-rc.1#b1c3a5a34ea713d6e35e792c497d4f8327feaf61"
 dependencies = [
  "blake3",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 zeroize = { version = "1.8.1", features = ["derive"] }
-zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
-zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1-beta.5" }
+zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
+zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0-rc.1" }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"


### PR DESCRIPTION
## Description

Bumps the `zkaleido` and `zkaleido-sp1-groth16-verifier` workspace dependencies from `v0.1-beta.5` to the new `v0.3.0-rc.1` tag so the workspace tracks the latest zkaleido release. `cargo check --workspace --all-features` passes.

### Type of Change

- [x] Dependency update

## Notes to Reviewers

Pure dependency bump — only `Cargo.toml` and `Cargo.lock` change.

### Why the exact tag string matters

Cargo identifies a git dependency by its *source id* — `(canonical repo URL, git reference)` — not by the commit it resolves to. A package in the graph is keyed by `(name, version, source_id)`, so two references to the same repo with different reference strings (e.g. `tag = "v0.1-beta.5"` vs `tag = "v0.3.0-rc.1"`, or `tag` vs `rev`) are two distinct source ids and Cargo compiles the crate twice — **even if both tags point to the same commit**. Dedup happens at the source-id level, before resolution, so "same commit, different tag" is not enough to unify them. The symptom downstream is the "multiple versions found" / duplicate-crate situation and confusing `expected zkaleido::Foo, found zkaleido::Foo` type errors.

This matters for consumers like alpen, which depend on `zkaleido` both directly and transitively through `strata-common`: the two copies only collapse into one when every pin uses the **identical** tag string. So a follow-up is needed to align alpen's direct `zkaleido` pin with this `v0.3.0-rc.1` tag.

## Checklist

- [x] I have performed a self-review of my code.
- [x] My changes do not introduce new warnings.
- [x] New and existing tests pass with my changes.

## Related Issues
