### PR TITLE
feat(logging): add owned, serde-serializable LoggingInitConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4091,6 +4091,8 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -10,7 +10,11 @@ workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
+serde.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -14,7 +14,8 @@ mod tests;
 // Re-export main types and functions
 pub use manager::{BoxedLayer, finalize, init, init_with_layers};
 pub use service::{
-    LoggingInitConfig, init_logging_from_config, init_logging_from_config_with_layers,
+    LoggingInitConfig, LoggingInitConfigRef, init_logging_from_config,
+    init_logging_from_config_with_layers,
 };
 // Re-export tracing-appender types for convenience
 pub use tracing_appender::rolling::Rotation;

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -2,13 +2,93 @@
 
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, init_with_layers};
 
-/// Configuration parameters for logging initialization.
+/// Owned, serde-serializable logging configuration.
+///
+/// This is the type binaries should embed in their own config structs (e.g. a
+/// `[logging]` TOML section) or populate from CLI flags. Every field is
+/// optional, so a partial or omitted section deserializes cleanly and falls
+/// back to the crate defaults.
+///
+/// It carries only the operator-tunable subset of the settings. The two
+/// binary-provided constants — the base service name and the default log-file
+/// prefix — are passed to [`init`](Self::init) / [`init_with_layers`](Self::init_with_layers)
+/// as arguments rather than serialized, so they never leak into a user's config
+/// file.
+///
+/// Under the hood these methods build a [`LoggingInitConfigRef`] (the borrowed,
+/// zero-copy view the init routines consume) and forward to
+/// [`init_logging_from_config`] / [`init_logging_from_config_with_layers`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LoggingInitConfig {
+    /// Optional service label appended to the service name (e.g. `"prod"`, `"dev"`).
+    pub service_label: Option<String>,
+    /// OpenTelemetry OTLP collector endpoint. When set, OTLP export is enabled.
+    pub otlp_url: Option<String>,
+    /// Directory to write rolling log files into. When unset, file logging is disabled.
+    pub log_dir: Option<PathBuf>,
+    /// Filename prefix for rolling log files. Falls back to the binary's default prefix.
+    pub log_file_prefix: Option<String>,
+    /// Use JSON output format instead of the compact text format.
+    pub json_format: Option<bool>,
+    /// Extra `EnvFilter` directives applied before `RUST_LOG` (e.g. to silence
+    /// noisy dependencies). Empty when omitted.
+    pub extra_filter_directives: Vec<String>,
+}
+
+impl LoggingInitConfig {
+    /// Initialize process-global logging from this config.
+    ///
+    /// `service_base_name` and `default_log_prefix` are binary-provided
+    /// constants (not part of the serialized config). Must be called once from
+    /// a process entrypoint, inside a Tokio runtime context when `otlp_url` is
+    /// set (the OTLP exporter is built on the reactor).
+    pub fn init(&self, service_base_name: &str, default_log_prefix: &str) {
+        self.init_with_layers(service_base_name, default_log_prefix, Vec::new());
+    }
+
+    /// Like [`init`](Self::init), but installs additional subscriber layers.
+    pub fn init_with_layers(
+        &self,
+        service_base_name: &str,
+        default_log_prefix: &str,
+        extra_layers: Vec<BoxedLayer>,
+    ) {
+        let extra_filter_directives: Vec<&str> = self
+            .extra_filter_directives
+            .iter()
+            .map(String::as_str)
+            .collect();
+        init_logging_from_config_with_layers(
+            LoggingInitConfigRef {
+                service_base_name,
+                service_label: self.service_label.as_deref(),
+                otlp_url: self.otlp_url.as_deref(),
+                log_dir: self.log_dir.as_ref(),
+                log_file_prefix: self.log_file_prefix.as_deref(),
+                json_format: self.json_format,
+                default_log_prefix,
+                extra_filter_directives: &extra_filter_directives,
+            },
+            extra_layers,
+        );
+    }
+}
+
+/// Borrowed, zero-copy view of the parameters [`init_logging_from_config`]
+/// consumes.
+///
+/// Prefer the owned [`LoggingInitConfig`] for config-file / CLI wiring. Reach
+/// for this only when you are assembling the parameters transiently at the call
+/// site (e.g. mixing borrowed CLI args with compile-time string literals) and
+/// don't want an owning struct.
 #[derive(Debug)]
-pub struct LoggingInitConfig<'a> {
+pub struct LoggingInitConfigRef<'a> {
     /// Base service name
     pub service_base_name: &'a str,
     /// Optional service label to append like prod or dev
@@ -36,7 +116,7 @@ pub struct LoggingInitConfig<'a> {
 /// This function encapsulates the common logging initialization logic used
 /// across binaries. It should be called once from a process entrypoint, not
 /// from libraries.
-pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
+pub fn init_logging_from_config(config: LoggingInitConfigRef<'_>) {
     init_logging_from_config_with_layers(config, Vec::new());
 }
 
@@ -45,7 +125,7 @@ pub fn init_logging_from_config(config: LoggingInitConfig<'_>) {
 /// This keeps logging initialization centralized while allowing companion crates
 /// to provide tracing layers without making this crate depend on them.
 pub fn init_logging_from_config_with_layers(
-    config: LoggingInitConfig<'_>,
+    config: LoggingInitConfigRef<'_>,
     extra_layers: Vec<BoxedLayer>,
 ) {
     // Construct service name with optional label

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -13,8 +13,11 @@ use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, in
 /// section) or populate it from CLI flags, then call [`init`](Self::init) /
 /// [`init_with_layers`](Self::init_with_layers) once at process startup.
 ///
-/// Every field is optional, so a partial or omitted section deserializes
-/// cleanly. With everything unset, logs go to the console in compact text
+/// Every field is optional, so a partial section deserializes cleanly. For an
+/// *omitted* section to also work, the embedding field must carry its own
+/// `#[serde(default)]` (as in the example below) — the `#[serde(default)]` on
+/// this struct only fills in missing fields once the section itself is
+/// present. With everything unset, logs go to the console in compact text
 /// format at `info` level (override via `RUST_LOG`); file logging and
 /// OpenTelemetry export stay disabled until [`log_dir`](Self::log_dir) /
 /// [`otlp_url`](Self::otlp_url) are set.
@@ -31,14 +34,22 @@ use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, in
 /// extra_filter_directives = ["jsonrpsee_server=warn"]
 /// ```
 ///
-/// Wiring it up in the binary:
+/// Wiring it up in the binary — the `#[serde(default)]` on the field is what
+/// lets the whole `[logging]` section be omitted:
 ///
 /// ```no_run
+/// use serde::Deserialize;
 /// use strata_logging::LoggingInitConfig;
 ///
-/// # fn load_config() -> LoggingInitConfig { LoggingInitConfig::default() }
-/// let logging: LoggingInitConfig = load_config();
-/// logging.init("strata-client", "strata");
+/// #[derive(Deserialize)]
+/// struct Config {
+///     #[serde(default)]
+///     logging: LoggingInitConfig,
+/// }
+///
+/// # fn load_config() -> Config { Config { logging: LoggingInitConfig::default() } }
+/// let config: Config = load_config();
+/// config.logging.init("strata-client", "strata");
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -7,22 +7,18 @@ use tracing::info;
 
 use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, init_with_layers};
 
-/// Owned, serde-serializable logging configuration.
+/// Configuration parameters for logging initialization.
 ///
-/// This is the type binaries should embed in their own config structs (e.g. a
-/// `[logging]` TOML section) or populate from CLI flags. Every field is
-/// optional, so a partial or omitted section deserializes cleanly and falls
-/// back to the crate defaults.
+/// Embed this in the binary's config struct (e.g. a `[logging]` TOML section)
+/// or populate it from CLI flags, then call [`init`](Self::init) /
+/// [`init_with_layers`](Self::init_with_layers). Every field is optional, so a
+/// partial or omitted section deserializes cleanly and falls back to the crate
+/// defaults.
 ///
 /// It carries only the operator-tunable subset of the settings. The two
 /// binary-provided constants — the base service name and the default log-file
-/// prefix — are passed to [`init`](Self::init) / [`init_with_layers`](Self::init_with_layers)
-/// as arguments rather than serialized, so they never leak into a user's config
-/// file.
-///
-/// Under the hood these methods build a [`LoggingInitConfigRef`] (the borrowed,
-/// zero-copy view the init routines consume) and forward to
-/// [`init_logging_from_config`] / [`init_logging_from_config_with_layers`].
+/// prefix — are passed to the init methods as arguments rather than
+/// serialized, so they never leak into a user's config file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LoggingInitConfig {
@@ -80,13 +76,12 @@ impl LoggingInitConfig {
     }
 }
 
-/// Borrowed, zero-copy view of the parameters [`init_logging_from_config`]
-/// consumes.
+/// Zero-copy view of [`LoggingInitConfig`], consumed by
+/// [`init_logging_from_config`] / [`init_logging_from_config_with_layers`].
 ///
-/// Prefer the owned [`LoggingInitConfig`] for config-file / CLI wiring. Reach
-/// for this only when you are assembling the parameters transiently at the call
-/// site (e.g. mixing borrowed CLI args with compile-time string literals) and
-/// don't want an owning struct.
+/// Prefer [`LoggingInitConfig`] for config-file / CLI wiring. Reach for this
+/// only when assembling the parameters transiently at the call site (e.g.
+/// mixing CLI args with compile-time string literals).
 #[derive(Debug)]
 pub struct LoggingInitConfigRef<'a> {
     /// Base service name

--- a/crates/logging/src/service.rs
+++ b/crates/logging/src/service.rs
@@ -9,41 +9,76 @@ use super::{BoxedLayer, FileLoggingConfig, LoggerConfig, format_service_name, in
 
 /// Configuration parameters for logging initialization.
 ///
-/// Embed this in the binary's config struct (e.g. a `[logging]` TOML section)
-/// or populate it from CLI flags, then call [`init`](Self::init) /
-/// [`init_with_layers`](Self::init_with_layers). Every field is optional, so a
-/// partial or omitted section deserializes cleanly and falls back to the crate
-/// defaults.
+/// Embed this in the binary's config struct (e.g. as a `[logging]` TOML
+/// section) or populate it from CLI flags, then call [`init`](Self::init) /
+/// [`init_with_layers`](Self::init_with_layers) once at process startup.
 ///
-/// It carries only the operator-tunable subset of the settings. The two
-/// binary-provided constants — the base service name and the default log-file
-/// prefix — are passed to the init methods as arguments rather than
-/// serialized, so they never leak into a user's config file.
+/// Every field is optional, so a partial or omitted section deserializes
+/// cleanly. With everything unset, logs go to the console in compact text
+/// format at `info` level (override via `RUST_LOG`); file logging and
+/// OpenTelemetry export stay disabled until [`log_dir`](Self::log_dir) /
+/// [`otlp_url`](Self::otlp_url) are set.
+///
+/// # Example
+///
+/// A `[logging]` section an operator might write:
+///
+/// ```toml
+/// [logging]
+/// service_label = "prod"
+/// otlp_url = "http://localhost:4317"
+/// log_dir = "/var/log/strata"
+/// extra_filter_directives = ["jsonrpsee_server=warn"]
+/// ```
+///
+/// Wiring it up in the binary:
+///
+/// ```no_run
+/// use strata_logging::LoggingInitConfig;
+///
+/// # fn load_config() -> LoggingInitConfig { LoggingInitConfig::default() }
+/// let logging: LoggingInitConfig = load_config();
+/// logging.init("strata-client", "strata");
+/// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LoggingInitConfig {
-    /// Optional service label appended to the service name (e.g. `"prod"`, `"dev"`).
+    /// Label identifying this deployment (e.g. `"prod"`, `"dev"`), appended to
+    /// the base service name in log output and the OpenTelemetry
+    /// `service.name`. When unset, the base name is used as-is.
     pub service_label: Option<String>,
-    /// OpenTelemetry OTLP collector endpoint. When set, OTLP export is enabled.
+    /// OpenTelemetry collector endpoint traces are exported to over gRPC
+    /// (e.g. `"http://localhost:4317"`). When unset, no traces are exported.
     pub otlp_url: Option<String>,
-    /// Directory to write rolling log files into. When unset, file logging is disabled.
+    /// Directory to write rolling log files into, rotated daily. When unset,
+    /// file logging is disabled.
     pub log_dir: Option<PathBuf>,
-    /// Filename prefix for rolling log files. Falls back to the binary's default prefix.
+    /// Filename prefix for the rolling log files (they are named
+    /// `<prefix>.<date>`). When unset, the binary's default prefix is used.
     pub log_file_prefix: Option<String>,
-    /// Use JSON output format instead of the compact text format.
+    /// Emit console logs as JSON instead of compact text. Defaults to compact
+    /// text. File logs are unaffected and always use compact text.
     pub json_format: Option<bool>,
-    /// Extra `EnvFilter` directives applied before `RUST_LOG` (e.g. to silence
-    /// noisy dependencies). Empty when omitted.
+    /// Additional log-filter directives in `RUST_LOG` syntax (e.g.
+    /// `"sp1_core_executor=warn"`), typically used to silence noisy
+    /// dependencies by default. `RUST_LOG` still wins on conflicts.
     pub extra_filter_directives: Vec<String>,
 }
 
 impl LoggingInitConfig {
-    /// Initialize process-global logging from this config.
+    /// Initializes process-global logging from this config.
     ///
-    /// `service_base_name` and `default_log_prefix` are binary-provided
-    /// constants (not part of the serialized config). Must be called once from
-    /// a process entrypoint, inside a Tokio runtime context when `otlp_url` is
-    /// set (the OTLP exporter is built on the reactor).
+    /// Call this once from the process entrypoint; libraries should emit
+    /// `tracing` events and leave subscriber installation to the binary. When
+    /// [`otlp_url`](Self::otlp_url) is set, this must run inside a Tokio
+    /// runtime (the OTLP exporter runs on it), and the binary should call
+    /// [`finalize`](crate::finalize) before exiting to flush pending spans.
+    ///
+    /// `service_base_name` is the service name reported in log output and
+    /// OpenTelemetry metadata; `default_log_prefix` names the log files when
+    /// [`log_file_prefix`](Self::log_file_prefix) is unset. Both are fixed
+    /// per binary, which is why they are arguments here rather than fields
+    /// in the serialized config.
     pub fn init(&self, service_base_name: &str, default_log_prefix: &str) {
         self.init_with_layers(service_base_name, default_log_prefix, Vec::new());
     }
@@ -134,6 +169,9 @@ pub fn init_logging_from_config_with_layers(
     }
 
     // Configure file logging if log directory provided
+    // TODO: `json_format` only applies to the console layer; file logs are
+    // always compact even though `FileLoggingConfig::with_json_format` exists.
+    // Consider exposing a knob for JSON file logs if a consumer needs it.
     let file_logging_config = config.log_dir.map(|dir| {
         let prefix = config
             .log_file_prefix

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -7,6 +7,7 @@ use opentelemetry::trace::TraceContextExt;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 
+use super::service::LoggingInitConfig;
 use super::types::*;
 
 #[test]
@@ -145,6 +146,32 @@ fn test_logger_config_with_extra_filter_directives() {
             "jsonrpsee_server::server=warn".to_string(),
         ]
     );
+}
+
+// A config that only sets one field must deserialize cleanly and leave every
+// other field at its default — the `#[serde(default)]` on the struct is what
+// lets consumers embed a partial `[logging]` section without hitting
+// `missing field` errors.
+#[test]
+fn test_logging_init_config_partial_deserialize_uses_defaults() {
+    let config: LoggingInitConfig =
+        serde_json::from_str(r#"{ "otlp_url": "http://localhost:4317" }"#).expect("should parse");
+
+    assert_eq!(config.otlp_url.as_deref(), Some("http://localhost:4317"));
+    assert!(config.service_label.is_none());
+    assert!(config.log_dir.is_none());
+    assert!(config.log_file_prefix.is_none());
+    assert!(config.json_format.is_none());
+    assert!(config.extra_filter_directives.is_empty());
+}
+
+// An empty object deserializes to the full default, matching an omitted section.
+#[test]
+fn test_logging_init_config_empty_deserialize_is_default() {
+    let config: LoggingInitConfig = serde_json::from_str("{}").expect("should parse");
+
+    assert!(config.otlp_url.is_none());
+    assert!(config.extra_filter_directives.is_empty());
 }
 
 #[test]

--- a/crates/logging/src/tests.rs
+++ b/crates/logging/src/tests.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::{KeyValue, global};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
+use serde::Deserialize;
 
 use super::service::LoggingInitConfig;
 use super::types::*;
@@ -165,13 +166,43 @@ fn test_logging_init_config_partial_deserialize_uses_defaults() {
     assert!(config.extra_filter_directives.is_empty());
 }
 
-// An empty object deserializes to the full default, matching an omitted section.
+// An empty object (a present-but-empty `[logging]` section) deserializes to
+// the full default.
 #[test]
 fn test_logging_init_config_empty_deserialize_is_default() {
     let config: LoggingInitConfig = serde_json::from_str("{}").expect("should parse");
 
     assert!(config.otlp_url.is_none());
     assert!(config.extra_filter_directives.is_empty());
+}
+
+// Omitting the section entirely is a different serde path from an empty
+// section: the struct's own `#[serde(default)]` doesn't fire for a missing
+// field in the *containing* struct, so the embedding field must carry
+// `#[serde(default)]` itself — this is the pattern the struct docs prescribe.
+#[test]
+fn test_logging_init_config_omitted_section_needs_field_default() {
+    #[derive(Deserialize)]
+    struct Config {
+        #[serde(default)]
+        logging: LoggingInitConfig,
+    }
+
+    // Without the field-level default this would fail with `missing field`.
+    let config: Config = serde_json::from_str("{}").expect("should parse");
+
+    assert!(config.logging.otlp_url.is_none());
+    assert!(config.logging.extra_filter_directives.is_empty());
+
+    // A bare `Deserialize` embedding (no field default) must reject the same
+    // input, otherwise the documented requirement would be stale.
+    #[derive(Deserialize)]
+    struct StrictConfig {
+        #[expect(dead_code, reason = "only deserialization behavior is under test")]
+        logging: LoggingInitConfig,
+    }
+
+    assert!(serde_json::from_str::<StrictConfig>("{}").is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Description

`strata-logging` only exposed a borrowed `LoggingInitConfig<'a>` — a struct full of `&str`/`&[&str]` meant to be assembled transiently at a call site, and additionally carrying two binary-provided constants (`service_base_name`, `default_log_prefix`) that have no business in a user-facing config file. As a result, any downstream that wants to surface logging options in a config-file section (e.g. asm-runner's `[logging]` TOML table) has to hand-roll an owned, serde-derived mirror struct plus the `Option<String>`→`Option<&str>` / `Vec<String>`→`Vec<&str>` conversion. CLI-driven consumers (alpen) sidestep this because their owned data already lives in the parsed CLI command; they build the borrowed struct transiently at the call site and never need the logging struct itself to be serde-deserializable.

This PR closes that gap by making the crate own the serde surface: a new owned `#[serde(default)]` `LoggingInitConfig` carrying only the operator-tunable subset, with `init` / `init_with_layers` methods that take the binary constants as arguments and build the borrowed view internally. The previous borrowed struct is renamed to `LoggingInitConfigRef` and remains the zero-copy view the free `init_logging_from_config*` functions consume.

Review entry point: `crates/logging/src/service.rs`.

### Type of Change

- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New or updated tests

## Notes to Reviewers

The rename is source-breaking for callers that reference `LoggingInitConfig` as the *borrowed* struct (alpen's binaries, strata-bridge's common wrapper). On their next tag bump they switch either to the owned `LoggingInitConfig` (recommended for config/CLI wiring) or to `LoggingInitConfigRef` to keep the current borrowed-literal call. asm-runner is the first consumer of the owned type and will drop its local mirror once this is tagged.

Open naming question for reviewers: `LoggingInitConfigRef` now has more fields than `LoggingInitConfig` (it also holds the two binary constants), so "Ref" is a low-level-params view rather than a strict borrow of the owned type — flagging in case a different suffix reads better.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

