### PR TITLE
feat(rpc): add cross-service HTTP trace propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +463,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +495,22 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -984,6 +1016,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1311,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1553,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1605,146 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "jsonrpsee-ws-client",
+ "tokio",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
+dependencies = [
+ "base64",
+ "futures-util",
+ "http",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-timer",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
+dependencies = [
+ "base64",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
+dependencies = [
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -1575,6 +1813,15 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1802,6 +2049,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
@@ -2137,6 +2390,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -2525,6 +2801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +2914,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
 name = "ruint"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,6 +2961,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +2992,80 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2726,6 +3111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +3149,12 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
@@ -2807,6 +3207,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2888,6 +3311,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -3398,6 +3832,22 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.7",
+ "sha1",
 ]
 
 [[package]]
@@ -3925,6 +4375,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-rpc-tracing"
+version = "0.1.0"
+dependencies = [
+ "http",
+ "jsonrpsee",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "strata-serde-utils"
 version = "0.1.0"
 dependencies = [
@@ -4272,6 +4737,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,6 +4755,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4290,6 +4766,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "libc",
  "pin-project-lite",
@@ -4607,6 +5084,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,6 +5238,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.9",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,11 +5303,38 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4820,18 +5348,55 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4840,10 +5405,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4852,10 +5441,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4864,16 +5483,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/ol-logs",
   "crates/predicate",
   "crates/retry",
+  "crates/rpc-tracing",
   "crates/serde-utils",
   "crates/service",
   "crates/ssz-tests",
@@ -44,6 +45,7 @@ strata-msg-fmt = { path = "crates/msg-fmt" }
 strata-ol-logs = { path = "crates/ol-logs" }
 strata-predicate = { path = "crates/predicate" }
 strata-retry = { path = "crates/retry" }
+strata-rpc-tracing = { path = "crates/rpc-tracing" }
 strata-serde-utils = { path = "crates/serde-utils" }
 strata-service = { path = "crates/service" }
 strata-ssz-tests = { path = "crates/ssz-tests" }
@@ -71,7 +73,9 @@ digest = "0.10"
 futures = "0.3"
 futures-util = "0.3"
 hex = { version = "0.4", features = ["serde"] }
+http = "1"
 int-enum = "1"
+jsonrpsee = "0.26"
 metrics = "0.24"
 metrics-exporter-otel = "0.3"
 metrics-exporter-prometheus = { version = "0.18", default-features = false, features = [
@@ -100,6 +104,7 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
+tower = "0.5"
 zeroize = { version = "1.8.1", features = ["derive"] }
 zkaleido = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0" }
 zkaleido-sp1-groth16-verifier = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.3.0" }

--- a/crates/rpc-tracing/Cargo.toml
+++ b/crates/rpc-tracing/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition = "2024"
+name = "strata-rpc-tracing"
+version = "0.1.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+http.workspace = true
+jsonrpsee = { workspace = true, features = ["http-client", "server", "ws-client"] }
+opentelemetry.workspace = true
+tower.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tokio.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/rpc-tracing/README.md
+++ b/crates/rpc-tracing/README.md
@@ -1,0 +1,81 @@
+# JSON-RPC tracing
+
+`strata-rpc-tracing` creates OpenTelemetry client/server spans for jsonrpsee
+services and propagates W3C Trace Context across HTTP service boundaries in
+request headers.
+
+The crate uses the process-global propagator and active tracing subscriber. A
+binary must configure those through `strata-logging`, including a distinct
+`service.name`; this crate does not install exporters or global telemetry state.
+
+## Server
+
+Every HTTP or WebSocket server installs both layers:
+
+```rust,ignore
+let server = ServerBuilder::new()
+    .set_http_middleware(http_trace_context_server_middleware())
+    .set_rpc_middleware(rpc_trace_context_server_middleware())
+    .build(address)
+    .await?;
+```
+
+Servers with existing HTTP middleware can compose the exported layer directly:
+
+```rust,ignore
+let http_middleware = ServiceBuilder::new()
+    .layer(HttpServerTraceContextLayer)
+    .layer(HealthHttpLayer::new(health_registry));
+```
+
+The HTTP layer deliberately ignores WebSocket upgrade headers: a pooled
+connection carries unrelated operations, so the handshake must never become
+their shared parent.
+
+## Clients
+
+HTTP clients install an RPC layer to create the client span and an HTTP layer to
+inject that span into the outgoing request:
+
+```rust,ignore
+let client: TracedHttpClient = HttpClientBuilder::default()
+    .set_headers(headers)
+    .set_http_middleware(http_trace_context_client_middleware())
+    .set_rpc_middleware(rpc_trace_context_http_client_middleware())
+    .build(url)?;
+```
+
+WebSocket clients create a client span per RPC operation on the shared
+connection:
+
+```rust,ignore
+let client: TracedWsClient = WsClientBuilder::default()
+    .set_headers(handshake_headers)
+    .set_rpc_middleware(rpc_trace_context_ws_client_middleware())
+    .build(url)
+    .await?;
+```
+
+[`TracedHttpClient`] and [`TracedWsClient`] hide jsonrpsee's nested middleware
+types, allowing binaries and shared crates to store and pass traced clients
+without duplicating fragile type aliases.
+
+## WebSocket propagation status
+
+Cross-service context is currently propagated over HTTP only. WebSocket
+operations get client and server spans, but the server spans are local roots:
+per-operation context on a shared connection must travel inside each JSON-RPC
+message rather than in connection headers. The candidate mechanisms are the
+request-extension API proposed upstream in
+[paritytech/jsonrpsee#1647](https://github.com/paritytech/jsonrpsee/pull/1647)
+(fits positional-parameter APIs, not yet released) and MCP-style
+`traceparent`/`tracestate` members inside `params._meta` (works on stock
+jsonrpsee, named-parameter APIs only). Per-message WebSocket propagation lands
+as a follow-up once one of these is settled.
+
+RPC spans use static tracing names and record the method, span kind, JSON-RPC
+error code, and failure status. Batches create one boundary span because
+jsonrpsee dispatches a batch through one middleware call.
+
+Do not put trace IDs in metric labels. Use the trace backend for individual
+operations and bounded RPC method/status attributes for aggregate metrics.

--- a/crates/rpc-tracing/src/client.rs
+++ b/crates/rpc-tracing/src/client.rs
@@ -1,0 +1,197 @@
+use std::future::Future;
+
+use jsonrpsee::core::client::{
+    Error as RpcClientError, MiddlewareBatchResponse, MiddlewareMethodResponse,
+    MiddlewareNotifResponse,
+};
+use jsonrpsee::core::middleware::{Batch, Notification, Request, RpcServiceBuilder, RpcServiceT};
+use jsonrpsee::http_client::transport::HttpBackend;
+use jsonrpsee::http_client::{HttpClient, RpcService as HttpRpcService};
+use jsonrpsee::ws_client::{RpcService as WsRpcService, WsClient};
+use opentelemetry::trace::Status;
+use tower::Layer;
+use tower::layer::util::{Identity, Stack};
+use tracing::{Instrument, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::transport::HttpClientTraceContextService;
+
+/// jsonrpsee client middleware that creates client spans around RPC operations.
+#[derive(Clone, Debug, Default)]
+pub struct RpcClientTraceLayer;
+
+impl<S> Layer<S> for RpcClientTraceLayer {
+    type Service = RpcClientTraceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcClientTraceService { inner }
+    }
+}
+
+/// Service used by the JSON-RPC client tracing middleware.
+#[derive(Clone, Debug)]
+pub struct RpcClientTraceService<S> {
+    inner: S,
+}
+
+/// RPC middleware stack used by jsonrpsee clients.
+pub(crate) type RpcTraceContextClientMiddleware =
+    RpcServiceBuilder<Stack<RpcClientTraceLayer, Identity>>;
+
+/// HTTP client with both RPC spans and W3C trace-context propagation installed.
+pub type TracedHttpClient =
+    HttpClient<RpcClientTraceService<HttpRpcService<HttpClientTraceContextService<HttpBackend>>>>;
+
+/// WebSocket client with RPC client spans installed.
+pub type TracedWsClient = WsClient<RpcClientTraceService<WsRpcService>>;
+
+/// Creates RPC middleware for a jsonrpsee HTTP client.
+///
+/// Pair this with `http_trace_context_client_middleware` so the client span is
+/// injected into the HTTP request headers.
+pub fn rpc_trace_context_http_client_middleware() -> RpcTraceContextClientMiddleware {
+    RpcServiceBuilder::new().layer(RpcClientTraceLayer)
+}
+
+/// Creates RPC middleware for a jsonrpsee WebSocket client.
+///
+/// This creates client spans for each RPC operation on the shared connection.
+/// Cross-service propagation is not performed: WebSocket handshake headers
+/// belong to the pooled connection rather than an individual operation, and
+/// per-message context requires JSON-RPC request-extension support that is not
+/// yet available in upstream jsonrpsee
+/// ([paritytech/jsonrpsee#1647](https://github.com/paritytech/jsonrpsee/pull/1647)).
+pub fn rpc_trace_context_ws_client_middleware() -> RpcTraceContextClientMiddleware {
+    RpcServiceBuilder::new().layer(RpcClientTraceLayer)
+}
+
+impl<S> RpcServiceT for RpcClientTraceService<S>
+where
+    S: RpcServiceT<
+            MethodResponse = Result<MiddlewareMethodResponse, RpcClientError>,
+            BatchResponse = Result<MiddlewareBatchResponse, RpcClientError>,
+            NotificationResponse = Result<MiddlewareNotifResponse, RpcClientError>,
+        > + Send
+        + Sync
+        + Clone
+        + 'static,
+{
+    type MethodResponse = Result<MiddlewareMethodResponse, RpcClientError>;
+    type BatchResponse = Result<MiddlewareBatchResponse, RpcClientError>;
+    type NotificationResponse = Result<MiddlewareNotifResponse, RpcClientError>;
+
+    fn call<'a>(
+        &self,
+        request: Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        let span = client_span(request.method_name());
+        let response_span = span.clone();
+        let response = self.inner.call(request);
+        async move {
+            let response = response.await;
+            record_method_response(&response_span, &response);
+            response
+        }
+        .instrument(span)
+    }
+
+    fn batch<'a>(
+        &self,
+        requests: Batch<'a>,
+    ) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let span = client_batch_span();
+        let response_span = span.clone();
+        let response = self.inner.batch(requests);
+        async move {
+            let response = response.await;
+            record_batch_response(&response_span, &response);
+            response
+        }
+        .instrument(span)
+    }
+
+    fn notification<'a>(
+        &self,
+        notification: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let span = client_span(notification.method_name());
+        let response_span = span.clone();
+        let response = self.inner.notification(notification);
+        async move {
+            let response = response.await;
+            if let Err(error) = &response {
+                record_client_error(&response_span, error);
+            }
+            response
+        }
+        .instrument(span)
+    }
+}
+
+fn client_span(method: &str) -> Span {
+    tracing::info_span!(
+        "rpc.client",
+        otel.name = %method,
+        otel.kind = "client",
+        rpc.system.name = "jsonrpc",
+        rpc.method = %method
+    )
+}
+
+fn client_batch_span() -> Span {
+    tracing::info_span!(
+        "rpc.client.batch",
+        otel.name = "jsonrpc",
+        otel.kind = "client",
+        rpc.system.name = "jsonrpc"
+    )
+}
+
+fn record_method_response(
+    span: &Span,
+    response: &Result<MiddlewareMethodResponse, RpcClientError>,
+) {
+    match response {
+        Ok(response) => {
+            if let Some(error) = response.as_error() {
+                record_rpc_error_code(span, error.code());
+            }
+        }
+        Err(error) => record_client_error(span, error),
+    }
+}
+
+fn record_batch_response(span: &Span, response: &Result<MiddlewareBatchResponse, RpcClientError>) {
+    match response {
+        Ok(responses) => {
+            if let Some(error_code) = responses
+                .iter()
+                .find_map(|response| response.as_error().map(|error| error.code()))
+            {
+                record_rpc_error_code(span, error_code);
+            }
+        }
+        Err(error) => record_client_error(span, error),
+    }
+}
+
+fn record_client_error(span: &Span, error: &RpcClientError) {
+    if let RpcClientError::Call(error_object) = error {
+        record_rpc_error_code(span, error_object.code());
+        return;
+    }
+
+    let error_type = match error {
+        RpcClientError::Transport(_) => "jsonrpsee.transport",
+        _ => "jsonrpsee.client",
+    };
+    span.set_attribute("error.type", error_type);
+    span.set_status(Status::error(error.to_string()));
+}
+
+fn record_rpc_error_code(span: &Span, error_code: i32) {
+    let error_code = error_code.to_string();
+    span.set_attribute("rpc.response.status_code", error_code.clone());
+    span.set_attribute("error.type", error_code.clone());
+    span.set_status(Status::error(format!("JSON-RPC error {error_code}")));
+}

--- a/crates/rpc-tracing/src/context.rs
+++ b/crates/rpc-tracing/src/context.rs
@@ -1,0 +1,87 @@
+use http::{HeaderMap, HeaderName, HeaderValue};
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry::{Context, global};
+use tracing::{debug, warn};
+
+#[derive(Clone, Debug)]
+pub(crate) struct RemoteTraceContext(pub(crate) Context);
+
+pub(crate) fn inject_context_into_headers(context: &Context, headers: &mut HeaderMap) {
+    global::get_text_map_propagator(|propagator| {
+        for field in propagator.fields() {
+            headers.remove(field);
+        }
+        propagator.inject_context(context, &mut HeaderInjector(headers));
+    });
+}
+
+pub(crate) fn extract_context_from_headers(headers: &HeaderMap) -> Option<RemoteTraceContext> {
+    global::get_text_map_propagator(|propagator| {
+        valid_remote_context(propagator.extract(&HeaderExtractor(headers)))
+    })
+}
+
+fn valid_remote_context(context: Context) -> Option<RemoteTraceContext> {
+    context
+        .span()
+        .span_context()
+        .is_valid()
+        .then_some(RemoteTraceContext(context))
+}
+
+struct HeaderExtractor<'a>(&'a HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| match value.to_str() {
+            Ok(value) => Some(value),
+            Err(error) => {
+                debug!(%error, %key, "ignoring malformed RPC trace-context header");
+                None
+            }
+        })
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|key| key.as_str()).collect()
+    }
+}
+
+struct HeaderInjector<'a>(&'a mut HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        let header_name = match HeaderName::from_bytes(key.as_bytes()) {
+            Ok(header_name) => header_name,
+            Err(error) => {
+                warn!(%error, %key, "failed to encode RPC trace-context header name");
+                return;
+            }
+        };
+        let header_value = match HeaderValue::from_str(&value) {
+            Ok(header_value) => header_value,
+            Err(error) => {
+                warn!(%error, %key, "failed to encode RPC trace-context header value");
+                return;
+            }
+        };
+        self.0.insert(header_name, header_value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+
+    use super::*;
+
+    #[test]
+    fn malformed_header_context_is_not_accepted() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let mut headers = HeaderMap::new();
+        headers.insert("traceparent", HeaderValue::from_static("not-a-traceparent"));
+
+        assert!(extract_context_from_headers(&headers).is_none());
+    }
+}

--- a/crates/rpc-tracing/src/lib.rs
+++ b/crates/rpc-tracing/src/lib.rs
@@ -1,0 +1,18 @@
+#![doc = include_str!("../README.md")]
+
+mod client;
+mod context;
+mod server;
+mod transport;
+
+pub use client::{
+    TracedHttpClient, TracedWsClient, rpc_trace_context_http_client_middleware,
+    rpc_trace_context_ws_client_middleware,
+};
+pub use server::rpc_trace_context_server_middleware;
+pub use transport::{
+    HttpServerTraceContextLayer, http_trace_context_client_middleware,
+    http_trace_context_server_middleware,
+};
+#[cfg(test)]
+use {opentelemetry_sdk as _, tokio as _, tracing_subscriber as _};

--- a/crates/rpc-tracing/src/server.rs
+++ b/crates/rpc-tracing/src/server.rs
@@ -1,0 +1,196 @@
+use std::future::Future;
+
+use http::Extensions;
+use jsonrpsee::MethodResponse;
+use jsonrpsee::core::middleware::{Batch, Notification, Request, RpcServiceBuilder, RpcServiceT};
+use opentelemetry::trace::Status;
+use tower::Layer;
+use tower::layer::util::{Identity, Stack};
+use tracing::{Instrument, Span, debug, warn};
+use tracing_opentelemetry::{OpenTelemetrySpanExt, SetParentError};
+
+use crate::context::RemoteTraceContext;
+
+/// jsonrpsee server middleware that creates remotely parented RPC spans.
+#[derive(Clone, Debug, Default)]
+pub struct RpcServerTraceLayer;
+
+impl<S> Layer<S> for RpcServerTraceLayer {
+    type Service = RpcServerTraceService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcServerTraceService { inner }
+    }
+}
+
+/// Service used by the JSON-RPC server tracing middleware.
+#[derive(Clone, Debug)]
+pub struct RpcServerTraceService<S> {
+    inner: S,
+}
+
+/// RPC middleware stack used by jsonrpsee servers.
+pub(crate) type RpcTraceContextServerMiddleware =
+    RpcServiceBuilder<Stack<RpcServerTraceLayer, Identity>>;
+
+/// Creates middleware that extracts remote context and traces jsonrpsee server requests.
+pub fn rpc_trace_context_server_middleware() -> RpcTraceContextServerMiddleware {
+    RpcServiceBuilder::new().layer(RpcServerTraceLayer)
+}
+
+impl<S> RpcServiceT for RpcServerTraceService<S>
+where
+    S: RpcServiceT<
+            MethodResponse = MethodResponse,
+            BatchResponse = MethodResponse,
+            NotificationResponse = MethodResponse,
+        > + Send
+        + Sync
+        + Clone
+        + 'static,
+{
+    type MethodResponse = S::MethodResponse;
+    type BatchResponse = S::BatchResponse;
+    type NotificationResponse = S::NotificationResponse;
+
+    fn call<'a>(
+        &self,
+        request: Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        let remote_context = extract_request_context(request.extensions());
+        let span = server_span(request.method_name(), remote_context.as_ref());
+        let response_span = span.clone();
+        let response = self.inner.call(request);
+
+        async move {
+            let response = response.await;
+            record_response(&response_span, &response);
+            response
+        }
+        .instrument(span)
+    }
+
+    fn batch<'a>(
+        &self,
+        mut requests: Batch<'a>,
+    ) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        let remote_context = extract_request_context(requests.extensions());
+        let span = tracing::info_span!(
+            "rpc.server.batch",
+            otel.name = "jsonrpc",
+            otel.kind = "server",
+            rpc.system.name = "jsonrpc"
+        );
+        if let Some(remote_context) = remote_context {
+            set_remote_parent(&span, remote_context, "batch");
+        }
+
+        let response_span = span.clone();
+        let response = self.inner.batch(requests);
+        async move {
+            let response = response.await;
+            record_response(&response_span, &response);
+            response
+        }
+        .instrument(span)
+    }
+
+    fn notification<'a>(
+        &self,
+        notification: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        let remote_context = extract_request_context(notification.extensions());
+        let span = server_span(notification.method_name(), remote_context.as_ref());
+        let response_span = span.clone();
+        let response = self.inner.notification(notification);
+
+        async move {
+            let response = response.await;
+            record_response(&response_span, &response);
+            response
+        }
+        .instrument(span)
+    }
+}
+
+fn extract_request_context(extensions: &Extensions) -> Option<RemoteTraceContext> {
+    extensions.get::<RemoteTraceContext>().cloned()
+}
+
+fn server_span(method: &str, remote_context: Option<&RemoteTraceContext>) -> Span {
+    let span = tracing::info_span!(
+        "rpc.server",
+        otel.name = %method,
+        otel.kind = "server",
+        rpc.system.name = "jsonrpc",
+        rpc.method = %method
+    );
+    if let Some(remote_context) = remote_context {
+        set_remote_parent(&span, remote_context.clone(), method);
+    }
+    span
+}
+
+fn set_remote_parent(span: &Span, remote_context: RemoteTraceContext, method: &str) {
+    match span.set_parent(remote_context.0) {
+        Ok(()) => {}
+        Err(SetParentError::LayerNotFound) => {
+            debug!(%method, "OpenTelemetry layer is disabled; RPC trace parent was not attached");
+        }
+        Err(SetParentError::SpanDisabled) => {
+            debug!(%method, "RPC server span is disabled; trace parent was not attached");
+        }
+        Err(SetParentError::AlreadyStarted) => {
+            warn!(%method, "RPC server span started before its remote trace parent was attached");
+        }
+    }
+}
+
+fn record_response(span: &Span, response: &MethodResponse) {
+    if let Some(error_code) = response.as_error_code() {
+        let error_code = error_code.to_string();
+        span.set_attribute("rpc.response.status_code", error_code.clone());
+        span.set_attribute("error.type", error_code.clone());
+        span.set_status(Status::error(format!("JSON-RPC error {error_code}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use jsonrpsee::types::Id;
+    use opentelemetry::Context as OtelContext;
+    use opentelemetry::trace::{
+        SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    };
+
+    use super::*;
+
+    #[test]
+    fn batch_context_comes_from_shared_request_extensions() {
+        let mut batch = Batch::new();
+        batch.push(request_with_context("first", 1));
+        batch.push(request_with_context("second", 2));
+
+        let context = extract_request_context(batch.extensions())
+            .expect("batch entries carry a remote context");
+        assert_eq!(
+            context.0.span().span_context().trace_id(),
+            TraceId::from_bytes([1; 16])
+        );
+    }
+
+    fn request_with_context(method: &'static str, id: u64) -> Request<'static> {
+        let span_context = SpanContext::new(
+            TraceId::from_bytes([1; 16]),
+            SpanId::from_bytes([7; 8]),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::default(),
+        );
+        let mut request = Request::borrowed(method, None, Id::Number(id));
+        request.extensions_mut().insert(RemoteTraceContext(
+            OtelContext::new().with_remote_span_context(span_context),
+        ));
+        request
+    }
+}

--- a/crates/rpc-tracing/src/transport.rs
+++ b/crates/rpc-tracing/src/transport.rs
@@ -1,0 +1,105 @@
+use std::task::{Context as TaskContext, Poll};
+
+use http::Request as HttpRequest;
+use jsonrpsee::server::ws::is_upgrade_request;
+use tower::layer::util::{Identity, Stack};
+use tower::{Layer, Service, ServiceBuilder};
+use tracing::Span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use crate::context::{extract_context_from_headers, inject_context_into_headers};
+
+/// HTTP server middleware that extracts trace context from non-WebSocket requests.
+#[derive(Clone, Debug, Default)]
+pub struct HttpServerTraceContextLayer;
+
+impl<S> Layer<S> for HttpServerTraceContextLayer {
+    type Service = HttpServerTraceContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpServerTraceContextService { inner }
+    }
+}
+
+/// Service produced by [`HttpServerTraceContextLayer`].
+#[derive(Clone, Debug)]
+pub struct HttpServerTraceContextService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<HttpRequest<B>> for HttpServerTraceContextService<S>
+where
+    S: Service<HttpRequest<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: HttpRequest<B>) -> Self::Future {
+        if !is_upgrade_request(&request)
+            && let Some(remote_context) = extract_context_from_headers(request.headers())
+        {
+            request.extensions_mut().insert(remote_context);
+        }
+
+        self.inner.call(request)
+    }
+}
+
+/// HTTP client middleware that injects the current span context into each request.
+#[derive(Clone, Debug, Default)]
+pub struct HttpClientTraceContextLayer;
+
+impl<S> Layer<S> for HttpClientTraceContextLayer {
+    type Service = HttpClientTraceContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpClientTraceContextService { inner }
+    }
+}
+
+/// Service produced by [`HttpClientTraceContextLayer`].
+#[derive(Clone, Debug)]
+pub struct HttpClientTraceContextService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<HttpRequest<B>> for HttpClientTraceContextService<S>
+where
+    S: Service<HttpRequest<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: HttpRequest<B>) -> Self::Future {
+        inject_context_into_headers(&Span::current().context(), request.headers_mut());
+        self.inner.call(request)
+    }
+}
+
+/// HTTP middleware stack used by jsonrpsee servers.
+pub(crate) type HttpServerTraceContextMiddleware =
+    ServiceBuilder<Stack<HttpServerTraceContextLayer, Identity>>;
+
+/// HTTP middleware stack used by jsonrpsee HTTP clients.
+pub(crate) type HttpClientTraceContextMiddleware =
+    ServiceBuilder<Stack<HttpClientTraceContextLayer, Identity>>;
+
+/// Creates the transport middleware for a jsonrpsee HTTP/WebSocket server.
+pub fn http_trace_context_server_middleware() -> HttpServerTraceContextMiddleware {
+    ServiceBuilder::new().layer(HttpServerTraceContextLayer)
+}
+
+/// Creates middleware that injects trace context into each HTTP client request.
+pub fn http_trace_context_client_middleware() -> HttpClientTraceContextMiddleware {
+    ServiceBuilder::new().layer(HttpClientTraceContextLayer)
+}

--- a/crates/rpc-tracing/tests/http_correlation.rs
+++ b/crates/rpc-tracing/tests/http_correlation.rs
@@ -1,0 +1,74 @@
+//! HTTP cross-service trace correlation tests.
+
+mod support;
+
+use http::{HeaderMap, HeaderValue};
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::{RpcModule, ServerBuilder};
+use opentelemetry::trace::SpanKind;
+use strata_rpc_tracing::{
+    TracedHttpClient, http_trace_context_client_middleware, http_trace_context_server_middleware,
+    rpc_trace_context_http_client_middleware, rpc_trace_context_server_middleware,
+};
+use support::{TestTracing, assert_parent_child, find_named_span, find_rpc_span};
+use tower as _;
+use tracing::Instrument;
+
+#[tokio::test(flavor = "current_thread")]
+async fn checkpoint_request_correlates_prover_and_strata_over_http() {
+    const STATIC_TRACE_ID: &str = "11111111111111111111111111111111";
+    const STATIC_TRACEPARENT: &str = "00-11111111111111111111111111111111-2222222222222222-01";
+
+    let tracing = TestTracing::init("strata-rpc-tracing-http-test");
+    let server = ServerBuilder::new()
+        .set_http_middleware(http_trace_context_server_middleware())
+        .set_rpc_middleware(rpc_trace_context_server_middleware())
+        .build("127.0.0.1:0")
+        .await
+        .expect("HTTP test server should start");
+    let server_address = server
+        .local_addr()
+        .expect("HTTP test server should expose its address");
+    let mut module = RpcModule::new(());
+    module
+        .register_method("get_checkpoint_info", |_, _, _| "checkpoint")
+        .expect("checkpoint method should register");
+    let server_handle = server.start(module);
+
+    let mut static_headers = HeaderMap::new();
+    static_headers.insert("traceparent", HeaderValue::from_static(STATIC_TRACEPARENT));
+    let client: TracedHttpClient = HttpClientBuilder::default()
+        .set_headers(static_headers)
+        .set_http_middleware(http_trace_context_client_middleware())
+        .set_rpc_middleware(rpc_trace_context_http_client_middleware())
+        .build(format!("http://{server_address}"))
+        .expect("HTTP test client should build");
+
+    let caller_span =
+        tracing::info_span!("prover.fetch_checkpoint", otel.name = "fetch_checkpoint");
+    let response: String = async {
+        client
+            .request("get_checkpoint_info", rpc_params![42_u64])
+            .await
+    }
+    .instrument(caller_span.clone())
+    .await
+    .expect("checkpoint request should succeed");
+    assert_eq!(response, "checkpoint");
+
+    drop(client);
+    drop(caller_span);
+    server_handle.stop().expect("HTTP test server should stop");
+    server_handle.stopped().await;
+    let spans = tracing.finish();
+
+    let caller = find_named_span(&spans, "fetch_checkpoint");
+    let client = find_rpc_span(&spans, SpanKind::Client, "get_checkpoint_info");
+    let server = find_rpc_span(&spans, SpanKind::Server, "get_checkpoint_info");
+    assert_parent_child(caller, client);
+    assert_parent_child(client, server);
+    assert!(server.parent_span_is_remote);
+    assert_ne!(server.span_context.trace_id().to_string(), STATIC_TRACE_ID);
+}

--- a/crates/rpc-tracing/tests/support/mod.rs
+++ b/crates/rpc-tracing/tests/support/mod.rs
@@ -1,0 +1,86 @@
+use std::sync::Once;
+
+use opentelemetry::trace::{SpanKind, TracerProvider as _};
+use opentelemetry::{Value, global};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+use tracing::subscriber::{DefaultGuard, set_default};
+use tracing_subscriber::layer::SubscriberExt;
+
+static INSTALL_PROPAGATOR: Once = Once::new();
+
+pub(crate) struct TestTracing {
+    exporter: InMemorySpanExporter,
+    provider: SdkTracerProvider,
+    subscriber_guard: Option<DefaultGuard>,
+}
+
+impl TestTracing {
+    pub(crate) fn init(instrumentation_name: &'static str) -> Self {
+        INSTALL_PROPAGATOR.call_once(|| {
+            global::set_text_map_propagator(TraceContextPropagator::new());
+        });
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer(instrumentation_name);
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let subscriber_guard = set_default(subscriber);
+
+        Self {
+            exporter,
+            provider,
+            subscriber_guard: Some(subscriber_guard),
+        }
+    }
+
+    pub(crate) fn finish(mut self) -> Vec<SpanData> {
+        drop(self.subscriber_guard.take());
+        self.provider
+            .force_flush()
+            .expect("test spans should flush");
+        let spans = self
+            .exporter
+            .get_finished_spans()
+            .expect("test spans should be readable");
+        self.provider
+            .shutdown()
+            .expect("test tracer provider should shut down");
+        spans
+    }
+}
+
+pub(crate) fn find_named_span<'a>(spans: &'a [SpanData], span_name: &str) -> &'a SpanData {
+    spans
+        .iter()
+        .find(|span| span.name == span_name)
+        .unwrap_or_else(|| panic!("span `{span_name}` should be exported"))
+}
+
+pub(crate) fn find_rpc_span<'a>(
+    spans: &'a [SpanData],
+    span_kind: SpanKind,
+    method: &str,
+) -> &'a SpanData {
+    let method_value = Value::String(method.to_owned().into());
+    spans
+        .iter()
+        .find(|span| {
+            span.span_kind == span_kind
+                && span.attributes.iter().any(|attribute| {
+                    attribute.key.as_str() == "rpc.method" && attribute.value == method_value
+                })
+        })
+        .unwrap_or_else(|| panic!("{span_kind:?} span for `{method}` should be exported"))
+}
+
+pub(crate) fn assert_parent_child(parent: &SpanData, child: &SpanData) {
+    assert_eq!(
+        child.span_context.trace_id(),
+        parent.span_context.trace_id()
+    );
+    assert_eq!(child.parent_span_id, parent.span_context.span_id());
+}

--- a/crates/rpc-tracing/tests/websocket_correlation.rs
+++ b/crates/rpc-tracing/tests/websocket_correlation.rs
@@ -1,0 +1,127 @@
+//! WebSocket transport tests.
+//!
+//! Cross-service propagation over WebSocket requires per-message JSON-RPC
+//! request extensions ([paritytech/jsonrpsee#1647]) and is intentionally not
+//! performed yet. These tests pin the interim behavior: client spans are
+//! created per operation, and the connection handshake headers never become
+//! RPC span parents.
+//!
+//! [paritytech/jsonrpsee#1647]: https://github.com/paritytech/jsonrpsee/pull/1647
+
+mod support;
+
+use http::{HeaderMap, HeaderValue};
+use jsonrpsee::core::client::{ClientT, Error as RpcClientError};
+use jsonrpsee::rpc_params;
+use jsonrpsee::server::{RpcModule, ServerBuilder};
+use jsonrpsee::types::ErrorObject;
+use jsonrpsee::ws_client::WsClientBuilder;
+use opentelemetry::Value;
+use opentelemetry::trace::{SpanKind, Status};
+use opentelemetry_sdk::trace::SpanData;
+use strata_rpc_tracing::{
+    TracedWsClient, http_trace_context_server_middleware, rpc_trace_context_server_middleware,
+    rpc_trace_context_ws_client_middleware,
+};
+use support::{TestTracing, assert_parent_child, find_named_span, find_rpc_span};
+use tower as _;
+use tracing::Instrument;
+
+#[tokio::test(flavor = "current_thread")]
+async fn websocket_operations_are_traced_without_handshake_parents() {
+    const HANDSHAKE_TRACE_ID: &str = "11111111111111111111111111111111";
+    const HANDSHAKE_TRACEPARENT: &str = "00-11111111111111111111111111111111-2222222222222222-01";
+
+    let tracing = TestTracing::init("strata-rpc-tracing-websocket-test");
+    let server = ServerBuilder::new()
+        .set_http_middleware(http_trace_context_server_middleware())
+        .set_rpc_middleware(rpc_trace_context_server_middleware())
+        .build("127.0.0.1:0")
+        .await
+        .expect("WebSocket test server should start");
+    let server_address = server
+        .local_addr()
+        .expect("WebSocket test server should expose its address");
+
+    let mut module = RpcModule::new(());
+    module
+        .register_method("first", |_, _, _| 1_u64)
+        .expect("first method should register");
+    module
+        .register_method("fail", |_, _, _| {
+            ErrorObject::owned(-32042, "request rejected", None::<()>)
+        })
+        .expect("failing method should register");
+    let server_handle = server.start(module);
+    let server_url = format!("ws://{server_address}");
+
+    let mut handshake_headers = HeaderMap::new();
+    handshake_headers.insert(
+        "traceparent",
+        HeaderValue::from_static(HANDSHAKE_TRACEPARENT),
+    );
+    let client: TracedWsClient = WsClientBuilder::default()
+        .set_headers(handshake_headers)
+        .set_rpc_middleware(rpc_trace_context_ws_client_middleware())
+        .build(&server_url)
+        .await
+        .expect("traced WebSocket client should connect");
+
+    let first_caller = tracing::info_span!("first_operation", otel.name = "first_operation");
+    let first: u64 = async { client.request("first", rpc_params![]).await }
+        .instrument(first_caller.clone())
+        .await
+        .expect("first request should succeed");
+    assert_eq!(first, 1);
+
+    let error = client
+        .request::<String, _>("fail", rpc_params![])
+        .await
+        .expect_err("failing request should return an error");
+    assert!(matches!(
+        error,
+        RpcClientError::Call(ref error) if error.code() == -32042
+    ));
+
+    drop(client);
+    drop(first_caller);
+    server_handle
+        .stop()
+        .expect("WebSocket test server should stop");
+    server_handle.stopped().await;
+    let spans = tracing.finish();
+
+    // Client spans are created per operation and parented by the caller.
+    let caller = find_named_span(&spans, "first_operation");
+    let client_span = find_rpc_span(&spans, SpanKind::Client, "first");
+    assert_parent_child(caller, client_span);
+
+    // Server spans are local roots: neither the handshake headers nor the
+    // client span may parent them until per-message propagation lands.
+    for method in ["first", "fail"] {
+        let server_span = find_rpc_span(&spans, SpanKind::Server, method);
+        assert!(!server_span.parent_span_is_remote);
+        assert_ne!(
+            server_span.span_context.trace_id().to_string(),
+            HANDSHAKE_TRACE_ID
+        );
+    }
+
+    let failing_client = find_rpc_span(&spans, SpanKind::Client, "fail");
+    let failing_server = find_rpc_span(&spans, SpanKind::Server, "fail");
+    assert_rpc_error_code(failing_client, "-32042");
+    assert_rpc_error_code(failing_server, "-32042");
+}
+
+fn assert_rpc_error_code(span: &SpanData, expected_error_code: &str) {
+    let expected_value = Value::String(expected_error_code.to_owned().into());
+    for attribute_name in ["rpc.response.status_code", "error.type"] {
+        assert!(
+            span.attributes.iter().any(|attribute| {
+                attribute.key.as_str() == attribute_name && attribute.value == expected_value
+            }),
+            "span should record `{attribute_name}` as `{expected_error_code}`"
+        );
+    }
+    assert!(matches!(&span.status, Status::Error { .. }));
+}


### PR DESCRIPTION
## What changed

- add `strata-rpc-tracing` as the shared jsonrpsee tracing boundary
- propagate W3C Trace Context through HTTP headers per request
- create OpenTelemetry client/server spans for calls, notifications, and batches
- export `TracedHttpClient` and `TracedWsClient` so consumers do not repeat middleware implementation types
- reject malformed context without panicking
- keep `strata-logging` responsible for process-global subscriber, propagator, resource, and exporter setup

**This PR builds entirely on crates.io jsonrpsee 0.26 — no fork, no `[patch.crates-io]`.** Consumers need no dependency patching.

## Why

[STR-1975](https://alpenlabs.atlassian.net/browse/STR-1975) requires one operation to remain correlated across service RPC boundaries. Transport and jsonrpsee mechanics belong in `strata-common`; binaries only configure telemetry identity and install the middleware at concrete boundaries.

## Scope: HTTP propagation now, WebSocket propagation as follow-up

HTTP context is carried in request headers, extracted by a tower layer, and flows to RPC method spans through `http::Extensions` — all stock jsonrpsee.

WebSocket operations get client and server spans, but server spans remain local roots for now. A pooled connection carries unrelated operations, so the upgrade handshake must never be their shared parent — and carrying per-operation context requires per-message JSON-RPC request extensions, proposed upstream in [paritytech/jsonrpsee#1647](https://github.com/paritytech/jsonrpsee/pull/1647) but not yet released. The complete per-message implementation exists on branch [`str-1975-jsonrpc-ws-tracing`](https://github.com/alpenlabs/strata-common/tree/str-1975-jsonrpc-ws-tracing) and lands as a follow-up PR once the upstream API is available (or the team agrees on an interim source — discussion pending).

The tests deliberately pin the interim behavior: handshake headers never become RPC span parents.

## API

The crate exposes middleware constructors for the jsonrpsee builder hooks and canonical traced client aliases for values that must cross crate boundaries. Existing server HTTP layers, such as bridge health routing and Alpen authentication/CORS, remain composable through `HttpServerTraceContextLayer`.

The crate does not install global telemetry state and does not put trace IDs into metric labels.

## Behavior covered

Real-socket transport tests verify:

- HTTP caller -> client span -> remote-parent server span
- WebSocket handshake headers never become RPC parents
- JSON-RPC errors are recorded on both boundary spans over both transports
- malformed context is ignored without panicking

## Validation

- `cargo test -p strata-rpc-tracing --all-features`
- `cargo clippy -p strata-rpc-tracing --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p strata-rpc-tracing --all-features --no-deps`
- `cargo check --workspace --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Note for review: Cargo.lock grows because the workspace lock now includes jsonrpsee and its tree (registry sources, standard checksums) — the dependency review surface is the `[workspace.dependencies]` line `jsonrpsee = "0.26"`.

[STR-1975]: https://alpenlabs.atlassian.net/browse/STR-1975
