### PR TITLE
test(crypto): fix flaky schnorr signature test

### DIFF
--- a/crates/crypto/src/schnorr.rs
+++ b/crates/crypto/src/schnorr.rs
@@ -215,8 +215,9 @@ mod tests {
 
         let msg: [u8; 32] = [(); 32].map(|_| OsRng.r#gen());
 
+        // Flip a bit so `mod_msg` always differs from `msg`.
         let mut mod_msg = msg;
-        mod_msg.swap(1, 2);
+        mod_msg[1] ^= 0x01;
         let msg = Buf32::from(msg);
         let mod_msg = Buf32::from(mod_msg);
 


### PR DESCRIPTION
## Description

`crates/crypto`'s `test_schnorr_signature_pass` is intermittently flaky in CI. It builds its "modified" message by swapping the bytes at indices 1 and 2 of a random 32-byte message, then asserts the original signature does **not** verify against that modified message. When those two random bytes happen to be equal (~1/256 chance), the swap is a no-op, the modified message equals the original, the signature verifies, and `assert!(!verify_schnorr_sig(...))` fails.

This surfaced as an unrelated unit-test failure on an open PR. The fix flips a single bit (`mod_msg[1] ^= 0x01`) so the modified message is always guaranteed to differ from the original, making the test deterministic.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New or updated tests

## Notes to Reviewers

Pre-existing flakiness on `main`, not introduced by any recent change. Landing as its own PR since it's unrelated to other in-flight work.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
