### PR TITLE
feat(retry): add shared strata-retry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,15 +1577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,29 +2140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,15 +2525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,12 +2755,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
@@ -4300,7 +4253,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,6 +3963,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-retry"
+version = "0.3.0-alpha.1"
+dependencies = [
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "strata-serde-utils"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/msg-fmt",
   "crates/ol-logs",
   "crates/predicate",
+  "crates/retry",
   "crates/serde-utils",
   "crates/service",
   "crates/ssz-tests",
@@ -42,6 +43,7 @@ strata-metrics = { path = "crates/metrics" }
 strata-msg-fmt = { path = "crates/msg-fmt" }
 strata-ol-logs = { path = "crates/ol-logs" }
 strata-predicate = { path = "crates/predicate" }
+strata-retry = { path = "crates/retry" }
 strata-serde-utils = { path = "crates/serde-utils" }
 strata-service = { path = "crates/service" }
 strata-ssz-tests = { path = "crates/ssz-tests" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.94"
 sha2 = "0.10"
 thiserror = "2"
-tokio = { version = "1.37", features = ["full"] }
+tokio = { version = "1.37", default-features = false }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"

--- a/crates/db-macros/Cargo.toml
+++ b/crates/db-macros/Cargo.toml
@@ -13,7 +13,7 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full", "derive"] }
 
 [dev-dependencies]
-tokio = { version = "1.37", features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -26,6 +26,6 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/retry/Cargo.toml
+++ b/crates/retry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2021"
+name = "strata-retry"
+version = "0.3.0-alpha.1"
+
+[lints]
+workspace = true
+
+[dependencies]
+serde.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/crates/retry/src/config.rs
+++ b/crates/retry/src/config.rs
@@ -1,0 +1,85 @@
+//! Serde-friendly retry configuration.
+
+use serde::{Deserialize, Serialize};
+
+use crate::policies::ExponentialBackoff;
+
+/// Default retry attempts after the initial call.
+const DEFAULT_MAX_RETRIES: u16 = 10;
+/// Default initial delay before the first retry, in milliseconds.
+const DEFAULT_BASE_DELAY_MS: u64 = 1_000;
+/// Default backoff multiplier numerator (paired with [`DEFAULT_MULTIPLIER_BASE`]
+/// for a 2× growth factor).
+const DEFAULT_MULTIPLIER: u64 = 20;
+/// Default backoff multiplier denominator.
+const DEFAULT_MULTIPLIER_BASE: u64 = 10;
+/// Default cap on the delay between retries, in milliseconds.
+const DEFAULT_MAX_DELAY_MS: u64 = 60_000;
+
+/// Serde-friendly configuration for [`retry_with_backoff_async`] +
+/// [`ExponentialBackoff`]. Mirrors `ExponentialBackoff`'s fields (so it can
+/// build one) and adds the `max_retries` count consumed by the retry helper.
+///
+/// See the `DEFAULT_*` consts in this module for the default values; together
+/// they give roughly 17 minutes of patience.
+///
+/// [`retry_with_backoff_async`]: crate::retry_with_backoff_async
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// Maximum number of retry attempts after the initial call.
+    #[serde(default = "RetryConfig::default_max_retries")]
+    pub max_retries: u16,
+    /// Initial delay before the first retry, in milliseconds.
+    #[serde(default = "RetryConfig::default_base_delay_ms")]
+    pub base_delay_ms: u64,
+    /// Numerator of the backoff multiplier (paired with `multiplier_base`).
+    #[serde(default = "RetryConfig::default_multiplier")]
+    pub multiplier: u64,
+    /// Denominator of the backoff multiplier.
+    #[serde(default = "RetryConfig::default_multiplier_base")]
+    pub multiplier_base: u64,
+    /// Maximum delay between retries, in milliseconds. Caps the exponential
+    /// growth so long retry sequences don't produce absurd waits or overflow.
+    #[serde(default = "RetryConfig::default_max_delay_ms")]
+    pub max_delay_ms: u64,
+}
+
+impl RetryConfig {
+    fn default_max_retries() -> u16 {
+        DEFAULT_MAX_RETRIES
+    }
+    fn default_base_delay_ms() -> u64 {
+        DEFAULT_BASE_DELAY_MS
+    }
+    fn default_multiplier() -> u64 {
+        DEFAULT_MULTIPLIER
+    }
+    fn default_multiplier_base() -> u64 {
+        DEFAULT_MULTIPLIER_BASE
+    }
+    fn default_max_delay_ms() -> u64 {
+        DEFAULT_MAX_DELAY_MS
+    }
+
+    /// Build an [`ExponentialBackoff`] from this config.
+    pub fn backoff(&self) -> ExponentialBackoff {
+        ExponentialBackoff::new(
+            self.base_delay_ms,
+            self.multiplier,
+            self.multiplier_base,
+            Some(self.max_delay_ms),
+        )
+    }
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: Self::default_max_retries(),
+            base_delay_ms: Self::default_base_delay_ms(),
+            multiplier: Self::default_multiplier(),
+            multiplier_base: Self::default_multiplier_base(),
+            max_delay_ms: Self::default_max_delay_ms(),
+        }
+    }
+}

--- a/crates/retry/src/config.rs
+++ b/crates/retry/src/config.rs
@@ -20,8 +20,10 @@ const DEFAULT_MAX_DELAY_MS: u64 = 60_000;
 /// [`ExponentialBackoff`]. Mirrors `ExponentialBackoff`'s fields (so it can
 /// build one) and adds the `max_retries` count consumed by the retry helper.
 ///
-/// See the `DEFAULT_*` consts in this module for the default values; together
-/// they give roughly 17 minutes of patience.
+/// See the `DEFAULT_*` consts in this module for the default values. Delays
+/// double each retry (1, 2, 4, ... seconds) but `DEFAULT_MAX_DELAY_MS` caps
+/// growth at 60s, so the 10 retries total 303s (~5 minutes) of patience, not
+/// the ~17 minutes an uncapped doubling schedule would reach.
 ///
 /// [`retry_with_backoff_async`]: crate::retry_with_backoff_async
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/retry/src/lib.rs
+++ b/crates/retry/src/lib.rs
@@ -1,0 +1,119 @@
+//! Retry-with-backoff helpers.
+//!
+//! Wrap a fallible async call with [`retry_with_backoff_async`], pick a
+//! [`Backoff`] implementation (e.g. [`ExponentialBackoff`]), and the helper
+//! handles delays, logging, and exhaustion. [`RetryConfig`] is a serde-friendly
+//! way to carry the parameters through configuration files.
+//!
+//! Consolidated from the per-repo copies that previously lived in
+//! `strata_common::retry` (alpen) and `bin/asm-runner/src/retry.rs` (asm).
+
+pub mod config;
+pub mod policies;
+
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+
+pub use config::RetryConfig;
+pub use policies::ExponentialBackoff;
+use tokio::time::sleep as async_sleep;
+use tracing::{error, warn};
+
+/// Backoff schedule: each implementation decides how the delay grows.
+pub trait Backoff {
+    /// Base delay in ms.
+    fn base_delay_ms(&self) -> u64;
+
+    /// Generates next delay given current delay.
+    fn next_delay_ms(&self, curr_delay_ms: u64) -> u64;
+}
+
+/// Runs a fallible async operation with a backoff retry.
+///
+/// Retries the given async `operation` up to `max_retries` times with delays
+/// increasing according to the provided [`Backoff`] implementation.
+///
+/// Logs a warning on each failure and an error if all retries are exhausted.
+///
+/// # Parameters
+///
+/// - `name`: Identifier used in logs for the operation.
+/// - `max_retries`: Maximum number of retry attempts (not counting the initial attempt).
+/// - `backoff`: Backoff configuration for computing delay.
+/// - `operation`: Closure returning a Future that resolves to `Result`; retried on `Err`.
+pub async fn retry_with_backoff_async<R, E, F, Fut>(
+    name: &str,
+    max_retries: u16,
+    backoff: &impl Backoff,
+    operation: F,
+) -> Result<R, E>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<R, E>>,
+    E: fmt::Debug,
+{
+    let mut delay = backoff.base_delay_ms();
+
+    for attempt in 0..=max_retries {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt < max_retries => {
+                warn!(
+                    attempt = attempt + 1,
+                    %name,
+                    delay_ms = delay,
+                    ?err,
+                    "operation failed, retrying"
+                );
+                async_sleep(Duration::from_millis(delay)).await;
+                delay = backoff.next_delay_ms(delay);
+            }
+            Err(err) => {
+                error!(%name, max_retries, ?err, "max retries exceeded, returning last error");
+                return Err(err);
+            }
+        }
+    }
+
+    // Loop above always returns inside the match.
+    unreachable!()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retries_until_success() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let backoff = ExponentialBackoff::new(1, 10, 10, Some(10));
+        let attempts_clone = attempts.clone();
+        let result: Result<&'static str, &'static str> =
+            retry_with_backoff_async("test", 5, &backoff, || {
+                let attempts = attempts_clone.clone();
+                async move {
+                    let n = attempts.fetch_add(1, Ordering::SeqCst);
+                    if n == 2 {
+                        Ok("ok")
+                    } else {
+                        Err("not yet")
+                    }
+                }
+            })
+            .await;
+        assert_eq!(result, Ok("ok"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn exhausts_and_returns_last_error() {
+        let backoff = ExponentialBackoff::new(1, 10, 10, Some(10));
+        let result: Result<(), &'static str> =
+            retry_with_backoff_async("test", 2, &backoff, || async { Err("nope") }).await;
+        assert_eq!(result, Err("nope"));
+    }
+}

--- a/crates/retry/src/policies.rs
+++ b/crates/retry/src/policies.rs
@@ -1,0 +1,90 @@
+//! [`Backoff`] implementations.
+
+use crate::Backoff;
+
+/// Configuration for exponential retry backoff.
+///
+/// Uses a fixed-point multiplier (`multiplier / multiplier_base`) to avoid
+/// floating-point math. For example, `multiplier = 150` with
+/// `multiplier_base = 100` represents a 1.5× multiplier.
+///
+/// Carries an optional `max_delay_ms` cap so delays don't explode when retrying
+/// for long durations. Without a cap, a 2× multiplier starting at 1 s reaches
+/// ~17 minutes by attempt 11 and overflows `u64` not long after; for
+/// resilience-oriented retry budgets the cap is essential.
+#[derive(Debug, Clone)]
+pub struct ExponentialBackoff {
+    base_delay_ms: u64,
+    multiplier: u64,
+    multiplier_base: u64,
+    max_delay_ms: Option<u64>,
+}
+
+impl ExponentialBackoff {
+    /// Builds a new [`ExponentialBackoff`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `multiplier_base` is zero.
+    pub fn new(
+        base_delay_ms: u64,
+        multiplier: u64,
+        multiplier_base: u64,
+        max_delay_ms: Option<u64>,
+    ) -> Self {
+        assert!(multiplier_base != 0, "multiplier_base must be non-zero");
+        Self {
+            base_delay_ms,
+            multiplier,
+            multiplier_base,
+            max_delay_ms,
+        }
+    }
+}
+
+impl Backoff for ExponentialBackoff {
+    fn base_delay_ms(&self) -> u64 {
+        self.base_delay_ms
+    }
+
+    fn next_delay_ms(&self, curr_delay_ms: u64) -> u64 {
+        let next = curr_delay_ms.saturating_mul(self.multiplier) / self.multiplier_base;
+        match self.max_delay_ms {
+            Some(cap) => next.min(cap),
+            None => next,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exponential_grows_then_caps() {
+        let b = ExponentialBackoff::new(1000, 20, 10, Some(60_000));
+        let d1 = b.next_delay_ms(b.base_delay_ms());
+        assert_eq!(d1, 2000);
+        let d2 = b.next_delay_ms(d1);
+        assert_eq!(d2, 4000);
+        // Saturates at the cap.
+        let mut d = d2;
+        for _ in 0..20 {
+            d = b.next_delay_ms(d);
+        }
+        assert_eq!(d, 60_000);
+    }
+
+    #[test]
+    fn exponential_without_cap_grows_unbounded() {
+        let b = ExponentialBackoff::new(1000, 20, 10, None);
+        assert_eq!(b.next_delay_ms(1000), 2000);
+        assert_eq!(b.next_delay_ms(2000), 4000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn zero_multiplier_base_panics() {
+        let _ = ExponentialBackoff::new(1000, 20, 0, None);
+    }
+}

--- a/crates/retry/src/policies.rs
+++ b/crates/retry/src/policies.rs
@@ -54,7 +54,12 @@ impl Backoff for ExponentialBackoff {
     }
 
     fn next_delay_ms(&self, curr_delay_ms: u64) -> u64 {
-        let next = curr_delay_ms.saturating_mul(self.multiplier) / self.multiplier_base;
+        // Widen to u128 before multiplying: a u64 `saturating_mul` can clip the
+        // product to u64::MAX ahead of the division, distorting the fixed-point
+        // ratio (e.g. multiplier == multiplier_base == u64::MAX, which should be
+        // a 1x no-op, would otherwise collapse to a near-zero delay).
+        let product = curr_delay_ms as u128 * self.multiplier as u128;
+        let next = (product / self.multiplier_base as u128).min(u64::MAX as u128) as u64;
         match self.max_delay_ms {
             Some(cap) => next.min(cap),
             None => next,
@@ -85,6 +90,14 @@ mod tests {
     fn base_delay_above_cap_is_clamped() {
         let b = ExponentialBackoff::new(100_000, 20, 10, Some(60_000));
         assert_eq!(b.base_delay_ms(), 60_000);
+    }
+
+    #[test]
+    fn ratio_survives_multiplication_overflow() {
+        // multiplier == multiplier_base is a 1x ratio; with u64 math the
+        // product would saturate to u64::MAX and divide back down to ~1ms.
+        let b = ExponentialBackoff::new(1000, u64::MAX, u64::MAX, None);
+        assert_eq!(b.next_delay_ms(1000), 1000);
     }
 
     #[test]

--- a/crates/retry/src/policies.rs
+++ b/crates/retry/src/policies.rs
@@ -33,6 +33,12 @@ impl ExponentialBackoff {
         max_delay_ms: Option<u64>,
     ) -> Self {
         assert!(multiplier_base != 0, "multiplier_base must be non-zero");
+        // Clamp so `max_delay_ms` is a real upper bound from the first retry
+        // onward, not just once `next_delay_ms()` has had a chance to apply it.
+        let base_delay_ms = match max_delay_ms {
+            Some(cap) => base_delay_ms.min(cap),
+            None => base_delay_ms,
+        };
         Self {
             base_delay_ms,
             multiplier,
@@ -73,6 +79,12 @@ mod tests {
             d = b.next_delay_ms(d);
         }
         assert_eq!(d, 60_000);
+    }
+
+    #[test]
+    fn base_delay_above_cap_is_clamped() {
+        let b = ExponentialBackoff::new(100_000, 20, 10, Some(60_000));
+        assert_eq!(b.base_delay_ms(), 60_000);
     }
 
     #[test]

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -12,7 +12,7 @@ metrics.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tracing.workspace = true
 
 [lints]

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -10,7 +10,14 @@ workspace = true
 anyhow.workspace = true
 futures-util.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = [
+  "macros",
+  "rt",
+  "signal",
+  "sync",
+  "time",
+] }
 tracing.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Description

Promotes the retry-with-backoff helpers into a dedicated `strata-retry` workspace crate. Until now the same logic was copied per repo — `strata_common::retry` in alpen and `bin/asm-runner/src/retry.rs` in asm — and kept in sync by hand (the asm copy carries an explicit "update both sides when changing" note and a `TODO(STR-3473)` to do exactly this). Owning one implementation here lets consumers depend on it instead of maintaining divergent copies.

The public surface is the union of the two copies, including asm's `max_delay_ms` cap on `ExponentialBackoff` (prevents delays exploding/overflowing over long retry budgets) and its serde-friendly `RetryConfig`.

Review entry point: [crates/retry/src/lib.rs](https://github.com/alpenlabs/strata-common/blob/feat/retry-crate/crates/retry/src/lib.rs).

Follow-up (separate PR, once a tag ships this crate): swap `bin/asm-runner/src/retry.rs` in asm for a dependency on `strata-retry` and delete the duplicate.

### Type of Change

- [x] Refactor
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)

## Notes to Reviewers

Organized into modules rather than one file: `Backoff` trait + async retry driver in the crate root, `ExponentialBackoff` in `policies`, serde `RetryConfig` in `config`. Tests (5) moved alongside the code they cover and pass; `cargo clippy` and `cargo fmt --check` are clean under the workspace lints.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-3473
