### PR TITLE
Add serde-utils crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,6 +4197,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-serde-utils"
+version = "0.1.0"
+dependencies = [
+ "arbitrary",
+ "ciborium",
+ "hex",
+ "serde",
+ "serde_json",
+ "ssz",
+ "ssz_derive",
+ "strata-codec",
+]
+
+[[package]]
 name = "strata-service"
 version = "0.3.0-alpha.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/msg-fmt",
   "crates/ol-logs",
   "crates/predicate",
+  "crates/serde-utils",
   "crates/service",
   "crates/ssz-tests",
   "crates/tasks",
@@ -41,6 +42,7 @@ strata-metrics = { path = "crates/metrics" }
 strata-msg-fmt = { path = "crates/msg-fmt" }
 strata-ol-logs = { path = "crates/ol-logs" }
 strata-predicate = { path = "crates/predicate" }
+strata-serde-utils = { path = "crates/serde-utils" }
 strata-service = { path = "crates/service" }
 strata-ssz-tests = { path = "crates/ssz-tests" }
 strata-tasks = { path = "crates/tasks" }
@@ -61,6 +63,7 @@ bincode = "1.3"
 bitcoin = { version = "0.32.9" }
 bitcoin-bosd = { version = "0.9.0", default-features = false }
 borsh = { version = "1.5.0", features = ["derive"] }
+ciborium = "0.2"
 const-hex = "1.18"
 digest = "0.10"
 futures = "0.3"

--- a/crates/codec-utils/src/borsh_shim.rs
+++ b/crates/codec-utils/src/borsh_shim.rs
@@ -3,6 +3,9 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_codec::{Codec, CodecError, Decoder, Encoder, Varint};
 
+/// Maximum byte length for a single Borsh-encoded object (16 MiB).
+const MAX_BORSH_OBJECT_BYTES: usize = 16 << 20;
+
 /// Wraps a Borsh type so that it can be transparently [`Codec`]ed.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, BorshSerialize, BorshDeserialize)]
 pub struct CodecBorsh<T: BorshSerialize + BorshDeserialize>(pub T);
@@ -30,6 +33,10 @@ impl<T: BorshSerialize + BorshDeserialize> Codec for CodecBorsh<T> {
         let len = Varint::decode(dec)?;
         let len_usize = len.inner() as usize;
 
+        if len_usize > MAX_BORSH_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
+
         // Read a buffer of that size.
         let mut buffer = vec![0u8; len_usize];
         dec.read_buf(&mut buffer)?;
@@ -43,6 +50,10 @@ impl<T: BorshSerialize + BorshDeserialize> Codec for CodecBorsh<T> {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         // Encode convert the inner value to Borsh.
         let bytes = borsh::to_vec(&self.0).map_err(|_| CodecError::MalformedField("borsh"))?;
+
+        if bytes.len() > MAX_BORSH_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
 
         // First encode the length as a varint.
         let len = Varint::new_usize(bytes.len()).ok_or(CodecError::OverflowContainer)?;

--- a/crates/codec-utils/src/ssz_shim.rs
+++ b/crates/codec-utils/src/ssz_shim.rs
@@ -4,6 +4,9 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use strata_codec::{Codec, CodecError, Decoder, Encoder, Varint};
 
+/// Maximum byte length for a single SSZ-encoded object (16 MiB).
+const MAX_SSZ_OBJECT_BYTES: usize = 16 << 20;
+
 /// Wraps an SSZ type so that it can be transparently [`Codec`]ed.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Decode, Encode)]
 #[ssz(struct_behaviour = "transparent")]
@@ -37,6 +40,10 @@ impl<T: Decode + Encode> Codec for CodecSsz<T> {
         let len = Varint::decode(dec)?;
         let len_usize = len.inner() as usize;
 
+        if len_usize > MAX_SSZ_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
+
         // Read a buffer of that size.
         let mut buffer = vec![0u8; len_usize];
         dec.read_buf(&mut buffer)?;
@@ -50,6 +57,10 @@ impl<T: Decode + Encode> Codec for CodecSsz<T> {
     fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
         // Encode convert the inner value to SSZ.
         let bytes = self.0.as_ssz_bytes();
+
+        if bytes.len() > MAX_SSZ_OBJECT_BYTES {
+            return Err(CodecError::OverflowContainer);
+        }
 
         // First encode the length as a varint.
         let len = Varint::new_usize(bytes.len()).ok_or(CodecError::OverflowContainer)?;

--- a/crates/serde-utils/Cargo.toml
+++ b/crates/serde-utils/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "strata-serde-utils"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+hex.workspace = true
+serde.workspace = true
+ssz.workspace = true
+strata-codec.workspace = true
+
+arbitrary = { workspace = true, optional = true }
+
+[dev-dependencies]
+ciborium.workspace = true
+serde_json.workspace = true
+ssz_derive.workspace = true
+
+[features]
+default = ["arbitrary"]
+arbitrary = ["dep:arbitrary"]
+
+[lints]
+workspace = true

--- a/crates/serde-utils/src/codec_shim.rs
+++ b/crates/serde-utils/src/codec_shim.rs
@@ -1,0 +1,176 @@
+//! Shim for exposing [`Codec`] types through [`serde`].
+
+use std::fmt;
+
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Visitor},
+    ser,
+};
+use strata_codec::{Codec, decode_buf_exact, encode_to_vec};
+
+/// Wraps a [`Codec`] type so that it can be transparently [`Serialize`]d and
+/// [`Deserialize`]d.
+///
+/// The inner value is encoded to its [`Codec`] byte representation. Binary
+/// formats receive it as a raw byte blob (like a `Vec<u8>`), while
+/// human-readable formats receive it as a hex-encoded string.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct SerdeCodec<T>(T);
+
+impl<T> SerdeCodec<T> {
+    /// Creates a new [`SerdeCodec`] wrapper around the given value.
+    pub fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    /// Returns a reference to the inner value.
+    pub fn inner(&self) -> &T {
+        &self.0
+    }
+
+    /// Consumes the wrapper and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    /// Returns a mutable reference to the inner value.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T: Codec> Serialize for SerdeCodec<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let bytes = encode_to_vec(&self.0).map_err(ser::Error::custom)?;
+
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&hex::encode(&bytes))
+        } else {
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+impl<'de, T: Codec> Deserialize<'de> for SerdeCodec<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            hex::decode(&s).map_err(de::Error::custom)?
+        } else {
+            deserializer.deserialize_bytes(BytesVisitor)?
+        };
+
+        let inner = decode_buf_exact(&bytes).map_err(de::Error::custom)?;
+
+        Ok(Self(inner))
+    }
+}
+
+/// Collects an arbitrary byte blob, accepting whatever shape the underlying
+/// binary format uses to represent bytes.
+struct BytesVisitor;
+
+impl<'de> Visitor<'de> for BytesVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a byte blob")
+    }
+
+    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        Ok(v.to_vec())
+    }
+
+    fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+        Ok(v)
+    }
+
+    fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut buf = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(byte) = seq.next_element()? {
+            buf.push(byte);
+        }
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strata_codec::{Codec, CodecError, Decoder, Encoder, VarVec};
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestStruct {
+        a: u32,
+        b: u64,
+    }
+
+    impl Codec for TestStruct {
+        fn decode(dec: &mut impl Decoder) -> Result<Self, CodecError> {
+            let a = u32::decode(dec)?;
+            let b = u64::decode(dec)?;
+            Ok(Self { a, b })
+        }
+
+        fn encode(&self, enc: &mut impl Encoder) -> Result<(), CodecError> {
+            self.a.encode(enc)?;
+            self.b.encode(enc)?;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_json_roundtrip_is_hex_string() {
+        let original = TestStruct { a: 42, b: 1337 };
+        let wrapped = SerdeCodec::new(original.clone());
+
+        let json = serde_json::to_string(&wrapped).expect("failed to serialize");
+
+        // Human-readable formats encode as a hex string.
+        let expected = format!("\"{}\"", hex::encode(encode_to_vec(&original).unwrap()));
+        assert_eq!(json, expected);
+
+        let decoded: SerdeCodec<TestStruct> =
+            serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_ciborium_roundtrip_is_binary() {
+        let original = TestStruct { a: 42, b: 1337 };
+        let wrapped = SerdeCodec::new(original.clone());
+
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&wrapped, &mut bytes).expect("failed to serialize");
+
+        let decoded: SerdeCodec<TestStruct> =
+            ciborium::from_reader(bytes.as_slice()).expect("failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_vector_roundtrip() {
+        let original: VarVec<u32> = VarVec::from_vec(vec![1u32, 2, 3, 4, 5]).unwrap();
+        let wrapped = SerdeCodec::new(original.clone());
+
+        let json = serde_json::to_string(&wrapped).expect("failed to serialize");
+        let decoded: SerdeCodec<VarVec<u32>> =
+            serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&wrapped, &mut bytes).expect("failed to serialize");
+        let decoded: SerdeCodec<VarVec<u32>> =
+            ciborium::from_reader(bytes.as_slice()).expect("failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_invalid_hex_fails() {
+        let bad = "\"not hex\"";
+        let result: Result<SerdeCodec<TestStruct>, _> = serde_json::from_str(bad);
+        assert!(result.is_err());
+    }
+}

--- a/crates/serde-utils/src/codec_shim.rs
+++ b/crates/serde-utils/src/codec_shim.rs
@@ -6,6 +6,8 @@ use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, ser};
 use strata_codec::{Codec, decode_buf_exact, encode_to_vec};
 
+use crate::common::prealloc_hinted_vec;
+
 /// Wraps a [`Codec`] type so that it can be transparently [`Serialize`]d and
 /// [`Deserialize`]d.
 ///
@@ -84,7 +86,7 @@ impl<'de> Visitor<'de> for BytesVisitor {
     }
 
     fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        let mut buf = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        let mut buf = prealloc_hinted_vec(seq.size_hint());
         while let Some(byte) = seq.next_element()? {
             buf.push(byte);
         }

--- a/crates/serde-utils/src/codec_shim.rs
+++ b/crates/serde-utils/src/codec_shim.rs
@@ -2,11 +2,8 @@
 
 use std::fmt;
 
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::{self, Visitor},
-    ser,
-};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, ser};
 use strata_codec::{Codec, decode_buf_exact, encode_to_vec};
 
 /// Wraps a [`Codec`] type so that it can be transparently [`Serialize`]d and

--- a/crates/serde-utils/src/common.rs
+++ b/crates/serde-utils/src/common.rs
@@ -1,0 +1,21 @@
+//! Common utilities.
+
+use std::mem;
+
+/// Maximum decoding size hint that we'll respect.
+const MAX_RESPECTED_HINT_BYTES: usize = 1 << 20; // 1 MiB
+
+/// Accepts a size hint and returns an new empty [`Vec`], potentially with a
+/// preallocated backing buffer.
+///
+/// If the total bytes that would be allocated based on the hint are below a
+/// resaonable size limit, the vec has the length hint number of bytes
+/// preallocated.  If it's over the limit, then we prealloc the most that would
+/// fit within the capacity limit.
+pub(crate) fn prealloc_hinted_vec<T>(hint: Option<usize>) -> Vec<T> {
+    let max_safe_len: usize = MAX_RESPECTED_HINT_BYTES / mem::size_of::<T>();
+    match hint {
+        Some(len) => Vec::with_capacity(usize::min(len, max_safe_len)),
+        _ => Vec::new(),
+    }
+}

--- a/crates/serde-utils/src/common.rs
+++ b/crates/serde-utils/src/common.rs
@@ -14,8 +14,6 @@ const MAX_RESPECTED_HINT_BYTES: usize = 1 << 20; // 1 MiB
 /// fit within the capacity limit.
 pub(crate) fn prealloc_hinted_vec<T>(hint: Option<usize>) -> Vec<T> {
     let max_safe_len: usize = MAX_RESPECTED_HINT_BYTES / mem::size_of::<T>();
-    match hint {
-        Some(len) => Vec::with_capacity(usize::min(len, max_safe_len)),
-        _ => Vec::new(),
-    }
+    let len = hint.map(|len| len.min(max_safe_len)).unwrap_or_default();
+    Vec::with_capacity(len)
 }

--- a/crates/serde-utils/src/lib.rs
+++ b/crates/serde-utils/src/lib.rs
@@ -1,0 +1,7 @@
+//! Utils for exposing other formats through [`serde`].
+
+mod codec_shim;
+mod ssz_shim;
+
+pub use codec_shim::*;
+pub use ssz_shim::*;

--- a/crates/serde-utils/src/lib.rs
+++ b/crates/serde-utils/src/lib.rs
@@ -1,6 +1,7 @@
 //! Utils for exposing other formats through [`serde`].
 
 mod codec_shim;
+mod common;
 mod ssz_shim;
 
 pub use codec_shim::*;

--- a/crates/serde-utils/src/ssz_shim.rs
+++ b/crates/serde-utils/src/ssz_shim.rs
@@ -1,0 +1,163 @@
+//! Shim for exposing SSZ types through [`serde`].
+
+use std::fmt;
+
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Visitor},
+};
+use ssz::{Decode, Encode};
+
+/// Wraps an SSZ type so that it can be transparently [`Serialize`]d and
+/// [`Deserialize`]d.
+///
+/// The inner value is encoded to its SSZ byte representation. Binary formats
+/// receive it as a raw byte blob (like a `Vec<u8>`), while human-readable
+/// formats receive it as a hex-encoded string.
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct SerdeSsz<T>(T);
+
+impl<T> SerdeSsz<T> {
+    /// Creates a new [`SerdeSsz`] wrapper around the given value.
+    pub fn new(inner: T) -> Self {
+        Self(inner)
+    }
+
+    /// Returns a reference to the inner value.
+    pub fn inner(&self) -> &T {
+        &self.0
+    }
+
+    /// Consumes the wrapper and returns the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+
+    /// Returns a mutable reference to the inner value.
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T: Encode> Serialize for SerdeSsz<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let bytes = self.0.as_ssz_bytes();
+
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&hex::encode(&bytes))
+        } else {
+            serializer.serialize_bytes(&bytes)
+        }
+    }
+}
+
+impl<'de, T: Decode> Deserialize<'de> for SerdeSsz<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let bytes = if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            hex::decode(&s).map_err(de::Error::custom)?
+        } else {
+            deserializer.deserialize_bytes(BytesVisitor)?
+        };
+
+        let inner =
+            T::from_ssz_bytes(&bytes).map_err(|e| de::Error::custom(format!("ssz ({e:?})")))?;
+
+        Ok(Self(inner))
+    }
+}
+
+/// Collects an arbitrary byte blob, accepting whatever shape the underlying
+/// binary format uses to represent bytes.
+struct BytesVisitor;
+
+impl<'de> Visitor<'de> for BytesVisitor {
+    type Value = Vec<u8>;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a byte blob")
+    }
+
+    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+        Ok(v.to_vec())
+    }
+
+    fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+        Ok(v)
+    }
+
+    fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        let mut buf = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        while let Some(byte) = seq.next_element()? {
+            buf.push(byte);
+        }
+        Ok(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ssz_derive::{Decode, Encode};
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode)]
+    struct TestStruct {
+        a: u32,
+        b: u64,
+    }
+
+    #[test]
+    fn test_json_roundtrip_is_hex_string() {
+        let original = TestStruct { a: 42, b: 1337 };
+        let wrapped = SerdeSsz::new(original.clone());
+
+        let json = serde_json::to_string(&wrapped).expect("test: failed to serialize");
+
+        // Human-readable formats encode as a hex string.
+        let expected = format!("\"{}\"", hex::encode(original.as_ssz_bytes()));
+        assert_eq!(json, expected);
+
+        let decoded: SerdeSsz<TestStruct> =
+            serde_json::from_str(&json).expect("test: failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_ciborium_roundtrip_is_binary() {
+        let original = TestStruct { a: 42, b: 1337 };
+        let wrapped = SerdeSsz::new(original.clone());
+
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&wrapped, &mut bytes).expect("test: failed to serialize");
+
+        let decoded: SerdeSsz<TestStruct> =
+            ciborium::from_reader(bytes.as_slice()).expect("test: failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_vector_roundtrip() {
+        let original = vec![1u32, 2, 3, 4, 5];
+        let wrapped = SerdeSsz::new(original.clone());
+
+        let json = serde_json::to_string(&wrapped).expect("test: failed to serialize");
+        let decoded: SerdeSsz<Vec<u32>> =
+            serde_json::from_str(&json).expect("test: failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&wrapped, &mut bytes).expect("test: failed to serialize");
+        let decoded: SerdeSsz<Vec<u32>> =
+            ciborium::from_reader(bytes.as_slice()).expect("test: failed to deserialize");
+        assert_eq!(decoded.inner(), &original);
+    }
+
+    #[test]
+    fn test_invalid_hex_fails() {
+        let bad = "\"not hex\"";
+        let result: Result<SerdeSsz<TestStruct>, _> = serde_json::from_str(bad);
+        assert!(result.is_err());
+    }
+}

--- a/crates/serde-utils/src/ssz_shim.rs
+++ b/crates/serde-utils/src/ssz_shim.rs
@@ -6,6 +6,8 @@ use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
 
+use crate::common::prealloc_hinted_vec;
+
 /// Wraps an SSZ type so that it can be transparently [`Serialize`]d and
 /// [`Deserialize`]d.
 ///
@@ -86,7 +88,7 @@ impl<'de> Visitor<'de> for BytesVisitor {
     }
 
     fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
-        let mut buf = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        let mut buf = prealloc_hinted_vec(seq.size_hint());
         while let Some(byte) = seq.next_element()? {
             buf.push(byte);
         }

--- a/crates/serde-utils/src/ssz_shim.rs
+++ b/crates/serde-utils/src/ssz_shim.rs
@@ -2,10 +2,8 @@
 
 use std::fmt;
 
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::{self, Visitor},
-};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use ssz::{Decode, Encode};
 
 /// Wraps an SSZ type so that it can be transparently [`Serialize`]d and


### PR DESCRIPTION
## Description

This PR adds a `strata-serde-utils` crate with utils for helping with writing serde-able serialization types when wrapping Codec and SSZ structures.  This is being used in the deborshification effort in the Alpen repo.

It also adds a sanity check that was missed to the `strata-codec-utils` crate.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
