### PR TITLE
feat: add shared bridge gateway and L1-height MMR constants

### DIFF
--- a/crates/identifiers/src/acct.rs
+++ b/crates/identifiers/src/acct.rs
@@ -147,6 +147,15 @@ impl fmt::Display for AccountSerial {
 #[cfg(feature = "ssz")]
 crate::impl_ssz_transparent_wrapper!(AccountSerial, RawAccountSerial);
 
+/// Reserved account reference assigned to the bridge gateway account.
+const BRIDGE_GATEWAY_REF: u8 = 0x10;
+
+/// Account ID assigned to the bridge gateway account.
+pub const BRIDGE_GATEWAY_ACCT_ID: AccountId = AccountId::special(BRIDGE_GATEWAY_REF);
+
+/// Account serial assigned to the bridge gateway account.
+pub const BRIDGE_GATEWAY_ACCT_SERIAL: AccountSerial = AccountSerial::reserved(BRIDGE_GATEWAY_REF);
+
 type RawSubjectId = [u8; SUBJ_ID_LEN];
 
 /// Identifier for a "subject" within the scope of an execution environment.

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -32,8 +32,8 @@ pub mod hash {
 }
 
 pub use acct::{
-    AccountId, AccountSerial, AccountTypeId, RawAccountTypeId, SUBJ_ID_LEN, SYSTEM_RESERVED_ACCTS,
-    SubjectId, SubjectIdBytes,
+    AccountId, AccountSerial, AccountTypeId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL,
+    RawAccountTypeId, SUBJ_ID_LEN, SYSTEM_RESERVED_ACCTS, SubjectId, SubjectIdBytes,
 };
 pub use buf::{Buf20, Buf32, Buf64, RBuf32};
 pub use epoch::EpochCommitment;

--- a/crates/merkle/src/lib.rs
+++ b/crates/merkle/src/lib.rs
@@ -29,6 +29,16 @@ mod proof;
 mod traits;
 mod tree;
 
+/// Prefill leaf used for L1-height-indexed MMRs before genesis.
+///
+/// MMR state treats [`MerkleHash::zero`] peak values as absent, so prefilled leaves use a
+/// non-zero value. Consumers that prefill the same height-indexed MMR must agree on this leaf to
+/// produce the same roots.
+///
+/// The specific bytes do not affect proof semantics as long as no real proof references a
+/// prefilled position.
+pub const L1_HEIGHT_MMR_PREFILL_LEAF: [u8; 32] = [0xffu8; 32];
+
 pub use error::*;
 pub use ext::*;
 pub use hasher::*;


### PR DESCRIPTION
## Description

- Add `BRIDGE_GATEWAY_ACCT_ID` and `BRIDGE_GATEWAY_ACCT_SERIAL` to `strata-identifiers` to avoid duplicate bridge gateway account definitions in `alpen` and `asm`.
- Add `L1_HEIGHT_MMR_PREFILL_LEAF` to `strata-merkle` to avoid duplicate L1-height-indexed MMR prefill values in `alpen` and `asm`.

**Notes**
- The MMR prefill constant is scoped to L1-height-indexed MMRs, not generic MMR usage.
- No shared `ALPN` magic-byte constant is added; magic bytes are network/config values and the EE-DA baked constant should be handled separately under STR-1907.

This PR was created with help from Claude Code and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

Closes [STR-3417](https://alpenlabs.atlassian.net/browse/STR-3417), addresses some parts of [STR-3315](https://alpenlabs.atlassian.net/browse/STR-3315)

[STR-3417]: https://alpenlabs.atlassian.net/browse/STR-3417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ