### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 to fix cargo-audit failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Description

The `Run cargo-audit` CI job started failing because `crossbeam-epoch` `0.9.18` is affected by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204): its `fmt::Display` impl for `Atomic`/`Shared` dereferences the underlying pointer, causing an invalid dereference for a null pointer. The advisory is patched in `>= 0.9.20`.

The crate is pulled in only transitively (`crossbeam` -> `slop`/`sp1` dev-dependencies), so the fix is a lockfile-only bump to `0.9.20` — no manifest changes required. `cargo audit` now exits cleanly (only the pre-existing, non-blocking `unmaintained`/`unsound` warnings remain).

This was surfaced on #143 but is unrelated to that change, so it is split into its own PR against `main`.

### Type of Change

- [x] Dependency update
- [x] Security fix

## Notes to Reviewers

Lockfile-only change. Reproduced and verified locally with `cargo audit`.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!-- none -->
