### PR TITLE
fix(strata-service): correct lifecycle span attribution

### DIFF
--- a/crates/service/src/async_worker.rs
+++ b/crates/service/src/async_worker.rs
@@ -28,75 +28,78 @@ where
     // Create parent lifecycle span wrapping entire service lifetime
     let lifecycle_span =
         instrumentation.create_lifecycle_span(&span_prefix, &service_name, "async");
-    let _lifecycle_guard = lifecycle_span.enter();
 
-    info!(service.name = %service_name, "service starting");
+    async move {
+        info!(service.name = %service_name, "service starting");
 
-    // Perform startup logic.  If this errors we propagate it immediately and
-    // crash the task.
-    {
-        let launch_span = info_span!(
-            "service.launch",
-            span_prefix = %span_prefix,
-            service.name = %service_name,
-        );
-        let start = Instant::now();
+        // Perform startup logic.  If this errors we propagate it immediately and
+        // crash the task.
+        {
+            let launch_span = info_span!(
+                "service.launch",
+                span_prefix = %span_prefix,
+                service.name = %service_name,
+            );
+            let start = Instant::now();
 
-        let launch_result = S::on_launch(&mut state).instrument(launch_span).await;
-        let duration = start.elapsed();
-        let result = OperationResult::from(&launch_result);
+            let launch_result = S::on_launch(&mut state).instrument(launch_span).await;
+            let duration = start.elapsed();
+            let result = OperationResult::from(&launch_result);
 
-        instrumentation.record_launch(duration, result);
+            instrumentation.record_launch(duration, result);
 
-        launch_result?;
-        info!(service.name = %service_name, duration_ms = duration.as_millis(), "service launch completed");
-    }
-
-    // Wrapping for the worker task to respect shutdown requests.
-    let err = {
-        let mut exit_fut = Box::pin(shutdown_guard.wait_for_shutdown().fuse());
-        let mut wkr_fut = Box::pin(
-            worker_task_inner::<S, I>(
-                &mut state,
-                &mut inp,
-                &status_tx,
-                &instrumentation,
-                &span_prefix,
-            )
-            .fuse(),
-        );
-
-        futures::select! {
-            _ = exit_fut => {
-                info!(service.name = %service_name, "shutdown signal received");
-                None
-            },
-            res = wkr_fut => res.err(),
+            launch_result?;
+            info!(service.name = %service_name, duration_ms = duration.as_millis(), "service launch completed");
         }
-    };
 
-    // Perform shutdown handling.
-    let shutdown_reason = if err.is_some() {
-        ShutdownReason::Error
-    } else {
-        ShutdownReason::Normal
-    };
+        // Wrapping for the worker task to respect shutdown requests.
+        let err = {
+            let mut exit_fut = Box::pin(shutdown_guard.wait_for_shutdown().fuse());
+            let mut wkr_fut = Box::pin(
+                worker_task_inner::<S, I>(
+                    &mut state,
+                    &mut inp,
+                    &status_tx,
+                    &instrumentation,
+                    &span_prefix,
+                )
+                .fuse(),
+            );
 
-    handle_shutdown::<S>(
-        &mut state,
-        err.as_ref(),
-        &instrumentation,
-        shutdown_reason,
-        &span_prefix,
-    )
-    .await;
+            futures::select! {
+                _ = exit_fut => {
+                    info!(service.name = %service_name, "shutdown signal received");
+                    None
+                },
+                res = wkr_fut => res.err(),
+            }
+        };
 
-    info!(service.name = %service_name, "service stopped");
+        // Perform shutdown handling.
+        let shutdown_reason = if err.is_some() {
+            ShutdownReason::Error
+        } else {
+            ShutdownReason::Normal
+        };
 
-    match err {
-        Some(e) => Err(e),
-        None => Ok(()),
+        handle_shutdown::<S>(
+            &mut state,
+            err.as_ref(),
+            &instrumentation,
+            shutdown_reason,
+            &span_prefix,
+        )
+        .await;
+
+        info!(service.name = %service_name, "service stopped");
+
+        match err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
+    .instrument(lifecycle_span)
+    .await
 }
 
 async fn worker_task_inner<S: AsyncService, I>(


### PR DESCRIPTION
## Description
Display correct spans in logs when using strata_service/async_worker. 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers
The service lifecycle span was entered with a thread-local guard held across .await points. This caused unrelated logs to have `service.lifecycle` span added to them.

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
