### PR TITLE
STR 4058 Shared commit-reveal builder and parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,13 +752,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,6 +3828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "strata-l1-commit-reveal-fmt"
+version = "0.1.0"
+dependencies = [
+ "bitcoin",
+ "strata-l1-envelope-fmt",
+ "strata-l1-txfmt",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "strata-l1-envelope-fmt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/crypto",
   "crates/db-macros",
   "crates/identifiers",
+  "crates/l1proto/commit-reveal",
   "crates/l1proto/envelope-fmt",
   "crates/l1proto/txfmt",
   "crates/logging",
@@ -34,6 +35,8 @@ strata-codec-utils = { path = "crates/codec-utils" }
 strata-crypto = { path = "crates/crypto" }
 strata-db-macros = { path = "crates/db-macros" }
 strata-identifiers = { path = "crates/identifiers" }
+strata-l1-commit-reveal-fmt = { path = "crates/l1proto/commit-reveal" }
+strata-l1-envelope-fmt = { path = "crates/l1proto/envelope-fmt" }
 strata-l1-txfmt = { path = "crates/l1proto/txfmt" }
 strata-logging = { path = "crates/logging" }
 strata-merkle = { path = "crates/merkle" }

--- a/crates/l1proto/commit-reveal/Cargo.toml
+++ b/crates/l1proto/commit-reveal/Cargo.toml
@@ -14,3 +14,6 @@ thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[features]
+test-utils = []

--- a/crates/l1proto/commit-reveal/Cargo.toml
+++ b/crates/l1proto/commit-reveal/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "strata-l1-commit-reveal-fmt"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+strata-l1-envelope-fmt.workspace = true
+# Use txfmt without default features: the zkVM guest build needs only MagicBytes,
+# not serde/borsh/arbitrary.
+strata-l1-txfmt = { path = "../txfmt", default-features = false }
+
+bitcoin.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/l1proto/commit-reveal/src/builder.rs
+++ b/crates/l1proto/commit-reveal/src/builder.rs
@@ -1,0 +1,363 @@
+//! Script construction for one commit-reveal set.
+
+use std::num::NonZeroUsize;
+
+use bitcoin::blockdata::script::Builder;
+use bitcoin::opcodes::all::OP_RETURN;
+use bitcoin::script::PushBytesBuf;
+use bitcoin::{Script, ScriptBuf};
+use strata_l1_envelope_fmt::SIGNED_LEAF_PUBKEY_LEN;
+use strata_l1_envelope_fmt::builder::{
+    build_signed_envelope_leaf, split_payload_into_envelope_chunks,
+};
+use strata_l1_txfmt::MagicBytes;
+
+use crate::MAX_MARKER_TAIL_BYTES;
+use crate::errors::CommitRevealBuildError;
+
+/// The scripts for one commit-reveal set.
+///
+/// Holding this is the writer-side contract: if it carries N reveal leaves, the
+/// commit transaction must fund exactly N reveal-slot outputs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRevealScripts {
+    marker_script: ScriptBuf,
+    reveal_leaf_scripts: Vec<ScriptBuf>,
+}
+
+impl CommitRevealScripts {
+    /// The commit marker script.
+    pub fn marker_script(&self) -> &Script {
+        &self.marker_script
+    }
+
+    /// The reveal leaf scripts, in commit-output order.
+    pub fn reveal_leaf_scripts(&self) -> &[ScriptBuf] {
+        &self.reveal_leaf_scripts
+    }
+
+    /// How many P2TR reveal slots the commit transaction must fund.
+    ///
+    /// Never zero: an empty chunk list is rejected with
+    /// [`CommitRevealBuildError::NoChunks`].
+    pub fn reveal_slot_count(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.reveal_leaf_scripts.len())
+            .expect("builder rejects an empty chunk list, so there is at least one leaf")
+    }
+
+    /// Consumes the set, returning the marker script and the leaf scripts.
+    pub fn into_parts(self) -> (ScriptBuf, Vec<ScriptBuf>) {
+        (self.marker_script, self.reveal_leaf_scripts)
+    }
+}
+
+/// Builds the marker and one reveal leaf per supplied chunk.
+///
+/// `marker_tail` follows the magic in the marker and is not interpreted here.
+/// Chunk boundaries are preserved: each supplied chunk becomes exactly one
+/// reveal leaf.
+///
+/// # Errors
+///
+/// [`CommitRevealBuildError::NoChunks`] if `chunks` is empty,
+/// [`CommitRevealBuildError::EmptyChunk`] if any chunk is empty,
+/// [`CommitRevealBuildError::MarkerTailTooLarge`] if `marker_tail` exceeds
+/// [`MAX_MARKER_TAIL_BYTES`], or [`CommitRevealBuildError::RevealLeaf`] if a leaf
+/// cannot be built.
+pub fn build_commit_reveal_scripts_from_chunks(
+    magic: &MagicBytes,
+    marker_tail: impl AsRef<[u8]>,
+    reveal_pubkey: &[u8; SIGNED_LEAF_PUBKEY_LEN],
+    chunks: &[impl AsRef<[u8]>],
+) -> Result<CommitRevealScripts, CommitRevealBuildError> {
+    if chunks.is_empty() {
+        return Err(CommitRevealBuildError::NoChunks);
+    }
+
+    if let Some(index) = chunks.iter().position(|chunk| chunk.as_ref().is_empty()) {
+        return Err(CommitRevealBuildError::EmptyChunk { index });
+    }
+
+    let marker_script = build_commit_marker_script(magic, marker_tail.as_ref())?;
+    let reveal_leaf_scripts = chunks
+        .iter()
+        .map(|chunk| build_signed_envelope_leaf(reveal_pubkey, chunk.as_ref()))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(CommitRevealScripts {
+        marker_script,
+        reveal_leaf_scripts,
+    })
+}
+
+/// Builds the marker and reveal leaves for one payload.
+///
+/// Convenience over [`build_commit_reveal_scripts_from_chunks`] that splits
+/// `payload` into envelope-sized chunks first. An empty payload yields no chunks
+/// and returns [`CommitRevealBuildError::NoChunks`].
+///
+/// # Errors
+///
+/// As [`build_commit_reveal_scripts_from_chunks`].
+pub fn build_commit_reveal_scripts(
+    magic: &MagicBytes,
+    marker_tail: impl AsRef<[u8]>,
+    reveal_pubkey: &[u8; SIGNED_LEAF_PUBKEY_LEN],
+    payload: impl AsRef<[u8]>,
+) -> Result<CommitRevealScripts, CommitRevealBuildError> {
+    let chunks = split_payload_into_envelope_chunks(payload.as_ref());
+    build_commit_reveal_scripts_from_chunks(magic, marker_tail, reveal_pubkey, &chunks)
+}
+
+/// Builds the commit marker script.
+///
+/// Produces `OP_RETURN <magic || tail>` as a single push; `tail` is opaque.
+///
+/// # Errors
+///
+/// Returns [`CommitRevealBuildError::MarkerTailTooLarge`] if `tail` exceeds
+/// [`MAX_MARKER_TAIL_BYTES`].
+pub(crate) fn build_commit_marker_script(
+    magic: &MagicBytes,
+    tail: &[u8],
+) -> Result<ScriptBuf, CommitRevealBuildError> {
+    if tail.len() > MAX_MARKER_TAIL_BYTES {
+        return Err(CommitRevealBuildError::MarkerTailTooLarge {
+            tail_len: tail.len(),
+            max: MAX_MARKER_TAIL_BYTES,
+        });
+    }
+
+    let mut payload = Vec::with_capacity(magic.as_bytes().len() + tail.len());
+    payload.extend_from_slice(magic.as_bytes());
+    payload.extend_from_slice(tail);
+
+    let push = PushBytesBuf::try_from(payload)
+        .expect("marker within the OP_RETURN push limit is a valid push");
+
+    Ok(Builder::new()
+        .push_opcode(OP_RETURN)
+        .push_slice(push)
+        .into_script())
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::opcodes::all::{OP_CHECKSIG, OP_ENDIF, OP_IF};
+    use bitcoin::opcodes::{OP_0, OP_FALSE};
+    use bitcoin::script::Instruction;
+    use strata_l1_envelope_fmt::builder::MAX_ENVELOPE_PAYLOAD_SIZE;
+
+    use super::*;
+    use crate::test_utils::{DEFAULT_KEY_SEED, TEST_MAGIC, make_xonly_pubkey_bytes};
+
+    /// The marker must be a single push so a reader can tell it from another
+    /// protocol's OP_RETURN that happens to share the magic prefix.
+    #[test]
+    fn test_marker_is_op_return_with_one_push_of_magic_and_tail() {
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [1, 2, 3, 4],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"payload",
+        )
+        .expect("builds");
+
+        let mut instructions = scripts.marker_script().instructions();
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::Op(op))) if op == OP_RETURN
+        ));
+        let Some(Ok(Instruction::PushBytes(push))) = instructions.next() else {
+            panic!("marker must carry a push");
+        };
+        assert_eq!(push.as_bytes(), b"TEST\x01\x02\x03\x04");
+        assert!(instructions.next().is_none(), "marker must be one push");
+    }
+
+    #[test]
+    fn test_marker_accepts_tail_up_to_limit() {
+        let tail = vec![0u8; MAX_MARKER_TAIL_BYTES];
+
+        assert!(build_commit_marker_script(&TEST_MAGIC, &tail).is_ok());
+    }
+
+    #[test]
+    fn test_marker_rejects_tail_over_limit() {
+        let tail = vec![0u8; MAX_MARKER_TAIL_BYTES + 1];
+
+        let error = build_commit_marker_script(&TEST_MAGIC, &tail).expect_err("over limit");
+
+        assert!(matches!(
+            error,
+            CommitRevealBuildError::MarkerTailTooLarge { max, .. }
+                if max == MAX_MARKER_TAIL_BYTES
+        ));
+    }
+
+    /// The leaf shape is what makes a confirmed spend evidence that the pubkey
+    /// holder signed, so the pubkey must sit first, guarded by OP_CHECKSIG.
+    #[test]
+    fn test_reveal_leaf_opens_with_pubkey_and_checksig() {
+        let pubkey = make_xonly_pubkey_bytes(DEFAULT_KEY_SEED);
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"chunk",
+        )
+        .expect("builds");
+
+        let mut instructions = scripts.reveal_leaf_scripts()[0].instructions();
+        let Some(Ok(Instruction::PushBytes(push))) = instructions.next() else {
+            panic!("leaf must open with a pubkey push");
+        };
+        assert_eq!(push.as_bytes(), pubkey.as_slice());
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::Op(op))) if op == OP_CHECKSIG
+        ));
+        // OP_FALSE pushes an empty byte array, so a decoded script presents it
+        // as an empty push rather than as the opcode.
+        let opener = instructions.next();
+        assert!(
+            matches!(opener, Some(Ok(Instruction::Op(op))) if op == OP_FALSE || op == OP_0)
+                || matches!(opener, Some(Ok(Instruction::PushBytes(b))) if b.as_bytes().is_empty()),
+            "envelope must open with OP_FALSE in one of its equivalent forms"
+        );
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::Op(op))) if op == OP_IF
+        ));
+    }
+
+    #[test]
+    fn test_reveal_leaf_ends_with_endif() {
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"chunk",
+        )
+        .expect("builds");
+
+        let last = scripts.reveal_leaf_scripts()[0].instructions().last();
+
+        assert!(matches!(last, Some(Ok(Instruction::Op(op))) if op == OP_ENDIF));
+    }
+
+    #[test]
+    fn test_payload_below_one_chunk_yields_one_leaf() {
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"short",
+        )
+        .expect("builds");
+
+        assert_eq!(scripts.reveal_leaf_scripts().len(), 1);
+        assert_eq!(scripts.reveal_slot_count().get(), 1);
+    }
+
+    /// Reveal count is not written on chain, so it has to follow from the
+    /// payload size and the per-reveal ceiling alone.
+    #[test]
+    fn test_payload_over_one_chunk_yields_one_leaf_per_chunk() {
+        let payload = vec![7u8; MAX_ENVELOPE_PAYLOAD_SIZE + 1];
+
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            &payload,
+        )
+        .expect("builds");
+
+        assert_eq!(scripts.reveal_slot_count().get(), 2);
+    }
+
+    /// The primitive builds one leaf per supplied chunk, without re-splitting.
+    #[test]
+    fn test_each_chunk_becomes_one_reveal_leaf() {
+        let chunks: [&[u8]; 3] = [b"a", b"bb", b"ccc"];
+
+        let scripts = build_commit_reveal_scripts_from_chunks(
+            &TEST_MAGIC,
+            b"",
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            &chunks,
+        )
+        .expect("builds");
+
+        assert_eq!(scripts.reveal_slot_count().get(), 3);
+    }
+
+    /// A writer publishing nothing must not build a set: both entry points
+    /// reject an empty input with `NoChunks`.
+    #[test]
+    fn test_empty_chunk_list_is_rejected() {
+        let empty: [&[u8]; 0] = [];
+
+        let error = build_commit_reveal_scripts_from_chunks(
+            &TEST_MAGIC,
+            b"",
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            &empty,
+        )
+        .expect_err("no chunks");
+
+        assert!(matches!(error, CommitRevealBuildError::NoChunks));
+    }
+
+    /// An empty chunk would build a reveal carrying nothing, so it is rejected —
+    /// on its own and when mixed with non-empty chunks — and the reported index
+    /// points at the offending chunk.
+    #[test]
+    fn test_empty_chunk_is_rejected() {
+        let key = make_xonly_pubkey_bytes(DEFAULT_KEY_SEED);
+        let lone: &[&[u8]] = &[b"" as &[u8]];
+        let mixed: &[&[u8]] = &[b"payload" as &[u8], b""];
+
+        for (chunks, expected_index) in [(lone, 0usize), (mixed, 1)] {
+            let error = build_commit_reveal_scripts_from_chunks(&TEST_MAGIC, b"", &key, chunks)
+                .expect_err("empty chunk");
+
+            assert!(
+                matches!(error, CommitRevealBuildError::EmptyChunk { index } if index == expected_index),
+                "expected EmptyChunk {{ index: {expected_index} }}, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_empty_payload_is_rejected() {
+        let error = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            b"",
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"",
+        )
+        .expect_err("empty payload");
+
+        assert!(matches!(error, CommitRevealBuildError::NoChunks));
+    }
+
+    #[test]
+    fn test_oversized_marker_tail_is_rejected() {
+        let tail = vec![0u8; MAX_MARKER_TAIL_BYTES + 1];
+
+        let error = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            tail,
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            b"payload",
+        )
+        .expect_err("marker over limit");
+
+        assert!(matches!(
+            error,
+            CommitRevealBuildError::MarkerTailTooLarge { .. }
+        ));
+    }
+}

--- a/crates/l1proto/commit-reveal/src/errors.rs
+++ b/crates/l1proto/commit-reveal/src/errors.rs
@@ -1,0 +1,38 @@
+//! Errors raised when building a commit-reveal set.
+
+use strata_l1_envelope_fmt::errors::EnvelopeBuildError;
+use thiserror::Error;
+
+/// Errors that can occur while building commit-reveal scripts.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CommitRevealBuildError {
+    /// The marker tail exceeds the room left after the magic.
+    #[error("commit marker tail ({tail_len} bytes) exceeds maximum ({max} bytes)")]
+    MarkerTailTooLarge {
+        /// Length of the supplied tail.
+        tail_len: usize,
+
+        /// The maximum allowed tail length.
+        max: usize,
+    },
+
+    /// No chunks were supplied, so there is nothing to reveal.
+    #[error("commit-reveal set has no chunks")]
+    NoChunks,
+
+    /// A chunk is empty; every reveal must carry data.
+    #[error("chunk {index} is empty")]
+    EmptyChunk {
+        /// Index of the empty chunk.
+        index: usize,
+    },
+
+    /// A reveal leaf script could not be built.
+    #[error("failed to build reveal leaf script: {source}")]
+    RevealLeaf {
+        /// The underlying envelope builder error.
+        #[from]
+        source: EnvelopeBuildError,
+    },
+}

--- a/crates/l1proto/commit-reveal/src/errors.rs
+++ b/crates/l1proto/commit-reveal/src/errors.rs
@@ -109,6 +109,10 @@ pub enum CommitRevealParseError {
     #[error("reveal spends multiple reveal slots of the commit tx")]
     RevealMultipleCommitSpends,
 
+    /// A reveal transaction spends reveal slots of more than one known commit.
+    #[error("reveal tx spends reveal slots of multiple commits")]
+    RevealSpansMultipleCommits,
+
     /// Two reveal transactions claim the same commit output.
     #[error("duplicate reveal for commit output {vout}")]
     DuplicateReveal {

--- a/crates/l1proto/commit-reveal/src/errors.rs
+++ b/crates/l1proto/commit-reveal/src/errors.rs
@@ -1,7 +1,18 @@
-//! Errors raised when building a commit-reveal set.
+//! Errors raised when building or parsing a commit-reveal set.
 
-use strata_l1_envelope_fmt::errors::EnvelopeBuildError;
+use strata_l1_envelope_fmt::errors::{EnvelopeBuildError, EnvelopeParseError};
 use thiserror::Error;
+
+/// Error returned when the marker tail has an unexpected length.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("expected marker tail to be {expected} bytes, found {found}")]
+pub struct MarkerTailArrayLengthError {
+    /// Expected marker-tail length.
+    pub expected: usize,
+
+    /// Actual marker-tail length.
+    pub found: usize,
+}
 
 /// Errors that can occur while building commit-reveal scripts.
 #[derive(Debug, Error)]
@@ -34,5 +45,121 @@ pub enum CommitRevealBuildError {
         /// The underlying envelope builder error.
         #[from]
         source: EnvelopeBuildError,
+    },
+}
+
+/// Errors that can occur while parsing a commit-reveal set.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CommitRevealParseError {
+    /// No commit marker was found for the supplied magic.
+    ///
+    /// No transaction in the supplied set carries one.
+    #[error("no commit marker for the supplied magic")]
+    MissingCommit,
+
+    /// The transaction set contains more than one commit-marked transaction.
+    #[error("multiple commit txs in set")]
+    MultipleCommits,
+
+    /// A commit output run has no reveal slots at all.
+    #[error("commit has no reveal slots")]
+    MissingRevealSlots,
+
+    /// A P2TR output follows a non-P2TR one, so the reveal-slot run is
+    /// ambiguous.
+    ///
+    /// Chunk count is derived from the contiguous run of P2TR outputs after the
+    /// marker, which is only sound while change is non-P2TR. A P2TR output
+    /// appearing after the run has closed makes the boundary unknowable, so the
+    /// commit is rejected rather than guessed at.
+    #[error("ambiguous P2TR change output at commit output {vout}")]
+    AmbiguousTaprootChangeOutput {
+        /// Output index of the offending P2TR output.
+        vout: u32,
+    },
+
+    /// A reveal-slot range was built with no slots in it.
+    ///
+    /// Output 0 carries the marker and is never a reveal slot, so a range
+    /// ending at 0 is empty.
+    #[error("reveal slot range must end after output 0")]
+    EmptyRevealSlotRange,
+
+    /// A reveal transaction has no inputs.
+    #[error("reveal tx has no inputs")]
+    RevealMissingInputs,
+
+    /// A reveal transaction does not spend the expected commit transaction.
+    #[error("reveal tx does not spend the commit tx")]
+    RevealWrongCommit,
+
+    /// A reveal transaction spends the commit's marker output.
+    #[error("reveal spends commit output 0 (marker)")]
+    RevealSpendsMarker,
+
+    /// A reveal transaction spends a commit output outside the reveal-slot run.
+    #[error("unexpected reveal for commit output {vout}")]
+    UnexpectedReveal {
+        /// Output index spent outside the reveal-slot run.
+        vout: u32,
+    },
+
+    /// A single reveal transaction spends more than one reveal slot.
+    #[error("reveal spends multiple reveal slots of the commit tx")]
+    RevealMultipleCommitSpends,
+
+    /// Two reveal transactions claim the same commit output.
+    #[error("duplicate reveal for commit output {vout}")]
+    DuplicateReveal {
+        /// Output index claimed twice.
+        vout: u32,
+    },
+
+    /// No reveal transaction was supplied for a commit output in the run.
+    #[error("missing reveal for commit output {vout}")]
+    MissingReveal {
+        /// Output index with no reveal.
+        vout: u32,
+    },
+
+    /// A reveal input carries no taproot leaf script in its witness.
+    #[error("reveal tx witness has no taproot leaf script")]
+    RevealMissingLeafScript,
+
+    /// A reveal leaf uses a leaf version other than tapscript.
+    #[error("reveal leaf uses unsupported leaf version {version:#04x}")]
+    RevealUnsupportedLeafVersion {
+        /// Consensus encoding of the offending leaf version.
+        version: u8,
+    },
+
+    /// A reveal leaf carries an empty payload; every reveal must carry data.
+    #[error("reveal for commit output {vout} carries an empty payload")]
+    EmptyReveal {
+        /// Output index whose reveal payload is empty.
+        vout: u32,
+    },
+
+    /// Reveal leaves in one set carry different pubkeys.
+    ///
+    /// SPS-53 signs every reveal of an inscription under one producer key, so a
+    /// set whose leaves disagree has no single key to authenticate against.
+    #[error("reveal for commit output {vout} carries a different pubkey than earlier reveals")]
+    InconsistentRevealPubkey {
+        /// Output index whose reveal pubkey differs.
+        vout: u32,
+    },
+
+    /// The reveal pubkey does not match the key the caller expected.
+    #[error("reveal pubkey does not match the expected key")]
+    UnexpectedRevealPubkey,
+
+    /// A reveal leaf did not match the strict signed envelope shape.
+    #[error("failed to parse reveal envelope: {source}")]
+    InvalidRevealEnvelope {
+        /// The underlying envelope parse failure.
+        #[from]
+        source: EnvelopeParseError,
     },
 }

--- a/crates/l1proto/commit-reveal/src/grouping.rs
+++ b/crates/l1proto/commit-reveal/src/grouping.rs
@@ -1,0 +1,404 @@
+//! Commit discovery and reveal grouping helpers.
+//!
+//! These functions are stateless. The caller owns block iteration,
+//! confirmation policy, reorg handling, persistence, and telemetry.
+
+use bitcoin::{Transaction, Txid};
+use strata_l1_txfmt::MagicBytes;
+
+use crate::errors::{CommitRevealParseError, MarkerTailArrayLengthError};
+use crate::parser::{
+    ParsedCommitReveal, RevealSlotRange, assemble_from_slots, classify_reveal_inputs_for_commit,
+    convert_marker_tail_to_array_ref, derive_reveal_slot_range, read_commit_marker,
+};
+
+/// Owned metadata for a transaction parsed as an SPS-53 commit.
+///
+/// The marker matches the supplied magic, the reveal-slot run is present and
+/// unambiguous, and the marker tail is available for caller-specific
+/// interpretation. It says nothing about confirmation, auth, payload type, or
+/// reveal completeness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommit {
+    txid: Txid,
+    marker_tail: Vec<u8>,
+    reveal_slots: RevealSlotRange,
+}
+
+impl ParsedCommit {
+    /// The commit transaction's id.
+    pub fn txid(&self) -> Txid {
+        self.txid
+    }
+
+    /// Marker bytes after the magic.
+    pub fn marker_tail(&self) -> &[u8] {
+        &self.marker_tail
+    }
+
+    /// Marker tail as a fixed-width byte array.
+    ///
+    /// This only checks length. The caller still owns any meaning assigned to
+    /// the tail bytes.
+    pub fn marker_tail_array<const N: usize>(
+        &self,
+    ) -> Result<&[u8; N], MarkerTailArrayLengthError> {
+        convert_marker_tail_to_array_ref(&self.marker_tail)
+    }
+
+    /// The commit's reveal-slot range.
+    pub const fn reveal_slots(&self) -> RevealSlotRange {
+        self.reveal_slots
+    }
+}
+
+/// Classifies one transaction as a commit candidate.
+///
+/// `Ok(Some)` means the marker matches `magic` and the reveal-slot run is
+/// unambiguous. `Ok(None)` means no marker matches. A matching marker with a
+/// malformed commit layout is an error.
+///
+/// # Errors
+///
+/// [`CommitRevealParseError::MissingRevealSlots`] for a matching marker with no
+/// reveal slots; [`CommitRevealParseError::AmbiguousTaprootChangeOutput`] when a
+/// P2TR output follows a non-P2TR one in the reveal-slot run.
+pub fn parse_commit_candidate(
+    magic: &MagicBytes,
+    tx: &Transaction,
+) -> Result<Option<ParsedCommit>, CommitRevealParseError> {
+    let Some(marker_tail) = read_commit_marker(magic, tx) else {
+        return Ok(None);
+    };
+
+    let reveal_slots =
+        derive_reveal_slot_range(tx)?.ok_or(CommitRevealParseError::MissingRevealSlots)?;
+    Ok(Some(ParsedCommit {
+        txid: tx.compute_txid(),
+        marker_tail: marker_tail.to_vec(),
+        reveal_slots,
+    }))
+}
+
+/// Assigns one transaction to the commit whose reveal slot it spends.
+///
+/// Returns `Ok(None)` when `tx` spends no reveal slot from `commits`. Returns
+/// [`CommitRevealParseError::RevealSpansMultipleCommits`] when it spends reveal
+/// slots from more than one commit.
+///
+/// # Errors
+///
+/// Also returns [`CommitRevealParseError::RevealSpendsMarker`],
+/// [`CommitRevealParseError::UnexpectedReveal`], or
+/// [`CommitRevealParseError::RevealMultipleCommitSpends`] when the transaction
+/// spends a malformed set of outputs from its assigned commit.
+pub fn assign_reveal_to_commit<'c>(
+    commits: impl IntoIterator<Item = &'c ParsedCommit>,
+    tx: &Transaction,
+) -> Result<Option<Txid>, CommitRevealParseError> {
+    let mut assigned: Option<&ParsedCommit> = None;
+    for commit in commits {
+        let spends_commit_slot = tx.input.iter().any(|input| {
+            let prev = input.previous_output;
+            prev.txid == commit.txid && commit.reveal_slots.contains(prev.vout)
+        });
+        if !spends_commit_slot {
+            continue;
+        }
+
+        match assigned {
+            Some(existing) if existing.txid != commit.txid => {
+                return Err(CommitRevealParseError::RevealSpansMultipleCommits);
+            }
+            Some(_) => {}
+            None => assigned = Some(commit),
+        }
+    }
+
+    let Some(commit) = assigned else {
+        return Ok(None);
+    };
+
+    let slot_spend = classify_reveal_inputs_for_commit(tx, commit.txid, commit.reveal_slots)?;
+    debug_assert!(
+        slot_spend.is_some(),
+        "assigned commit has a reveal-slot spend"
+    );
+
+    Ok(Some(commit.txid))
+}
+
+/// Extracts the payload for a parsed commit from its reveal transactions.
+///
+/// # Errors
+///
+/// Returns a [`CommitRevealParseError`] if a slot is missing or claimed twice, a
+/// reveal fails to parse, or the reveals disagree on one pubkey.
+pub fn extract_payload_for_parsed_commit<'c, 't>(
+    commit: &'c ParsedCommit,
+    reveals: impl IntoIterator<Item = &'t Transaction>,
+) -> Result<ParsedCommitReveal<'c>, CommitRevealParseError> {
+    assemble_from_slots(
+        commit.txid,
+        &commit.marker_tail,
+        commit.reveal_slots,
+        reveals,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract_payload_from_single_commit_set;
+    use crate::test_utils::{
+        DEFAULT_KEY_SEED, TEST_MAGIC, build_commit_reveal_set, build_commit_tx, build_reveal_input,
+        build_reveal_tx, build_reveal_tx_with_marker_output, make_change_script, make_p2tr_script,
+        make_txid,
+    };
+
+    fn parsed_commit(commit: &Transaction) -> ParsedCommit {
+        parse_commit_candidate(&TEST_MAGIC, commit)
+            .expect("valid commit")
+            .expect("marker matches")
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_returns_parsed_commit() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[3, 4], 2, &[]);
+
+        let parsed = parse_commit_candidate(&TEST_MAGIC, &commit)
+            .expect("valid commit")
+            .expect("marker matches");
+
+        assert_eq!(parsed.txid(), commit.compute_txid());
+        assert_eq!(parsed.marker_tail(), &[3, 4]);
+        assert_eq!(parsed.reveal_slots().last_vout(), 2);
+        assert_eq!(parsed.reveal_slots().slot_count().get(), 2);
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_fixed_width_tail_succeeds() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[0, 0, 0, 7], 2, &[]);
+
+        let parsed = parsed_commit(&commit);
+
+        assert_eq!(
+            parsed.marker_tail_array::<4>().expect("width matches"),
+            &[0, 0, 0, 7]
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_wrong_width_tail_fails() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[7, 7], 2, &[]);
+        let parsed = parsed_commit(&commit);
+
+        let error = parsed
+            .marker_tail_array::<4>()
+            .expect_err("tail is not four bytes");
+
+        assert_eq!(
+            error,
+            MarkerTailArrayLengthError {
+                expected: 4,
+                found: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_ignores_non_commit() {
+        let not_a_commit = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        assert!(
+            parse_commit_candidate(&TEST_MAGIC, &not_a_commit)
+                .expect("not a malformed commit")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_rejects_marker_without_slots() {
+        let no_slots = build_commit_tx(&TEST_MAGIC, &[7, 7], 0, &[]);
+
+        let error =
+            parse_commit_candidate(&TEST_MAGIC, &no_slots).expect_err("commit has no slots");
+
+        assert!(matches!(error, CommitRevealParseError::MissingRevealSlots));
+    }
+
+    #[test]
+    fn test_parse_commit_candidate_rejects_ambiguous_change() {
+        let mut tx = build_commit_tx(&TEST_MAGIC, &[7, 7], 1, &[make_change_script()]);
+        tx.output.push(bitcoin::TxOut {
+            value: bitcoin::Amount::from_sat(1000),
+            script_pubkey: make_p2tr_script(),
+        });
+
+        let error = parse_commit_candidate(&TEST_MAGIC, &tx).expect_err("ambiguous change");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::AmbiguousTaprootChangeOutput { .. }
+        ));
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_returns_owner() {
+        let set_a = build_commit_reveal_set(
+            &TEST_MAGIC,
+            &[1],
+            &[b"a1".as_slice(), b"a2".as_slice()],
+            DEFAULT_KEY_SEED,
+        );
+        let set_b =
+            build_commit_reveal_set(&TEST_MAGIC, &[2], &[b"b1".as_slice()], DEFAULT_KEY_SEED);
+        let (parsed_a, parsed_b) = (parsed_commit(&set_a.commit), parsed_commit(&set_b.commit));
+
+        let owner = assign_reveal_to_commit([&parsed_a, &parsed_b], &set_a.reveals[0])
+            .expect("valid reveal")
+            .expect("assigned");
+
+        assert_eq!(owner, parsed_a.txid());
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_ignores_unrelated_tx() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[1], 1, &[]);
+        let parsed = parsed_commit(&commit);
+        let unrelated = build_reveal_tx(vec![build_reveal_input(
+            make_txid(99),
+            1,
+            Some(b"x"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        assert_eq!(
+            assign_reveal_to_commit([&parsed], &unrelated).expect("not malformed"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_rejects_same_commit_outpoint_defects() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[1], 2, &[]);
+        let parsed = parsed_commit(&commit);
+
+        let spends_marker = build_reveal_tx(vec![
+            build_reveal_input(parsed.txid(), 1, Some(b"a"), DEFAULT_KEY_SEED),
+            build_reveal_input(parsed.txid(), 0, Some(b"m"), DEFAULT_KEY_SEED),
+        ]);
+        let spends_non_slot = build_reveal_tx(vec![
+            build_reveal_input(parsed.txid(), 1, Some(b"a"), DEFAULT_KEY_SEED),
+            build_reveal_input(parsed.txid(), 3, Some(b"n"), DEFAULT_KEY_SEED),
+        ]);
+        let spends_two_slots = build_reveal_tx(vec![
+            build_reveal_input(parsed.txid(), 1, Some(b"a"), DEFAULT_KEY_SEED),
+            build_reveal_input(parsed.txid(), 2, Some(b"b"), DEFAULT_KEY_SEED),
+        ]);
+
+        let marker_error = assign_reveal_to_commit([&parsed], &spends_marker)
+            .expect_err("marker output is not a slot");
+        let non_slot_error = assign_reveal_to_commit([&parsed], &spends_non_slot)
+            .expect_err("non-slot output is not a reveal");
+        let multi_slot_error = assign_reveal_to_commit([&parsed], &spends_two_slots)
+            .expect_err("one reveal carries one chunk");
+
+        assert!(matches!(
+            marker_error,
+            CommitRevealParseError::RevealSpendsMarker
+        ));
+        assert!(matches!(
+            non_slot_error,
+            CommitRevealParseError::UnexpectedReveal { vout: 3 }
+        ));
+        assert!(matches!(
+            multi_slot_error,
+            CommitRevealParseError::RevealMultipleCommitSpends
+        ));
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_ignores_other_commit_non_slot_spend() {
+        let commit_a = build_commit_tx(&TEST_MAGIC, &[1], 1, &[make_change_script()]);
+        let commit_b = build_commit_tx(&TEST_MAGIC, &[2], 1, &[]);
+        let (parsed_a, parsed_b) = (parsed_commit(&commit_a), parsed_commit(&commit_b));
+        let reveal = build_reveal_tx(vec![
+            build_reveal_input(parsed_b.txid(), 1, Some(b"b"), DEFAULT_KEY_SEED),
+            build_reveal_input(parsed_a.txid(), 2, None, DEFAULT_KEY_SEED),
+        ]);
+
+        let owner = assign_reveal_to_commit([&parsed_a, &parsed_b], &reveal)
+            .expect("other commit's non-slot spend is unrelated")
+            .expect("assigned");
+
+        assert_eq!(owner, parsed_b.txid());
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_rejects_cross_commit_reveal() {
+        let commit_a = build_commit_tx(&TEST_MAGIC, &[1], 1, &[]);
+        let commit_b = build_commit_tx(&TEST_MAGIC, &[2], 1, &[]);
+        let (parsed_a, parsed_b) = (parsed_commit(&commit_a), parsed_commit(&commit_b));
+        let reveal = build_reveal_tx(vec![
+            build_reveal_input(parsed_a.txid(), 1, Some(b"a"), DEFAULT_KEY_SEED),
+            build_reveal_input(parsed_b.txid(), 1, Some(b"b"), DEFAULT_KEY_SEED),
+        ]);
+
+        let error =
+            assign_reveal_to_commit([&parsed_a, &parsed_b], &reveal).expect_err("spans commits");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::RevealSpansMultipleCommits
+        ));
+    }
+
+    #[test]
+    fn test_assign_reveal_to_commit_ignores_marker_output_on_reveal() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let parsed = parsed_commit(&commit);
+        let marker = build_commit_tx(&TEST_MAGIC, &[9], 1, &[]).output[0].clone();
+        let reveal = build_reveal_tx_with_marker_output(
+            vec![build_reveal_input(
+                parsed.txid(),
+                1,
+                Some(b"chunk"),
+                DEFAULT_KEY_SEED,
+            )],
+            marker,
+        );
+
+        let owner = assign_reveal_to_commit([&parsed], &reveal)
+            .expect("reveal output marker is unrelated")
+            .expect("assigned");
+
+        assert_eq!(owner, parsed.txid());
+    }
+
+    #[test]
+    fn test_extract_payload_for_parsed_commit_matches_closed_set() {
+        let set = build_commit_reveal_set(
+            &TEST_MAGIC,
+            &[7, 7],
+            &[b"first".as_slice(), b"second".as_slice()],
+            DEFAULT_KEY_SEED,
+        );
+        let parsed = parsed_commit(&set.commit);
+
+        let via_set = extract_payload_from_single_commit_set(
+            &TEST_MAGIC,
+            [&set.commit].into_iter().chain(set.reveals.iter()),
+        )
+        .expect("closed set parses");
+        let via_parsed =
+            extract_payload_for_parsed_commit(&parsed, set.reveals.iter()).expect("parsed");
+
+        assert_eq!(via_set, via_parsed);
+    }
+}

--- a/crates/l1proto/commit-reveal/src/lib.rs
+++ b/crates/l1proto/commit-reveal/src/lib.rs
@@ -32,8 +32,9 @@ mod errors;
 mod grouping;
 mod parser;
 
-#[cfg(test)]
-mod test_utils;
+/// Transaction fixtures, behind the `test-utils` feature.
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 
 /// Maximum commit-marker push, in bytes, as specified by SPS-53.
 ///

--- a/crates/l1proto/commit-reveal/src/lib.rs
+++ b/crates/l1proto/commit-reveal/src/lib.rs
@@ -4,18 +4,32 @@
 //! covers the multi-transaction carrier on top of it: a commit transaction's
 //! OP_RETURN marker plus one signed reveal leaf per payload chunk.
 //!
-//! The builder is layout-neutral — it returns the marker and leaf scripts
-//! without fixing where those outputs sit, since output ordering is transaction
-//! assembly, which is out of scope along with funding, fees, change, and
-//! signing.
+//! ```text
+//! commit tx:
+//!   vout 0    = OP_RETURN <single push: magic || consumer-defined tail>
+//!   vout 1..N = P2TR reveal slots (contiguous run)
+//!   change afterwards, which MUST NOT be P2TR
+//!
+//! reveal tx i:
+//!   spends commit vout i
+//!   witness tapscript leaf carries exactly one envelope chunk
+//! ```
+//!
+//! The chunk count is not on chain; it is the length of the contiguous P2TR run
+//! after marker output 0. The builder is layout-neutral — it emits the marker
+//! and leaf scripts without fixing where outputs sit — but the parser reads
+//! Layout A: marker at vout 0, then that run. The run's change MUST NOT be P2TR,
+//! or it would be indistinguishable from a slot.
 //!
 //! The crate is consumer-neutral: no magic value, no interpretation of the
-//! marker tail, no key policy. Callers supply all of that.
+//! marker tail, no key policy. Callers supply all of that. Transaction assembly
+//! — funding, fees, change, signing — is out of scope.
 
 use strata_l1_txfmt::MAGIC_BYTES_LEN;
 
 mod builder;
 mod errors;
+mod parser;
 
 #[cfg(test)]
 mod test_utils;
@@ -37,4 +51,7 @@ pub const MAX_MARKER_TAIL_BYTES: usize = MAX_MARKER_PAYLOAD_BYTES - MAGIC_BYTES_
 pub use builder::{
     CommitRevealScripts, build_commit_reveal_scripts, build_commit_reveal_scripts_from_chunks,
 };
-pub use errors::CommitRevealBuildError;
+pub use errors::{CommitRevealBuildError, CommitRevealParseError, MarkerTailArrayLengthError};
+pub use parser::{
+    ParsedCommitReveal, RevealSlotRange, extract_payload_from_single_commit_set, read_commit_marker,
+};

--- a/crates/l1proto/commit-reveal/src/lib.rs
+++ b/crates/l1proto/commit-reveal/src/lib.rs
@@ -29,6 +29,7 @@ use strata_l1_txfmt::MAGIC_BYTES_LEN;
 
 mod builder;
 mod errors;
+mod grouping;
 mod parser;
 
 #[cfg(test)]
@@ -52,6 +53,10 @@ pub use builder::{
     CommitRevealScripts, build_commit_reveal_scripts, build_commit_reveal_scripts_from_chunks,
 };
 pub use errors::{CommitRevealBuildError, CommitRevealParseError, MarkerTailArrayLengthError};
+pub use grouping::{
+    ParsedCommit, assign_reveal_to_commit, extract_payload_for_parsed_commit,
+    parse_commit_candidate,
+};
 pub use parser::{
     ParsedCommitReveal, RevealSlotRange, extract_payload_from_single_commit_set, read_commit_marker,
 };

--- a/crates/l1proto/commit-reveal/src/lib.rs
+++ b/crates/l1proto/commit-reveal/src/lib.rs
@@ -1,0 +1,40 @@
+//! SPS-53 chunked envelope format for Bitcoin L1.
+//!
+//! Where [`strata_l1_envelope_fmt`] handles one script envelope, this crate
+//! covers the multi-transaction carrier on top of it: a commit transaction's
+//! OP_RETURN marker plus one signed reveal leaf per payload chunk.
+//!
+//! The builder is layout-neutral — it returns the marker and leaf scripts
+//! without fixing where those outputs sit, since output ordering is transaction
+//! assembly, which is out of scope along with funding, fees, change, and
+//! signing.
+//!
+//! The crate is consumer-neutral: no magic value, no interpretation of the
+//! marker tail, no key policy. Callers supply all of that.
+
+use strata_l1_txfmt::MAGIC_BYTES_LEN;
+
+mod builder;
+mod errors;
+
+#[cfg(test)]
+mod test_utils;
+
+/// Maximum commit-marker push, in bytes, as specified by SPS-53.
+///
+/// The cap follows OP_RETURN relay policy rather than consensus, so a confirmed
+/// transaction can carry a larger push. Such a transaction is not a valid
+/// commit under this format.
+pub const MAX_MARKER_PAYLOAD_BYTES: usize = 80;
+
+/// Maximum consumer-defined marker tail, in bytes.
+///
+/// The marker is `magic || tail` in a single push, so the tail a caller may
+/// supply is [`MAX_MARKER_PAYLOAD_BYTES`] less the fixed magic length. Derived
+/// rather than written out, so the two cannot drift.
+pub const MAX_MARKER_TAIL_BYTES: usize = MAX_MARKER_PAYLOAD_BYTES - MAGIC_BYTES_LEN;
+
+pub use builder::{
+    CommitRevealScripts, build_commit_reveal_scripts, build_commit_reveal_scripts_from_chunks,
+};
+pub use errors::CommitRevealBuildError;

--- a/crates/l1proto/commit-reveal/src/parser.rs
+++ b/crates/l1proto/commit-reveal/src/parser.rs
@@ -3,7 +3,7 @@
 //! The enforcement side of the format: what a reader accepts back off chain.
 
 use std::collections::BTreeMap;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use bitcoin::opcodes::all::OP_RETURN;
 use bitcoin::script::Instruction;
@@ -116,6 +116,11 @@ impl RevealSlotRange {
     /// Whether `vout` is a reveal slot of this commit.
     pub const fn contains(&self, vout: u32) -> bool {
         vout >= 1 && vout <= self.last_vout.get()
+    }
+
+    /// How many reveals a complete set has.
+    pub fn slot_count(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.last_vout.get() as usize).expect("a nonzero u32 is a nonzero usize")
     }
 }
 
@@ -249,8 +254,18 @@ fn assemble_parsed_commit_reveal<'c, 't>(
 ) -> Result<ParsedCommitReveal<'c>, CommitRevealParseError> {
     let slots =
         derive_reveal_slot_range(commit)?.ok_or(CommitRevealParseError::MissingRevealSlots)?;
-    let commit_txid = commit.compute_txid();
+    assemble_from_slots(commit.compute_txid(), marker_tail, slots, reveals)
+}
 
+/// Assembles a set from an already-resolved commit txid, marker tail, and slot
+/// range, enforcing slot coverage, no duplicate or unexpected reveals, and one
+/// pubkey across the set.
+pub(crate) fn assemble_from_slots<'c, 't>(
+    commit_txid: Txid,
+    marker_tail: &'c [u8],
+    slots: RevealSlotRange,
+    reveals: impl IntoIterator<Item = &'t Transaction>,
+) -> Result<ParsedCommitReveal<'c>, CommitRevealParseError> {
     let mut by_vout = BTreeMap::new();
     for reveal in reveals {
         let RevealChunk {
@@ -631,6 +646,14 @@ mod tests {
             error,
             CommitRevealParseError::EmptyRevealSlotRange
         ));
+    }
+
+    /// Slots run `1..=last_vout`, so a complete set has `last_vout` reveals.
+    #[test]
+    fn test_slot_range_slot_count_equals_the_run_length() {
+        let range = RevealSlotRange::try_new(3).expect("nonzero");
+
+        assert_eq!(range.slot_count().get(), 3);
     }
 
     // Chunk extraction.

--- a/crates/l1proto/commit-reveal/src/parser.rs
+++ b/crates/l1proto/commit-reveal/src/parser.rs
@@ -1,0 +1,1283 @@
+//! Marker classification, reveal-slot derivation, and payload extraction.
+//!
+//! The enforcement side of the format: what a reader accepts back off chain.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroU32;
+
+use bitcoin::opcodes::all::OP_RETURN;
+use bitcoin::script::Instruction;
+use bitcoin::taproot::LeafVersion;
+use bitcoin::{Transaction, TxIn, Txid};
+use strata_l1_envelope_fmt::SIGNED_LEAF_PUBKEY_LEN;
+use strata_l1_envelope_fmt::parser::parse_signed_envelope_leaf;
+use strata_l1_txfmt::MagicBytes;
+
+use crate::MAX_MARKER_PAYLOAD_BYTES;
+use crate::errors::{CommitRevealParseError, MarkerTailArrayLengthError};
+
+/// Payload extracted from one validated commit-reveal set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommitReveal<'t> {
+    marker_tail: &'t [u8],
+    reveal_pubkey: [u8; SIGNED_LEAF_PUBKEY_LEN],
+    chunks: Vec<Vec<u8>>,
+}
+
+impl<'t> ParsedCommitReveal<'t> {
+    /// Marker bytes after the magic, for the caller to interpret.
+    pub const fn marker_tail(&self) -> &'t [u8] {
+        self.marker_tail
+    }
+
+    /// Marker tail as a fixed-width byte array.
+    ///
+    /// This only checks length. The caller still owns any meaning assigned to
+    /// the tail bytes.
+    pub fn marker_tail_array<const N: usize>(
+        &self,
+    ) -> Result<&'t [u8; N], MarkerTailArrayLengthError> {
+        convert_marker_tail_to_array_ref(self.marker_tail)
+    }
+
+    /// The x-only pubkey every reveal leaf in the set carries.
+    ///
+    /// This crate applies no key policy. Comparing these bytes against a
+    /// configured key authenticates the set, but only because the leaves parsed
+    /// strictly; see
+    /// [`parse_signed_envelope_leaf`](strata_l1_envelope_fmt::parser::parse_signed_envelope_leaf).
+    pub const fn reveal_pubkey(&self) -> [u8; SIGNED_LEAF_PUBKEY_LEN] {
+        self.reveal_pubkey
+    }
+
+    /// Rejects the set unless every reveal leaf is keyed to `expected`.
+    ///
+    /// Comparing the recovered pubkey is meaningful because the leaves parsed
+    /// through the strict signed envelope leaf grammar.
+    pub fn authenticate(
+        self,
+        expected: &[u8; SIGNED_LEAF_PUBKEY_LEN],
+    ) -> Result<Self, CommitRevealParseError> {
+        if self.reveal_pubkey != *expected {
+            return Err(CommitRevealParseError::UnexpectedRevealPubkey);
+        }
+        Ok(self)
+    }
+
+    /// Payload chunks in commit-output order.
+    ///
+    /// The payload is their concatenation. Borrowed rather than joined so
+    /// callers can decode across chunks without allocating a contiguous payload.
+    pub fn chunks(&self) -> &[Vec<u8>] {
+        &self.chunks
+    }
+
+    /// Consumes the set, returning the ordered payload chunks.
+    pub fn into_chunks(self) -> Vec<Vec<u8>> {
+        self.chunks
+    }
+
+    /// Consumes the set, joining the chunks into the payload.
+    ///
+    /// Allocates and copies the whole payload; use [`Self::chunks`] where that
+    /// matters.
+    pub fn into_payload(self) -> Vec<u8> {
+        self.chunks.concat()
+    }
+}
+
+/// The reveal-slot range `[1, last_vout]` of a commit transaction.
+///
+/// Output 0 is the marker, so slots start at 1. Chunk count is conveyed by the
+/// length of this run and never written on chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RevealSlotRange {
+    last_vout: NonZeroU32,
+}
+
+impl RevealSlotRange {
+    /// Constructs a range covering outputs `1..=last_vout`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommitRevealParseError::EmptyRevealSlotRange`] when
+    /// `last_vout` is 0, since output 0 is the marker and never a slot.
+    pub fn try_new(last_vout: u32) -> Result<Self, CommitRevealParseError> {
+        let last_vout =
+            NonZeroU32::new(last_vout).ok_or(CommitRevealParseError::EmptyRevealSlotRange)?;
+        Ok(Self { last_vout })
+    }
+
+    /// The last output index in the range.
+    pub const fn last_vout(&self) -> u32 {
+        self.last_vout.get()
+    }
+
+    /// Whether `vout` is a reveal slot of this commit.
+    pub const fn contains(&self, vout: u32) -> bool {
+        vout >= 1 && vout <= self.last_vout.get()
+    }
+}
+
+/// The one reveal-slot input a reveal spends of a given commit.
+pub(crate) struct RevealSlotSpend<'t> {
+    input: &'t TxIn,
+    vout: u32,
+}
+
+/// One decoded reveal carrying a commit-reveal chunk.
+#[derive(Debug)]
+struct RevealChunk {
+    vout: u32,
+    pubkey: [u8; SIGNED_LEAF_PUBKEY_LEN],
+    payload: Vec<u8>,
+}
+
+pub(crate) fn convert_marker_tail_to_array_ref<const N: usize>(
+    tail: &[u8],
+) -> Result<&[u8; N], MarkerTailArrayLengthError> {
+    tail.try_into().map_err(|_| MarkerTailArrayLengthError {
+        expected: N,
+        found: tail.len(),
+    })
+}
+
+/// Reads the marker tail from a candidate commit transaction.
+///
+/// Returns `Some(tail)` when output 0 is an `OP_RETURN` carrying exactly one
+/// push that starts with `magic` and is no longer than
+/// [`MAX_MARKER_PAYLOAD_BYTES`], `None` otherwise. The tail is not interpreted.
+pub fn read_commit_marker<'t>(magic: &MagicBytes, tx: &'t Transaction) -> Option<&'t [u8]> {
+    let first_output = tx.output.first()?;
+    let mut instructions = first_output.script_pubkey.instructions();
+
+    match instructions.next() {
+        Some(Ok(Instruction::Op(OP_RETURN))) => {}
+        _ => return None,
+    }
+
+    let Some(Ok(Instruction::PushBytes(push))) = instructions.next() else {
+        return None;
+    };
+
+    // Exactly one push: a second instruction means this is some other
+    // protocol's OP_RETURN that happens to share our prefix.
+    if instructions.next().is_some() {
+        return None;
+    }
+
+    let payload = push.as_bytes();
+    if payload.len() > MAX_MARKER_PAYLOAD_BYTES {
+        return None;
+    }
+
+    payload.strip_prefix(magic.as_bytes().as_slice())
+}
+
+/// Extracts a payload from a closed set containing one commit and its reveals.
+///
+/// The commit is selected by its marker; no commit or more than one commit is an
+/// error.
+///
+/// # Errors
+///
+/// [`CommitRevealParseError::MissingCommit`] or
+/// [`CommitRevealParseError::MultipleCommits`] if the group does not hold exactly
+/// one commit, plus any extraction error from the reveals.
+pub fn extract_payload_from_single_commit_set<'t>(
+    magic: &MagicBytes,
+    txs: impl IntoIterator<Item = &'t Transaction>,
+) -> Result<ParsedCommitReveal<'t>, CommitRevealParseError> {
+    let mut commit = None;
+    let mut reveals = Vec::new();
+
+    for tx in txs {
+        match read_commit_marker(magic, tx) {
+            Some(tail) => {
+                if commit.replace((tx, tail)).is_some() {
+                    return Err(CommitRevealParseError::MultipleCommits);
+                }
+            }
+            None => reveals.push(tx),
+        }
+    }
+
+    let (commit, marker_tail) = commit.ok_or(CommitRevealParseError::MissingCommit)?;
+
+    assemble_parsed_commit_reveal(commit, marker_tail, reveals)
+}
+
+/// Derives the reveal-slot range of a commit transaction.
+///
+/// Returns the last index of the contiguous P2TR run starting at output 1, or
+/// `Ok(None)` when there is none.
+///
+/// Reading chunk count off this run is sound only while change is non-P2TR. A
+/// P2TR output after the run has closed makes the boundary unknowable, so the
+/// parser rejects it rather than guessing.
+///
+/// # Errors
+///
+/// Returns [`CommitRevealParseError::AmbiguousTaprootChangeOutput`] when a P2TR
+/// output follows a non-P2TR one.
+pub(crate) fn derive_reveal_slot_range(
+    commit: &Transaction,
+) -> Result<Option<RevealSlotRange>, CommitRevealParseError> {
+    let mut last_reveal_vout = None;
+    let mut run_closed = false;
+
+    for (idx, output) in commit.output.iter().enumerate().skip(1) {
+        if output.script_pubkey.is_p2tr() {
+            if run_closed {
+                return Err(CommitRevealParseError::AmbiguousTaprootChangeOutput {
+                    vout: idx as u32,
+                });
+            }
+            last_reveal_vout = Some(idx as u32);
+        } else {
+            run_closed = true;
+        }
+    }
+
+    last_reveal_vout.map(RevealSlotRange::try_new).transpose()
+}
+
+fn assemble_parsed_commit_reveal<'c, 't>(
+    commit: &'c Transaction,
+    marker_tail: &'c [u8],
+    reveals: impl IntoIterator<Item = &'t Transaction>,
+) -> Result<ParsedCommitReveal<'c>, CommitRevealParseError> {
+    let slots =
+        derive_reveal_slot_range(commit)?.ok_or(CommitRevealParseError::MissingRevealSlots)?;
+    let commit_txid = commit.compute_txid();
+
+    let mut by_vout = BTreeMap::new();
+    for reveal in reveals {
+        let RevealChunk {
+            vout,
+            pubkey,
+            payload,
+        } = extract_reveal_chunk_for_commit(reveal, commit_txid, slots)?;
+        if by_vout.insert(vout, (pubkey, payload)).is_some() {
+            return Err(CommitRevealParseError::DuplicateReveal { vout });
+        }
+    }
+
+    for vout in 1..=slots.last_vout() {
+        if !by_vout.contains_key(&vout) {
+            return Err(CommitRevealParseError::MissingReveal { vout });
+        }
+    }
+
+    // SPS-53 signs every reveal of an inscription under one producer key, so
+    // disagreement means there is no single key to authenticate against.
+    let mut reveal_pubkey = None;
+    let mut chunks = Vec::with_capacity(by_vout.len());
+    for (vout, (pubkey, bytes)) in by_vout {
+        match reveal_pubkey {
+            None => reveal_pubkey = Some(pubkey),
+            Some(first) if first != pubkey => {
+                return Err(CommitRevealParseError::InconsistentRevealPubkey { vout });
+            }
+            Some(_) => {}
+        }
+        chunks.push(bytes);
+    }
+
+    Ok(ParsedCommitReveal {
+        marker_tail,
+        reveal_pubkey: reveal_pubkey.expect("a slot range always covers at least one reveal"),
+        chunks,
+    })
+}
+
+/// Classifies how `reveal` spends the caller-named `commit_txid`'s outputs:
+/// `Ok(Some)` for a single reveal-slot spend, `Ok(None)` when it spends none of
+/// them.
+///
+/// Strict for that one commit: its marker, a non-slot output, or a second slot
+/// is an error even without a slot spend. The commit is named, not discovered;
+/// which commit a transaction belongs to is the caller's call.
+///
+/// # Errors
+///
+/// [`CommitRevealParseError::RevealSpendsMarker`],
+/// [`CommitRevealParseError::UnexpectedReveal`], or
+/// [`CommitRevealParseError::RevealMultipleCommitSpends`].
+pub(crate) fn classify_reveal_inputs_for_commit(
+    reveal: &Transaction,
+    commit_txid: Txid,
+    slots: RevealSlotRange,
+) -> Result<Option<RevealSlotSpend<'_>>, CommitRevealParseError> {
+    // Non-marker defects are accumulated rather than reported on sight, and the
+    // reported vout is the lowest offending one, so a reveal carrying more than
+    // one gives the same error whatever order its inputs are in.
+    let mut slot_spend = None;
+    let mut unexpected_vout = None;
+    let mut has_multiple_slot_spends = false;
+
+    for input in &reveal.input {
+        if input.previous_output.txid != commit_txid {
+            continue;
+        }
+
+        let vout = input.previous_output.vout;
+        if vout == 0 {
+            return Err(CommitRevealParseError::RevealSpendsMarker);
+        }
+
+        if !slots.contains(vout) {
+            unexpected_vout = Some(unexpected_vout.map_or(vout, |seen: u32| seen.min(vout)));
+            continue;
+        }
+
+        if slot_spend
+            .replace(RevealSlotSpend { input, vout })
+            .is_some()
+        {
+            has_multiple_slot_spends = true;
+        }
+    }
+
+    if let Some(vout) = unexpected_vout {
+        return Err(CommitRevealParseError::UnexpectedReveal { vout });
+    }
+
+    if has_multiple_slot_spends {
+        return Err(CommitRevealParseError::RevealMultipleCommitSpends);
+    }
+
+    Ok(slot_spend)
+}
+
+/// Extracts the payload chunk a single reveal transaction carries for a known
+/// commit.
+///
+/// The reveal must spend exactly one slot of `commit_txid` with a tapscript
+/// leaf matching the strict signed envelope shape.
+///
+/// The commit is named, not discovered, so this is safe against arbitrary L1: a
+/// reveal that also carries its own marker at output 0 is still read as a
+/// reveal for `commit_txid`.
+fn extract_reveal_chunk_for_commit(
+    reveal: &Transaction,
+    commit_txid: Txid,
+    slots: RevealSlotRange,
+) -> Result<RevealChunk, CommitRevealParseError> {
+    if reveal.input.is_empty() {
+        return Err(CommitRevealParseError::RevealMissingInputs);
+    }
+
+    let RevealSlotSpend { input, vout } =
+        classify_reveal_inputs_for_commit(reveal, commit_txid, slots)?
+            .ok_or(CommitRevealParseError::RevealWrongCommit)?;
+
+    let leaf = input
+        .witness
+        .taproot_leaf_script()
+        .ok_or(CommitRevealParseError::RevealMissingLeafScript)?;
+    if leaf.version != LeafVersion::TapScript {
+        return Err(CommitRevealParseError::RevealUnsupportedLeafVersion {
+            version: leaf.version.to_consensus(),
+        });
+    }
+
+    let parsed = parse_signed_envelope_leaf(&leaf.script.into())?;
+    let pubkey = *parsed.pubkey();
+    let payload = parsed.into_payload();
+
+    // A reveal slot carries a chunk, so an empty payload is not a valid reveal.
+    // Accepting one would also make the encoding non-canonical: an extra empty
+    // slot changes the chunk count while concatenating to the same payload.
+    if payload.is_empty() {
+        return Err(CommitRevealParseError::EmptyReveal { vout });
+    }
+
+    Ok(RevealChunk {
+        vout,
+        pubkey,
+        payload,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::ScriptBuf;
+    use bitcoin::blockdata::script::Builder;
+    use bitcoin::opcodes::OP_TRUE;
+    use bitcoin::script::PushBytesBuf;
+    use strata_l1_envelope_fmt::builder::MAX_ENVELOPE_PAYLOAD_SIZE;
+    use strata_l1_txfmt::MagicBytes;
+
+    use super::*;
+    use crate::builder::build_commit_reveal_scripts;
+    use crate::test_utils::{
+        DEFAULT_KEY_SEED, TEST_MAGIC, assemble_commit_tx, build_commit_tx,
+        build_marker_candidate_tx, build_reveal_input, build_reveal_input_from_leaf,
+        build_reveal_tx, build_reveal_tx_with_marker_output, build_unsupported_leaf_reveal_input,
+        make_change_script, make_p2tr_script, make_txid, make_xonly_pubkey_bytes,
+    };
+
+    const OTHER_MAGIC: MagicBytes = MagicBytes::new(*b"OTHR");
+
+    fn extract_payload_for_commit<'c, 't>(
+        magic: &MagicBytes,
+        commit: &'c Transaction,
+        reveals: impl IntoIterator<Item = &'t Transaction>,
+    ) -> Result<ParsedCommitReveal<'c>, CommitRevealParseError> {
+        let marker_tail =
+            read_commit_marker(magic, commit).ok_or(CommitRevealParseError::MissingCommit)?;
+        assemble_parsed_commit_reveal(commit, marker_tail, reveals)
+    }
+
+    /// Reads across chunks without joining them.
+    struct ChunkReader<'a> {
+        chunks: &'a [Vec<u8>],
+        chunk: usize,
+        offset: usize,
+    }
+
+    impl ChunkReader<'_> {
+        /// Fills `buf` across chunk boundaries, returning bytes read.
+        fn read(&mut self, buf: &mut [u8]) -> usize {
+            let mut filled = 0;
+            while filled < buf.len() {
+                let Some(chunk) = self.chunks.get(self.chunk) else {
+                    break;
+                };
+                if self.offset == chunk.len() {
+                    self.chunk += 1;
+                    self.offset = 0;
+                    continue;
+                }
+                let take = (chunk.len() - self.offset).min(buf.len() - filled);
+                buf[filled..filled + take].copy_from_slice(&chunk[self.offset..self.offset + take]);
+                self.offset += take;
+                filled += take;
+            }
+            filled
+        }
+    }
+
+    fn build_op_return_script(payload: &[u8]) -> ScriptBuf {
+        Builder::new()
+            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+            .push_slice(PushBytesBuf::try_from(payload.to_vec()).expect("push fits"))
+            .into_script()
+    }
+
+    /// Builds fixture commit-reveal txs from builder-produced scripts.
+    fn build_commit_reveal_txs(payload: &[u8]) -> (Transaction, Vec<Transaction>) {
+        let scripts = build_commit_reveal_scripts(
+            &TEST_MAGIC,
+            [],
+            &make_xonly_pubkey_bytes(DEFAULT_KEY_SEED),
+            payload,
+        )
+        .expect("builds");
+        let (marker, leaves) = scripts.into_parts();
+        let commit = assemble_commit_tx(marker, leaves.len());
+        let commit_txid = commit.compute_txid();
+        let reveals = leaves
+            .into_iter()
+            .enumerate()
+            .map(|(idx, leaf)| {
+                build_reveal_tx(vec![build_reveal_input_from_leaf(
+                    commit_txid,
+                    idx as u32 + 1,
+                    leaf,
+                    DEFAULT_KEY_SEED,
+                )])
+            })
+            .collect();
+
+        (commit, reveals)
+    }
+
+    // Marker classification.
+
+    #[test]
+    fn test_marker_returns_tail_for_matching_magic() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[1, 2, 3, 4], 1, &[]);
+
+        assert_eq!(
+            read_commit_marker(&TEST_MAGIC, &commit),
+            Some([1, 2, 3, 4].as_slice())
+        );
+    }
+
+    #[test]
+    fn test_marker_accepts_empty_tail() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+
+        assert_eq!(
+            read_commit_marker(&TEST_MAGIC, &commit),
+            Some([].as_slice())
+        );
+    }
+
+    /// No magic value is baked in: the same transaction is ours or not
+    /// depending only on the magic the caller supplies.
+    #[test]
+    fn test_marker_rejects_different_configured_magic() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[1, 2, 3, 4], 1, &[]);
+
+        assert!(read_commit_marker(&OTHER_MAGIC, &commit).is_none());
+    }
+
+    #[test]
+    fn test_marker_ignores_unrelated_op_return() {
+        let tx = build_marker_candidate_tx(build_op_return_script(b"somebody elses protocol"));
+
+        assert!(read_commit_marker(&TEST_MAGIC, &tx).is_none());
+    }
+
+    #[test]
+    fn test_marker_ignores_push_shorter_than_magic() {
+        let tx = build_marker_candidate_tx(build_op_return_script(b"TE"));
+
+        assert!(read_commit_marker(&TEST_MAGIC, &tx).is_none());
+    }
+
+    #[test]
+    fn test_marker_ignores_extra_opcodes() {
+        let script = Builder::new()
+            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+            .push_slice(*b"TESTtail")
+            .push_opcode(OP_TRUE)
+            .into_script();
+        let tx = build_marker_candidate_tx(script);
+
+        assert!(read_commit_marker(&TEST_MAGIC, &tx).is_none());
+    }
+
+    #[test]
+    fn test_marker_ignores_non_op_return_first_output() {
+        let tx = build_marker_candidate_tx(make_p2tr_script());
+
+        assert!(read_commit_marker(&TEST_MAGIC, &tx).is_none());
+    }
+
+    #[test]
+    fn test_marker_accepts_push_at_policy_limit() {
+        let payload = [b"TEST".as_slice(), &[0u8; MAX_MARKER_PAYLOAD_BYTES - 4]].concat();
+        assert_eq!(payload.len(), MAX_MARKER_PAYLOAD_BYTES);
+        let tx = build_marker_candidate_tx(build_op_return_script(&payload));
+
+        assert_eq!(
+            read_commit_marker(&TEST_MAGIC, &tx).map(<[u8]>::len),
+            Some(MAX_MARKER_PAYLOAD_BYTES - 4)
+        );
+    }
+
+    #[test]
+    fn test_marker_ignores_push_over_policy_limit() {
+        let payload = [b"TEST".as_slice(), &[0u8; MAX_MARKER_PAYLOAD_BYTES - 3]].concat();
+        assert_eq!(payload.len(), MAX_MARKER_PAYLOAD_BYTES + 1);
+        let tx = build_marker_candidate_tx(build_op_return_script(&payload));
+
+        assert!(read_commit_marker(&TEST_MAGIC, &tx).is_none());
+    }
+
+    // Reveal-slot range.
+
+    #[test]
+    fn test_slot_range_covers_contiguous_p2tr_run() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 3, &[make_change_script()]);
+
+        let range = derive_reveal_slot_range(&commit)
+            .expect("valid commit")
+            .expect("has slots");
+
+        assert_eq!(range.last_vout(), 3);
+        assert!(range.contains(1) && range.contains(3));
+        assert!(!range.contains(0) && !range.contains(4));
+    }
+
+    #[test]
+    fn test_slot_range_rejects_p2tr_after_change() {
+        let commit = build_commit_tx(
+            &TEST_MAGIC,
+            &[],
+            2,
+            &[make_change_script(), make_p2tr_script()],
+        );
+
+        let error =
+            derive_reveal_slot_range(&commit).expect_err("ambiguous change must be rejected");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::AmbiguousTaprootChangeOutput { vout: 4 }
+        ));
+    }
+
+    #[test]
+    fn test_slot_range_absent_when_no_p2tr_outputs() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 0, &[make_change_script()]);
+
+        assert!(
+            derive_reveal_slot_range(&commit)
+                .expect("valid commit")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_slot_range_rejects_zero_last_vout() {
+        let error = RevealSlotRange::try_new(0).expect_err("output 0 is the marker");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::EmptyRevealSlotRange
+        ));
+    }
+
+    // Chunk extraction.
+
+    #[test]
+    fn test_chunks_are_ordered_by_commit_output() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 2, &[]);
+        let commit_txid = commit.compute_txid();
+        let second = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            2,
+            Some(b"second"),
+            DEFAULT_KEY_SEED,
+        )]);
+        let first = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"first"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let parsed = extract_payload_for_commit(&TEST_MAGIC, &commit, [&second, &first])
+            .expect("valid envelope");
+
+        // Supplied out of order; ordering follows the spent commit vout.
+        assert_eq!(parsed.chunks(), [b"first".to_vec(), b"second".to_vec()]);
+        assert_eq!(parsed.into_payload(), b"firstsecond");
+    }
+
+    #[test]
+    fn test_extraction_rejects_missing_reveal() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 2, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"one"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect_err("slot 2 is unfilled");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::MissingReveal { vout: 2 }
+        ));
+    }
+
+    #[test]
+    fn test_extraction_rejects_duplicate_reveal() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let commit_txid = commit.compute_txid();
+        let one = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"a"),
+            DEFAULT_KEY_SEED,
+        )]);
+        let two = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"b"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&one, &two])
+            .expect_err("slot claimed twice");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::DuplicateReveal { vout: 1 }
+        ));
+    }
+
+    #[test]
+    fn test_extraction_rejects_commit_without_slots() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 0, &[]);
+
+        let error =
+            extract_payload_for_commit(&TEST_MAGIC, &commit, []).expect_err("no slots to reveal");
+
+        assert!(matches!(error, CommitRevealParseError::MissingRevealSlots));
+    }
+
+    #[test]
+    fn test_reveal_rejects_marker_output_spend() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            0,
+            None,
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("marker output is not a slot");
+
+        assert!(matches!(error, CommitRevealParseError::RevealSpendsMarker));
+    }
+
+    #[test]
+    fn test_reveal_rejects_commit_output_outside_slot_range() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            2,
+            None,
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("slot 2 is outside");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::UnexpectedReveal { vout: 2 }
+        ));
+    }
+
+    /// A reveal that spends a valid slot *and* another output of the same
+    /// commit is malformed. Accepting it would let the set look complete while
+    /// one reveal quietly consumed a non-slot output.
+    #[test]
+    fn test_reveal_rejects_non_slot_commit_output_alongside_valid_slot() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![
+            build_reveal_input(make_txid(1), 1, Some(b"chunk"), DEFAULT_KEY_SEED),
+            build_reveal_input(make_txid(1), 2, None, DEFAULT_KEY_SEED),
+        ]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("non-slot spend of the same commit");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::UnexpectedReveal { vout: 2 }
+        ));
+    }
+
+    /// Input order must not decide which defect is reported.
+    #[test]
+    fn test_reveal_error_does_not_depend_on_input_order() {
+        let slots = RevealSlotRange::try_new(2).expect("valid range");
+        let duplicate_slot =
+            || build_reveal_input(make_txid(1), 1, Some(b"chunk"), DEFAULT_KEY_SEED);
+        let out_of_range = || build_reveal_input(make_txid(1), 5, None, DEFAULT_KEY_SEED);
+
+        let forward = build_reveal_tx(vec![duplicate_slot(), duplicate_slot(), out_of_range()]);
+        let reversed = build_reveal_tx(vec![out_of_range(), duplicate_slot(), duplicate_slot()]);
+
+        let first = extract_reveal_chunk_for_commit(&forward, make_txid(1), slots)
+            .expect_err("malformed reveal");
+        let second = extract_reveal_chunk_for_commit(&reversed, make_txid(1), slots)
+            .expect_err("malformed reveal");
+
+        assert!(matches!(
+            first,
+            CommitRevealParseError::UnexpectedReveal { vout: 5 }
+        ));
+        assert!(matches!(
+            second,
+            CommitRevealParseError::UnexpectedReveal { vout: 5 }
+        ));
+    }
+
+    #[test]
+    fn test_reveal_rejects_wrong_commit() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(2),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("spends a different commit");
+
+        assert!(matches!(error, CommitRevealParseError::RevealWrongCommit));
+    }
+
+    #[test]
+    fn test_reveal_rejects_multiple_slot_spends() {
+        let slots = RevealSlotRange::try_new(2).expect("valid range");
+        let tx = build_reveal_tx(vec![
+            build_reveal_input(make_txid(1), 1, Some(b"a"), DEFAULT_KEY_SEED),
+            build_reveal_input(make_txid(1), 2, Some(b"b"), DEFAULT_KEY_SEED),
+        ]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("one reveal carries one chunk");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::RevealMultipleCommitSpends
+        ));
+    }
+
+    #[test]
+    fn test_reveal_rejects_no_inputs() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("no inputs to read");
+
+        assert!(matches!(error, CommitRevealParseError::RevealMissingInputs));
+    }
+
+    #[test]
+    fn test_reveal_rejects_missing_leaf_script() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            1,
+            None,
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("witness has no leaf");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::RevealMissingLeafScript
+        ));
+    }
+
+    #[test]
+    fn test_reveal_rejects_non_tapscript_leaf() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let future = LeafVersion::from_consensus(0xc2).expect("future leaf version");
+        let tx = build_reveal_tx(vec![build_unsupported_leaf_reveal_input(
+            make_txid(1),
+            1,
+            b"chunk",
+            DEFAULT_KEY_SEED,
+            future,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("only tapscript leaves are parsed");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::RevealUnsupportedLeafVersion { version } if version == 0xc2
+        ));
+    }
+
+    #[test]
+    fn test_reveal_rejects_empty_payload() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            1,
+            Some(b""),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_reveal_chunk_for_commit(&tx, make_txid(1), slots)
+            .expect_err("empty reveal payload is rejected");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::EmptyReveal { vout } if vout == 1
+        ));
+    }
+
+    /// The parser applies no key policy: it reports whichever key the leaf
+    /// commits to and leaves authentication to the caller.
+    #[test]
+    fn test_reveal_reports_observed_pubkey_without_policy() {
+        let slots = RevealSlotRange::try_new(1).expect("valid range");
+        let tx = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            1,
+            Some(b"chunk"),
+            11,
+        )]);
+
+        let RevealChunk { pubkey, .. } =
+            extract_reveal_chunk_for_commit(&tx, make_txid(1), slots).expect("parses fine");
+
+        assert_eq!(pubkey, make_xonly_pubkey_bytes(11));
+    }
+
+    /// A reveal may itself be another commit candidate. Once a commit is
+    /// selected, reveal parsing must not re-classify by marker.
+    #[test]
+    fn test_extraction_is_safe_when_reveal_is_also_a_commit() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let commit_txid = commit.compute_txid();
+        let next_commit_marker = build_commit_tx(&TEST_MAGIC, &[9], 1, &[]).output[0].clone();
+        let reveal = build_reveal_tx_with_marker_output(
+            vec![build_reveal_input(
+                commit_txid,
+                1,
+                Some(b"chunk"),
+                DEFAULT_KEY_SEED,
+            )],
+            next_commit_marker,
+        );
+
+        assert!(read_commit_marker(&TEST_MAGIC, &reveal).is_some());
+
+        let parsed = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect("reveal still parses");
+
+        assert_eq!(parsed.into_payload(), b"chunk");
+    }
+
+    // Single-commit-set entry point.
+
+    #[test]
+    fn test_single_commit_set_returns_tail_and_chunks() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[7, 7], 2, &[]);
+        let commit_txid = commit.compute_txid();
+        let one = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"first"),
+            DEFAULT_KEY_SEED,
+        )]);
+        let two = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            2,
+            Some(b"second"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let set = extract_payload_from_single_commit_set(&TEST_MAGIC, [&commit, &two, &one])
+            .expect("well-formed set");
+
+        assert_eq!(set.marker_tail(), &[7, 7]);
+        assert_eq!(set.chunks().len(), 2);
+        assert_eq!(set.into_payload(), b"firstsecond");
+    }
+
+    #[test]
+    fn test_single_commit_set_rejects_missing_commit() {
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            make_txid(1),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_payload_from_single_commit_set(&TEST_MAGIC, [&reveal])
+            .expect_err("set has no commit");
+
+        assert!(matches!(error, CommitRevealParseError::MissingCommit));
+    }
+
+    #[test]
+    fn test_single_commit_set_rejects_multiple_commits() {
+        let one = build_commit_tx(&TEST_MAGIC, &[1], 1, &[]);
+        let two = build_commit_tx(&TEST_MAGIC, &[2], 1, &[]);
+
+        let error = extract_payload_from_single_commit_set(&TEST_MAGIC, [&one, &two])
+            .expect_err("set has two commits");
+
+        assert!(matches!(error, CommitRevealParseError::MultipleCommits));
+    }
+
+    // Pubkey agreement and authentication.
+
+    /// SPS-53 signs every reveal of an inscription under one producer key, so a
+    /// set whose leaves disagree has no single key to authenticate against.
+    #[test]
+    fn test_extraction_rejects_reveals_with_different_pubkeys() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 2, &[]);
+        let commit_txid = commit.compute_txid();
+        let one = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"first"),
+            DEFAULT_KEY_SEED,
+        )]);
+        let two = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            2,
+            Some(b"second"),
+            DEFAULT_KEY_SEED + 1,
+        )]);
+
+        let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&one, &two])
+            .expect_err("reveals must agree on one key");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::InconsistentRevealPubkey { vout: 2 }
+        ));
+    }
+
+    #[test]
+    fn test_authenticate_accepts_expected_key() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let parsed = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect("valid envelope")
+            .authenticate(&make_xonly_pubkey_bytes(DEFAULT_KEY_SEED))
+            .expect("key matches");
+
+        assert_eq!(parsed.into_payload(), b"chunk");
+    }
+
+    #[test]
+    fn test_authenticate_rejects_unexpected_key() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect("valid envelope")
+            .authenticate(&make_xonly_pubkey_bytes(DEFAULT_KEY_SEED + 1))
+            .expect_err("key differs");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::UnexpectedRevealPubkey
+        ));
+    }
+
+    #[test]
+    fn test_matching_key_allows_payload_access() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let payload = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect("round trips")
+            .authenticate(&make_xonly_pubkey_bytes(DEFAULT_KEY_SEED))
+            .expect("key matches")
+            .into_payload();
+
+        assert_eq!(payload, b"chunk");
+    }
+
+    #[test]
+    fn test_non_matching_key_is_rejected() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+            .expect("round trips")
+            .authenticate(&make_xonly_pubkey_bytes(DEFAULT_KEY_SEED + 1))
+            .expect_err("key differs");
+
+        assert!(matches!(
+            error,
+            CommitRevealParseError::UnexpectedRevealPubkey
+        ));
+    }
+
+    #[test]
+    fn test_fixed_width_marker_tail_succeeds() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[0, 0, 0, 7], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let parsed =
+            extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal]).expect("round trips");
+
+        assert_eq!(
+            parsed.marker_tail_array::<4>().expect("width matches"),
+            &[0, 0, 0, 7]
+        );
+    }
+
+    #[test]
+    fn test_wrong_width_marker_tail_fails() {
+        for tail in [&[1, 2, 3][..], &[1, 2, 3, 4, 5][..]] {
+            let commit = build_commit_tx(&TEST_MAGIC, tail, 1, &[]);
+            let reveal = build_reveal_tx(vec![build_reveal_input(
+                commit.compute_txid(),
+                1,
+                Some(b"chunk"),
+                DEFAULT_KEY_SEED,
+            )]);
+
+            let parsed =
+                extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal]).expect("round trips");
+            let error = parsed
+                .marker_tail_array::<4>()
+                .expect_err("tail is not four bytes");
+
+            assert_eq!(
+                error,
+                MarkerTailArrayLengthError {
+                    expected: 4,
+                    found: tail.len(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn test_chunk_order_is_preserved() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 2, &[]);
+        let commit_txid = commit.compute_txid();
+        let first = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            1,
+            Some(b"first"),
+            DEFAULT_KEY_SEED,
+        )]);
+        let second = build_reveal_tx(vec![build_reveal_input(
+            commit_txid,
+            2,
+            Some(b"second"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let chunks = extract_payload_for_commit(&TEST_MAGIC, &commit, [&second, &first])
+            .expect("round trips")
+            .into_chunks();
+
+        assert_eq!(chunks, vec![b"first".to_vec(), b"second".to_vec()]);
+    }
+
+    /// Chunk count is never written on chain, so what a consumer observes must
+    /// follow from the payload size and the per-reveal ceiling alone.
+    #[test]
+    fn test_chunks_observed_follow_the_envelope_ceiling() {
+        for (len, expected) in [
+            (
+                MAX_ENVELOPE_PAYLOAD_SIZE - 1,
+                vec![MAX_ENVELOPE_PAYLOAD_SIZE - 1],
+            ),
+            (MAX_ENVELOPE_PAYLOAD_SIZE, vec![MAX_ENVELOPE_PAYLOAD_SIZE]),
+            (
+                MAX_ENVELOPE_PAYLOAD_SIZE + 1,
+                vec![MAX_ENVELOPE_PAYLOAD_SIZE, 1],
+            ),
+        ] {
+            let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+            let (commit, reveals) = build_commit_reveal_txs(&payload);
+
+            let parsed = extract_payload_for_commit(&TEST_MAGIC, &commit, reveals.iter())
+                .expect("round trips");
+
+            let lens: Vec<usize> = parsed.chunks().iter().map(Vec::len).collect();
+            assert_eq!(lens, expected, "payload of {len} bytes");
+            assert_eq!(parsed.into_payload(), payload, "payload of {len} bytes");
+        }
+    }
+
+    /// Two non-slot spends must report the same vout either way round, or the
+    /// public error depends on input ordering.
+    #[test]
+    fn test_non_slot_commit_output_reported_is_the_lowest() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[], 1, &[]);
+        let commit_txid = commit.compute_txid();
+        let low = build_reveal_input(commit_txid, 5, None, DEFAULT_KEY_SEED);
+        let high = build_reveal_input(commit_txid, 7, None, DEFAULT_KEY_SEED);
+
+        for inputs in [
+            vec![low.clone(), high.clone()],
+            vec![high.clone(), low.clone()],
+        ] {
+            let reveal = build_reveal_tx(inputs);
+
+            let error = extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal])
+                .expect_err("both spends are outside the slot range");
+
+            assert!(matches!(
+                error,
+                CommitRevealParseError::UnexpectedReveal { vout: 5 }
+            ));
+        }
+    }
+
+    /// `into_payload` consumes the result, so the marker tail a host still needs
+    /// afterwards borrows from the transactions rather than from the result.
+    #[test]
+    fn test_tail_outlives_the_joined_payload() {
+        let commit = build_commit_tx(&TEST_MAGIC, &[7, 7], 1, &[]);
+        let reveal = build_reveal_tx(vec![build_reveal_input(
+            commit.compute_txid(),
+            1,
+            Some(b"chunk"),
+            DEFAULT_KEY_SEED,
+        )]);
+
+        let parsed =
+            extract_payload_for_commit(&TEST_MAGIC, &commit, [&reveal]).expect("round trips");
+        let tail = parsed.marker_tail();
+
+        assert_eq!(parsed.into_payload(), b"chunk");
+        assert_eq!(tail, &[7, 7]);
+    }
+
+    /// Reads that straddle a chunk boundary must work off the borrowed view.
+    #[test]
+    fn test_payload_reads_across_a_chunk_boundary_without_joining() {
+        let payload: Vec<u8> = (0..MAX_ENVELOPE_PAYLOAD_SIZE + 64)
+            .map(|i| (i % 251) as u8)
+            .collect();
+        let (commit, reveals) = build_commit_reveal_txs(&payload);
+
+        let parsed =
+            extract_payload_for_commit(&TEST_MAGIC, &commit, reveals.iter()).expect("round trips");
+        assert_eq!(parsed.chunks().len(), 2, "payload must span two reveals");
+
+        // A step that does not divide the ceiling guarantees a read lands
+        // astride the boundary rather than flush against it.
+        const STEP: usize = 7;
+        assert_ne!(MAX_ENVELOPE_PAYLOAD_SIZE % STEP, 0, "step must straddle");
+
+        let mut reader = ChunkReader {
+            chunks: parsed.chunks(),
+            chunk: 0,
+            offset: 0,
+        };
+        let mut seen = Vec::new();
+        let mut buf = [0u8; STEP];
+        loop {
+            let read = reader.read(&mut buf);
+            if read == 0 {
+                break;
+            }
+            seen.extend_from_slice(&buf[..read]);
+        }
+
+        assert_eq!(seen, payload);
+    }
+}

--- a/crates/l1proto/commit-reveal/src/test_utils.rs
+++ b/crates/l1proto/commit-reveal/src/test_utils.rs
@@ -1,0 +1,53 @@
+//! Fixtures for commit-reveal tests.
+
+use std::sync::OnceLock;
+
+use bitcoin::secp256k1::{All, Keypair, Secp256k1, SecretKey, XOnlyPublicKey};
+use strata_l1_envelope_fmt::SIGNED_LEAF_PUBKEY_LEN;
+use strata_l1_txfmt::MagicBytes;
+
+/// Magic used by fixtures unless a test needs a different one.
+pub(crate) const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
+
+/// Key seed used by fixtures unless a test needs a different one.
+pub(crate) const DEFAULT_KEY_SEED: u8 = 7;
+
+/// Verification context for fixture key derivation.
+fn secp() -> &'static Secp256k1<All> {
+    static SECP: OnceLock<Secp256k1<All>> = OnceLock::new();
+    SECP.get_or_init(Secp256k1::new)
+}
+
+/// A deterministic x-only key, distinct per `seed`.
+///
+/// Every `u8` seed is valid. The scalar keeps a fixed non-zero prefix and
+/// varies only its last byte, since a repeated seed would give an all-zero
+/// scalar at `seed == 0`, which secp256k1 rejects.
+pub(crate) fn make_xonly_pubkey(seed: u8) -> XOnlyPublicKey {
+    let mut secret = [1u8; 32];
+    secret[31] = seed;
+    let secret_key = SecretKey::from_slice(&secret).expect("non-zero scalar below curve order");
+    let keypair = Keypair::from_secret_key(secp(), &secret_key);
+    XOnlyPublicKey::from_keypair(&keypair).0
+}
+
+/// The 32-byte serialization of [`make_xonly_pubkey`].
+pub(crate) fn make_xonly_pubkey_bytes(seed: u8) -> [u8; SIGNED_LEAF_PUBKEY_LEN] {
+    make_xonly_pubkey(seed).serialize()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    /// Seed 0 would panic on a repeated-byte scalar: all zeros is not a valid
+    /// secp256k1 secret key.
+    #[test]
+    fn test_make_xonly_pubkey_accepts_every_seed() {
+        let keys: BTreeSet<_> = (u8::MIN..=u8::MAX).map(make_xonly_pubkey_bytes).collect();
+
+        assert_eq!(keys.len(), 256, "each seed must give a distinct key");
+    }
+}

--- a/crates/l1proto/commit-reveal/src/test_utils.rs
+++ b/crates/l1proto/commit-reveal/src/test_utils.rs
@@ -12,7 +12,7 @@ use strata_l1_envelope_fmt::SIGNED_LEAF_PUBKEY_LEN;
 use strata_l1_envelope_fmt::builder::build_signed_envelope_leaf;
 use strata_l1_txfmt::MagicBytes;
 
-use crate::builder::build_commit_marker_script;
+use crate::builder::{build_commit_marker_script, build_commit_reveal_scripts_from_chunks};
 
 /// Magic used by fixtures unless a test needs a different one.
 pub(crate) const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
@@ -86,6 +86,45 @@ pub(crate) fn build_commit_tx(
         });
     }
     tx
+}
+
+/// A valid commit transaction and its reveal transactions.
+pub(crate) struct CommitRevealTxSet {
+    pub(crate) commit: Transaction,
+    pub(crate) reveals: Vec<Transaction>,
+}
+
+/// Builds one valid commit and one reveal per supplied chunk.
+pub(crate) fn build_commit_reveal_set(
+    magic: &MagicBytes,
+    tail: &[u8],
+    chunks: &[impl AsRef<[u8]>],
+    key_seed: u8,
+) -> CommitRevealTxSet {
+    let scripts = build_commit_reveal_scripts_from_chunks(
+        magic,
+        tail,
+        &make_xonly_pubkey_bytes(key_seed),
+        chunks,
+    )
+    .expect("valid commit-reveal set builds");
+    let (marker, leaves) = scripts.into_parts();
+    let commit = assemble_commit_tx(marker, leaves.len());
+    let commit_txid = commit.compute_txid();
+    let reveals = leaves
+        .into_iter()
+        .enumerate()
+        .map(|(idx, leaf)| {
+            build_reveal_tx(vec![build_reveal_input_from_leaf(
+                commit_txid,
+                idx as u32 + 1,
+                leaf,
+                key_seed,
+            )])
+        })
+        .collect();
+
+    CommitRevealTxSet { commit, reveals }
 }
 
 /// Assembles a commit tx from a prebuilt marker script and a slot count.

--- a/crates/l1proto/commit-reveal/src/test_utils.rs
+++ b/crates/l1proto/commit-reveal/src/test_utils.rs
@@ -2,9 +2,17 @@
 
 use std::sync::OnceLock;
 
-use bitcoin::secp256k1::{All, Keypair, Secp256k1, SecretKey, XOnlyPublicKey};
+use bitcoin::absolute::LockTime;
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::{All, Keypair, Parity, Secp256k1, SecretKey, XOnlyPublicKey};
+use bitcoin::taproot::{ControlBlock, LeafVersion, TapNodeHash, TaprootMerkleBranch};
+use bitcoin::transaction::Version;
+use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
 use strata_l1_envelope_fmt::SIGNED_LEAF_PUBKEY_LEN;
+use strata_l1_envelope_fmt::builder::build_signed_envelope_leaf;
 use strata_l1_txfmt::MagicBytes;
+
+use crate::builder::build_commit_marker_script;
 
 /// Magic used by fixtures unless a test needs a different one.
 pub(crate) const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
@@ -12,10 +20,15 @@ pub(crate) const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
 /// Key seed used by fixtures unless a test needs a different one.
 pub(crate) const DEFAULT_KEY_SEED: u8 = 7;
 
-/// Verification context for fixture key derivation.
+/// Secp256k1 context for fixture key derivation.
 fn secp() -> &'static Secp256k1<All> {
     static SECP: OnceLock<Secp256k1<All>> = OnceLock::new();
     SECP.get_or_init(Secp256k1::new)
+}
+
+/// A deterministic txid, distinct per `seed`.
+pub(crate) fn make_txid(seed: u8) -> Txid {
+    Txid::from_byte_array([seed; 32])
 }
 
 /// A deterministic x-only key, distinct per `seed`.
@@ -34,6 +47,191 @@ pub(crate) fn make_xonly_pubkey(seed: u8) -> XOnlyPublicKey {
 /// The 32-byte serialization of [`make_xonly_pubkey`].
 pub(crate) fn make_xonly_pubkey_bytes(seed: u8) -> [u8; SIGNED_LEAF_PUBKEY_LEN] {
     make_xonly_pubkey(seed).serialize()
+}
+
+fn build_control_block(internal_key: XOnlyPublicKey, leaf_version: LeafVersion) -> ControlBlock {
+    let branch: [TapNodeHash; 0] = [];
+    ControlBlock {
+        leaf_version,
+        output_key_parity: Parity::Even,
+        internal_key,
+        merkle_branch: TaprootMerkleBranch::from(branch),
+    }
+}
+
+/// A P2TR script, for extending or breaking a reveal-slot run.
+pub(crate) fn make_p2tr_script() -> ScriptBuf {
+    ScriptBuf::new_p2tr(secp(), make_xonly_pubkey(9), None)
+}
+
+/// A non-P2TR script, standing in for wallet change.
+pub(crate) fn make_change_script() -> ScriptBuf {
+    ScriptBuf::new_op_return([0u8; 4])
+}
+
+/// Builds a commit tx: marker at output 0, `reveal_slots` P2TR outputs, then
+/// `trailing_outputs` standing in for change.
+pub(crate) fn build_commit_tx(
+    magic: &MagicBytes,
+    tail: &[u8],
+    reveal_slots: usize,
+    trailing_outputs: &[ScriptBuf],
+) -> Transaction {
+    let marker = build_commit_marker_script(magic, tail).expect("marker within limit");
+    let mut tx = assemble_commit_tx(marker, reveal_slots);
+    for script in trailing_outputs {
+        tx.output.push(TxOut {
+            value: Amount::from_sat(1000),
+            script_pubkey: script.clone(),
+        });
+    }
+    tx
+}
+
+/// Assembles a commit tx from a prebuilt marker script and a slot count.
+///
+/// The counterpart to [`CommitRevealScripts`](crate::builder::CommitRevealScripts):
+/// a writer funds exactly `reveal_slots` P2TR outputs after the marker.
+pub(crate) fn assemble_commit_tx(marker: ScriptBuf, reveal_slots: usize) -> Transaction {
+    let reveal_key = make_xonly_pubkey(3);
+    let mut output = vec![TxOut {
+        value: Amount::ZERO,
+        script_pubkey: marker,
+    }];
+    for _ in 0..reveal_slots {
+        output.push(TxOut {
+            value: Amount::from_sat(1000),
+            script_pubkey: ScriptBuf::new_p2tr(secp(), reveal_key, None),
+        });
+    }
+
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output,
+    }
+}
+
+/// Builds a transaction carrying `script` at output 0.
+///
+/// For exercising marker classification against output-0 scripts the commit
+/// builder would never produce.
+pub(crate) fn build_marker_candidate_tx(script: ScriptBuf) -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            value: Amount::ZERO,
+            script_pubkey: script,
+        }],
+    }
+}
+
+/// Builds a reveal input spending `commit_txid:vout`, whose leaf carries
+/// `key_seed`'s pubkey.
+///
+/// With `chunk`, the witness carries a well-formed signed envelope leaf and a
+/// placeholder signature; with `None` the witness is empty.
+///
+/// The witness signature is a placeholder, not a real signature over the
+/// spend. These fixtures exercise leaf *shape*, which is what the parser
+/// checks; they prove nothing about signature validity.
+pub(crate) fn build_reveal_input(
+    commit_txid: Txid,
+    vout: u32,
+    chunk: Option<&[u8]>,
+    key_seed: u8,
+) -> TxIn {
+    match chunk {
+        Some(chunk) => {
+            let leaf = build_signed_envelope_leaf(&make_xonly_pubkey_bytes(key_seed), chunk)
+                .expect("leaf builds");
+            build_reveal_input_from_leaf(commit_txid, vout, leaf, key_seed)
+        }
+        None => build_txin(commit_txid, vout, Witness::new()),
+    }
+}
+
+/// Builds a reveal input whose witness carries `leaf`, for driving the parser
+/// with scripts a builder produced.
+pub(crate) fn build_reveal_input_from_leaf(
+    commit_txid: Txid,
+    vout: u32,
+    leaf: ScriptBuf,
+    key_seed: u8,
+) -> TxIn {
+    let mut witness = Witness::new();
+    witness.push([1u8; 64]);
+    witness.push(leaf);
+    witness
+        .push(build_control_block(make_xonly_pubkey(key_seed), LeafVersion::TapScript).serialize());
+
+    build_txin(commit_txid, vout, witness)
+}
+
+/// Builds a reveal input whose leaf carries an unsupported leaf version.
+pub(crate) fn build_unsupported_leaf_reveal_input(
+    commit_txid: Txid,
+    vout: u32,
+    chunk: &[u8],
+    key_seed: u8,
+    leaf_version: LeafVersion,
+) -> TxIn {
+    let mut witness = Witness::new();
+    witness.push([1u8; 64]);
+    witness.push(
+        build_signed_envelope_leaf(&make_xonly_pubkey_bytes(key_seed), chunk).expect("leaf builds"),
+    );
+    witness.push(build_control_block(make_xonly_pubkey(key_seed), leaf_version).serialize());
+
+    build_txin(commit_txid, vout, witness)
+}
+
+fn build_txin(commit_txid: Txid, vout: u32, witness: Witness) -> TxIn {
+    TxIn {
+        previous_output: OutPoint {
+            txid: commit_txid,
+            vout,
+        },
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness,
+    }
+}
+
+/// Builds a reveal tx that carries no marker of its own.
+pub(crate) fn build_reveal_tx(inputs: Vec<TxIn>) -> Transaction {
+    build_tx(
+        inputs,
+        vec![TxOut {
+            value: Amount::from_sat(1000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+    )
+}
+
+/// Builds a reveal tx carrying a marker output at vout 0.
+///
+/// Used to prove reveal parsing does not reject a reveal only because its output
+/// 0 also carries a marker.
+pub(crate) fn build_reveal_tx_with_marker_output(inputs: Vec<TxIn>, marker: TxOut) -> Transaction {
+    build_tx(inputs, vec![marker])
+}
+
+fn build_tx(input: Vec<TxIn>, output: Vec<TxOut>) -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input,
+        output,
+    }
 }
 
 #[cfg(test)]

--- a/crates/l1proto/commit-reveal/src/test_utils.rs
+++ b/crates/l1proto/commit-reveal/src/test_utils.rs
@@ -1,4 +1,8 @@
 //! Fixtures for commit-reveal tests.
+//!
+//! These reproduce transaction *shape*, which is all the parser reads. Witness
+//! signatures are placeholders and the P2TR slots do not commit to the leaves
+//! revealed against them, so nothing built here is spend-valid.
 
 use std::sync::OnceLock;
 
@@ -15,10 +19,10 @@ use strata_l1_txfmt::MagicBytes;
 use crate::builder::{build_commit_marker_script, build_commit_reveal_scripts_from_chunks};
 
 /// Magic used by fixtures unless a test needs a different one.
-pub(crate) const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
+pub const TEST_MAGIC: MagicBytes = MagicBytes::new(*b"TEST");
 
 /// Key seed used by fixtures unless a test needs a different one.
-pub(crate) const DEFAULT_KEY_SEED: u8 = 7;
+pub const DEFAULT_KEY_SEED: u8 = 7;
 
 /// Secp256k1 context for fixture key derivation.
 fn secp() -> &'static Secp256k1<All> {
@@ -27,7 +31,7 @@ fn secp() -> &'static Secp256k1<All> {
 }
 
 /// A deterministic txid, distinct per `seed`.
-pub(crate) fn make_txid(seed: u8) -> Txid {
+pub fn make_txid(seed: u8) -> Txid {
     Txid::from_byte_array([seed; 32])
 }
 
@@ -36,7 +40,7 @@ pub(crate) fn make_txid(seed: u8) -> Txid {
 /// Every `u8` seed is valid. The scalar keeps a fixed non-zero prefix and
 /// varies only its last byte, since a repeated seed would give an all-zero
 /// scalar at `seed == 0`, which secp256k1 rejects.
-pub(crate) fn make_xonly_pubkey(seed: u8) -> XOnlyPublicKey {
+pub fn make_xonly_pubkey(seed: u8) -> XOnlyPublicKey {
     let mut secret = [1u8; 32];
     secret[31] = seed;
     let secret_key = SecretKey::from_slice(&secret).expect("non-zero scalar below curve order");
@@ -45,7 +49,7 @@ pub(crate) fn make_xonly_pubkey(seed: u8) -> XOnlyPublicKey {
 }
 
 /// The 32-byte serialization of [`make_xonly_pubkey`].
-pub(crate) fn make_xonly_pubkey_bytes(seed: u8) -> [u8; SIGNED_LEAF_PUBKEY_LEN] {
+pub fn make_xonly_pubkey_bytes(seed: u8) -> [u8; SIGNED_LEAF_PUBKEY_LEN] {
     make_xonly_pubkey(seed).serialize()
 }
 
@@ -60,18 +64,22 @@ fn build_control_block(internal_key: XOnlyPublicKey, leaf_version: LeafVersion) 
 }
 
 /// A P2TR script, for extending or breaking a reveal-slot run.
-pub(crate) fn make_p2tr_script() -> ScriptBuf {
+pub fn make_p2tr_script() -> ScriptBuf {
     ScriptBuf::new_p2tr(secp(), make_xonly_pubkey(9), None)
 }
 
 /// A non-P2TR script, standing in for wallet change.
-pub(crate) fn make_change_script() -> ScriptBuf {
+pub fn make_change_script() -> ScriptBuf {
     ScriptBuf::new_op_return([0u8; 4])
 }
 
 /// Builds a commit tx: marker at output 0, `reveal_slots` P2TR outputs, then
 /// `trailing_outputs` standing in for change.
-pub(crate) fn build_commit_tx(
+///
+/// # Panics
+///
+/// If `tail` exceeds [`MAX_MARKER_TAIL_BYTES`](crate::MAX_MARKER_TAIL_BYTES).
+pub fn build_commit_tx(
     magic: &MagicBytes,
     tail: &[u8],
     reveal_slots: usize,
@@ -89,13 +97,17 @@ pub(crate) fn build_commit_tx(
 }
 
 /// A valid commit transaction and its reveal transactions.
-pub(crate) struct CommitRevealTxSet {
-    pub(crate) commit: Transaction,
-    pub(crate) reveals: Vec<Transaction>,
+#[derive(Debug)]
+pub struct CommitRevealTxSet {
+    /// Commit transaction carrying the marker and reveal slots.
+    pub commit: Transaction,
+
+    /// Reveal transactions, one per supplied chunk.
+    pub reveals: Vec<Transaction>,
 }
 
 /// Builds one valid commit and one reveal per supplied chunk.
-pub(crate) fn build_commit_reveal_set(
+pub fn build_commit_reveal_set(
     magic: &MagicBytes,
     tail: &[u8],
     chunks: &[impl AsRef<[u8]>],
@@ -131,7 +143,7 @@ pub(crate) fn build_commit_reveal_set(
 ///
 /// The counterpart to [`CommitRevealScripts`](crate::builder::CommitRevealScripts):
 /// a writer funds exactly `reveal_slots` P2TR outputs after the marker.
-pub(crate) fn assemble_commit_tx(marker: ScriptBuf, reveal_slots: usize) -> Transaction {
+pub fn assemble_commit_tx(marker: ScriptBuf, reveal_slots: usize) -> Transaction {
     let reveal_key = make_xonly_pubkey(3);
     let mut output = vec![TxOut {
         value: Amount::ZERO,
@@ -161,7 +173,7 @@ pub(crate) fn assemble_commit_tx(marker: ScriptBuf, reveal_slots: usize) -> Tran
 ///
 /// For exercising marker classification against output-0 scripts the commit
 /// builder would never produce.
-pub(crate) fn build_marker_candidate_tx(script: ScriptBuf) -> Transaction {
+pub fn build_marker_candidate_tx(script: ScriptBuf) -> Transaction {
     Transaction {
         version: Version::TWO,
         lock_time: LockTime::ZERO,
@@ -179,10 +191,17 @@ pub(crate) fn build_marker_candidate_tx(script: ScriptBuf) -> Transaction {
 /// With `chunk`, the witness carries a well-formed signed envelope leaf and a
 /// placeholder signature; with `None` the witness is empty.
 ///
+/// One seed keys both the leaf and the control block, since SPS-53 uses the
+/// producer key as the taproot internal key as well.
+///
 /// The witness signature is a placeholder, not a real signature over the
 /// spend. These fixtures exercise leaf *shape*, which is what the parser
 /// checks; they prove nothing about signature validity.
-pub(crate) fn build_reveal_input(
+///
+/// # Panics
+///
+/// If `chunk` exceeds the per-reveal envelope maximum.
+pub fn build_reveal_input(
     commit_txid: Txid,
     vout: u32,
     chunk: Option<&[u8]>,
@@ -200,23 +219,33 @@ pub(crate) fn build_reveal_input(
 
 /// Builds a reveal input whose witness carries `leaf`, for driving the parser
 /// with scripts a builder produced.
-pub(crate) fn build_reveal_input_from_leaf(
+///
+/// `internal_key_seed` keys the control block only. The leaf's pubkey is
+/// whatever `leaf` already carries, unlike [`build_reveal_input`] where the
+/// seed chooses it.
+pub fn build_reveal_input_from_leaf(
     commit_txid: Txid,
     vout: u32,
     leaf: ScriptBuf,
-    key_seed: u8,
+    internal_key_seed: u8,
 ) -> TxIn {
     let mut witness = Witness::new();
     witness.push([1u8; 64]);
     witness.push(leaf);
-    witness
-        .push(build_control_block(make_xonly_pubkey(key_seed), LeafVersion::TapScript).serialize());
+    witness.push(
+        build_control_block(make_xonly_pubkey(internal_key_seed), LeafVersion::TapScript)
+            .serialize(),
+    );
 
     build_txin(commit_txid, vout, witness)
 }
 
 /// Builds a reveal input whose leaf carries an unsupported leaf version.
-pub(crate) fn build_unsupported_leaf_reveal_input(
+///
+/// # Panics
+///
+/// If `chunk` exceeds the per-reveal envelope maximum.
+pub fn build_unsupported_leaf_reveal_input(
     commit_txid: Txid,
     vout: u32,
     chunk: &[u8],
@@ -246,7 +275,7 @@ fn build_txin(commit_txid: Txid, vout: u32, witness: Witness) -> TxIn {
 }
 
 /// Builds a reveal tx that carries no marker of its own.
-pub(crate) fn build_reveal_tx(inputs: Vec<TxIn>) -> Transaction {
+pub fn build_reveal_tx(inputs: Vec<TxIn>) -> Transaction {
     build_tx(
         inputs,
         vec![TxOut {
@@ -260,7 +289,7 @@ pub(crate) fn build_reveal_tx(inputs: Vec<TxIn>) -> Transaction {
 ///
 /// Used to prove reveal parsing does not reject a reveal only because its output
 /// 0 also carries a marker.
-pub(crate) fn build_reveal_tx_with_marker_output(inputs: Vec<TxIn>, marker: TxOut) -> Transaction {
+pub fn build_reveal_tx_with_marker_output(inputs: Vec<TxIn>, marker: TxOut) -> Transaction {
     build_tx(inputs, vec![marker])
 }
 

--- a/crates/l1proto/envelope-fmt/src/builder.rs
+++ b/crates/l1proto/envelope-fmt/src/builder.rs
@@ -5,6 +5,7 @@ use bitcoin::opcodes::OP_FALSE;
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_ENDIF, OP_IF};
 use bitcoin::script::PushBytesBuf;
 
+use crate::SIGNED_LEAF_PUBKEY_LEN;
 use crate::errors::EnvelopeBuildError;
 
 /// Minimum recommended total envelope payload size in bytes.
@@ -178,6 +179,33 @@ pub fn build_envelope_script(payload: &[u8]) -> Result<ScriptBuf, EnvelopeBuildE
     Ok(builder.into_script())
 }
 
+/// Builds a signed envelope leaf:
+/// `<pubkey> OP_CHECKSIG OP_FALSE OP_IF <payload pushes> OP_ENDIF`.
+///
+/// The pubkey is fixed to [`SIGNED_LEAF_PUBKEY_LEN`] bytes. The
+/// [`MIN_ENVELOPE_PAYLOAD_SIZE`] recommendation is not enforced.
+///
+/// # Errors
+///
+/// Returns [`EnvelopeBuildError::PayloadTooLarge`] if `payload` exceeds
+/// [`MAX_ENVELOPE_PAYLOAD_SIZE`].
+pub fn build_signed_envelope_leaf(
+    pubkey: &[u8; SIGNED_LEAF_PUBKEY_LEN],
+    payload: &[u8],
+) -> Result<ScriptBuf, EnvelopeBuildError> {
+    EnvelopeScriptBuilder::with_pubkey(pubkey)?
+        .add_envelope(payload)?
+        .build_without_min_check()
+}
+
+/// Splits `payload` into chunks of at most [`MAX_ENVELOPE_PAYLOAD_SIZE`] bytes.
+///
+/// Chunks are full-sized except the last, and an empty payload returns no
+/// chunks.
+pub fn split_payload_into_envelope_chunks(payload: &[u8]) -> Vec<&[u8]> {
+    payload.chunks(MAX_ENVELOPE_PAYLOAD_SIZE).collect()
+}
+
 /// Helper function to add envelope opcodes and payload chunks to a builder.
 ///
 /// Takes a mutable builder and a payload, and extends the builder with:
@@ -203,7 +231,7 @@ fn push_envelope(
 
 #[cfg(test)]
 mod tests {
-    use bitcoin::opcodes::all::{OP_ENDIF, OP_IF};
+    use bitcoin::opcodes::all::{OP_CHECKSIG, OP_ENDIF, OP_IF};
     use bitcoin::script::Instruction;
 
     use super::*;
@@ -593,5 +621,108 @@ mod tests {
             .unwrap();
 
         assert!(!script.is_empty());
+    }
+
+    #[test]
+    fn test_build_signed_envelope_leaf_structure() {
+        let pubkey = [0x03; SIGNED_LEAF_PUBKEY_LEN];
+        let payload = vec![7u8; 50];
+
+        let script = build_signed_envelope_leaf(&pubkey, &payload).unwrap();
+        let mut instructions = script.instructions();
+
+        // <32-byte pubkey>
+        match instructions.next() {
+            Some(Ok(Instruction::PushBytes(bytes))) => {
+                assert_eq!(
+                    bytes.as_bytes(),
+                    pubkey.as_slice(),
+                    "leaf must open with the 32-byte pubkey"
+                );
+            }
+            other => panic!("expected pubkey push, got {other:?}"),
+        }
+        // OP_CHECKSIG
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::Op(op))) if op == OP_CHECKSIG
+        ));
+        // OP_FALSE, encoded as an empty push
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes().is_empty()
+        ));
+        // OP_IF
+        assert!(matches!(
+            instructions.next(),
+            Some(Ok(Instruction::Op(op))) if op == OP_IF
+        ));
+        // payload push(es), then OP_ENDIF, then nothing
+        let mut body = Vec::new();
+        loop {
+            match instructions.next() {
+                Some(Ok(Instruction::PushBytes(bytes))) => body.extend_from_slice(bytes.as_bytes()),
+                Some(Ok(Instruction::Op(op))) if op == OP_ENDIF => break,
+                other => panic!("expected data push or OP_ENDIF, got {other:?}"),
+            }
+        }
+        assert_eq!(body, payload, "recovered body must equal the payload");
+        assert!(
+            instructions.next().is_none(),
+            "strict leaf must have nothing after OP_ENDIF"
+        );
+    }
+
+    #[test]
+    fn test_build_signed_envelope_leaf_allows_below_min_payload() {
+        // The 126-byte builder minimum is a `build()`-only efficiency rule; the
+        // strict leaf builder does not apply it, since reveal chunk sizes are
+        // format-determined rather than a caller's choice.
+        let pubkey = [0x02; SIGNED_LEAF_PUBKEY_LEN];
+        let script = build_signed_envelope_leaf(&pubkey, &[1u8; 10]).unwrap();
+        assert!(!script.is_empty());
+    }
+
+    #[test]
+    fn test_build_signed_envelope_leaf_rejects_oversized_payload() {
+        let pubkey = [0x02; SIGNED_LEAF_PUBKEY_LEN];
+        let result = build_signed_envelope_leaf(&pubkey, &vec![0u8; MAX_ENVELOPE_PAYLOAD_SIZE + 1]);
+        match result {
+            Err(EnvelopeBuildError::PayloadTooLarge { total_size, max }) => {
+                assert_eq!(total_size, MAX_ENVELOPE_PAYLOAD_SIZE + 1);
+                assert_eq!(max, MAX_ENVELOPE_PAYLOAD_SIZE);
+            }
+            other => panic!("expected PayloadTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_split_payload_into_envelope_chunks_boundaries() {
+        // Empty payload: no chunks (no "one empty chunk" special case).
+        assert!(split_payload_into_envelope_chunks(&[]).is_empty());
+
+        // One byte: a single one-byte chunk.
+        let one = split_payload_into_envelope_chunks(&[9u8]);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0], &[9u8]);
+
+        // Exactly the ceiling: a single full chunk.
+        let exact = vec![1u8; MAX_ENVELOPE_PAYLOAD_SIZE];
+        let chunks = split_payload_into_envelope_chunks(&exact);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), MAX_ENVELOPE_PAYLOAD_SIZE);
+
+        // One over: a full chunk plus a one-byte remainder; concat round-trips.
+        let over = vec![2u8; MAX_ENVELOPE_PAYLOAD_SIZE + 1];
+        let chunks = split_payload_into_envelope_chunks(&over);
+        assert_eq!(
+            chunks.iter().map(|c| c.len()).collect::<Vec<_>>(),
+            vec![MAX_ENVELOPE_PAYLOAD_SIZE, 1]
+        );
+        assert_eq!(
+            chunks.concat(),
+            over,
+            "re-joining chunks recovers the payload"
+        );
     }
 }

--- a/crates/l1proto/envelope-fmt/src/errors.rs
+++ b/crates/l1proto/envelope-fmt/src/errors.rs
@@ -2,18 +2,19 @@ use thiserror::Error;
 
 /// Errors that can occur while parsing Bitcoin script envelopes.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EnvelopeParseError {
     /// No envelopes found in the script.
     #[error("no envelopes found in script")]
     NoEnvelopesFound,
 
-    /// Missing or invalid pubkey in envelope container.
-    #[error("missing or invalid pubkey in container")]
+    /// Missing or invalid pubkey before `OP_CHECKSIG`.
+    #[error("missing or invalid pubkey before OP_CHECKSIG")]
     MissingPubkey,
 
-    /// Missing CHECKSIGVERIFY opcode after pubkey in container.
-    #[error("missing CHECKSIGVERIFY after pubkey")]
-    MissingChecksigverify,
+    /// Missing `OP_CHECKSIG` after the pubkey.
+    #[error("missing OP_CHECKSIG after pubkey")]
+    MissingChecksig,
 
     /// Missing OP_FALSE at the start of an envelope.
     #[error("missing OP_FALSE at envelope start")]
@@ -31,6 +32,48 @@ pub enum EnvelopeParseError {
     /// Missing OP_ENDIF at the end of an envelope.
     #[error("missing OP_ENDIF at envelope end")]
     MissingOpEndif,
+
+    /// Pubkey push in a signed envelope leaf has invalid length.
+    ///
+    /// Only raised by the strict leaf parser, which requires exactly
+    /// [`SIGNED_LEAF_PUBKEY_LEN`](crate::SIGNED_LEAF_PUBKEY_LEN) bytes.
+    /// Under BIP342 a tapscript pubkey that is neither empty nor x-only sized
+    /// is an unknown public key type, for which `OP_CHECKSIG` succeeds without
+    /// verifying any signature. Accepting such a leaf would void the
+    /// authentication the envelope shape is meant to provide, so the strict
+    /// parser rejects it rather than reporting a pubkey the caller might
+    /// compare against.
+    #[error("signed envelope leaf pubkey must be exactly {expected} bytes, found {found}")]
+    InvalidPubkeyLength {
+        /// The required pubkey length.
+        expected: usize,
+
+        /// Length of the offending pubkey push.
+        found: usize,
+    },
+
+    /// Instructions remain after the envelope's OP_ENDIF.
+    ///
+    /// Only raised by the strict leaf parser, which requires the envelope to be
+    /// the entire script. This rejects trailing opcodes that could discard or
+    /// override the `OP_CHECKSIG` result, and additional envelopes beyond the
+    /// first.
+    #[error("unexpected instructions after envelope OP_ENDIF")]
+    UnexpectedTrailingInstructions,
+
+    /// Total envelope payload size exceeds the maximum allowed.
+    #[error("total envelope payload size ({total_size} bytes) exceeds maximum ({max} bytes)")]
+    PayloadTooLarge {
+        /// Total payload size decoded before the limit was exceeded.
+        total_size: usize,
+
+        /// The maximum allowed size.
+        max: usize,
+    },
+
+    /// Script could not be decoded into instructions.
+    #[error("malformed script")]
+    MalformedScript,
 }
 
 /// Errors that can occur while building Bitcoin script envelopes.
@@ -55,6 +98,7 @@ pub enum EnvelopeBuildError {
     PayloadTooSmall {
         /// The actual total size of all payloads.
         total_size: usize,
+
         /// The minimum recommended size.
         min: usize,
     },
@@ -65,6 +109,7 @@ pub enum EnvelopeBuildError {
     PayloadTooLarge {
         /// The actual total size of all payloads.
         total_size: usize,
+
         /// The maximum allowed size.
         max: usize,
     },

--- a/crates/l1proto/envelope-fmt/src/lib.rs
+++ b/crates/l1proto/envelope-fmt/src/lib.rs
@@ -55,6 +55,12 @@
 //!     .unwrap();
 //! ```
 
+/// Required length of the x-only public key in a signed envelope leaf.
+///
+/// Any other non-zero length is a BIP342 unknown key type that `OP_CHECKSIG` accepts without
+/// a signature (anyone-can-spend).
+pub const SIGNED_LEAF_PUBKEY_LEN: usize = 32;
+
 /// Bitcoin script envelope builder utilities.
 pub mod builder;
 

--- a/crates/l1proto/envelope-fmt/src/lib.rs
+++ b/crates/l1proto/envelope-fmt/src/lib.rs
@@ -15,17 +15,27 @@
 //!
 //! # Envelope Container
 //!
-//! An envelope container wraps one or more envelopes with a pubkey and CHECKSIGVERIFY:
+//! An envelope container wraps one or more envelopes with a pubkey and OP_CHECKSIG:
 //! ```text
 //! <pubkey>
-//! CHECKSIGVERIFY
+//! OP_CHECKSIG
 //! <envelope_0>
 //! ...
 //! <envelope_n>
 //! ```
 //!
-//! The envelope container is typically placed in a transaction input's script_sig,
-//! allowing arbitrary data to be included in Bitcoin transactions.
+//! The envelope container is carried in a transaction input's script context —
+//! a tapscript leaf or a script_sig — allowing arbitrary data to be included in
+//! Bitcoin transactions.
+//!
+//! # Lenient and strict parsing
+//!
+//! The **lenient** parsers scan for envelopes and ignore trailing opcodes —
+//! fine for scripts whose only job is to carry data.
+//! The **strict** [`parser::parse_signed_envelope_leaf`] requires exactly
+//! `<32-byte pubkey> OP_CHECKSIG` + one envelope and nothing else; use it where
+//! the shape authenticates, since only then can no later opcode discard or
+//! invert the `OP_CHECKSIG` result.
 //!
 //! # Examples
 //!

--- a/crates/l1proto/envelope-fmt/src/parser.rs
+++ b/crates/l1proto/envelope-fmt/src/parser.rs
@@ -1,15 +1,39 @@
+use bitcoin::ScriptBuf;
 use bitcoin::opcodes::all::{OP_CHECKSIG, OP_ENDIF, OP_IF};
 use bitcoin::opcodes::{OP_0, OP_FALSE};
 use bitcoin::script::{Instruction, Instructions};
-use bitcoin::{Opcode, ScriptBuf};
 
+use crate::SIGNED_LEAF_PUBKEY_LEN;
+use crate::builder::MAX_ENVELOPE_PAYLOAD_SIZE;
 use crate::errors::EnvelopeParseError;
 
-/// Extracts the next instruction from the iterator and attempts to parse it as an opcode.
-fn next_op(instructions: &mut Instructions<'_>) -> Option<Opcode> {
-    match instructions.next() {
-        Some(Ok(Instruction::Op(opcode))) => Some(opcode),
-        _ => None,
+/// One parsed signed envelope leaf.
+///
+/// "Signed" is the script *shape* — a pubkey guarded by `OP_CHECKSIG` — not a
+/// verified signature.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignedEnvelopeLeaf {
+    pubkey: [u8; SIGNED_LEAF_PUBKEY_LEN],
+    payload: Vec<u8>,
+}
+
+impl SignedEnvelopeLeaf {
+    /// The x-only public key the leaf's `OP_CHECKSIG` binds spending to.
+    ///
+    /// Callers authenticate by comparing these bytes against their own expected
+    /// key; this crate applies no key policy.
+    pub fn pubkey(&self) -> &[u8; SIGNED_LEAF_PUBKEY_LEN] {
+        &self.pubkey
+    }
+
+    /// Concatenated payload bytes carried between `OP_IF` and `OP_ENDIF`.
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    /// Consumes the leaf, returning the payload bytes.
+    pub fn into_payload(self) -> Vec<u8> {
+        self.payload
     }
 }
 
@@ -25,7 +49,7 @@ fn next_op(instructions: &mut Instructions<'_>) -> Option<Opcode> {
 pub fn parse_envelope_payload(script: &ScriptBuf) -> Result<Vec<u8>, EnvelopeParseError> {
     let mut instructions = script.instructions();
     enter_envelope(&mut instructions)?;
-    extract_until_op_endif(&mut instructions)
+    read_payload_until_endif(&mut instructions, usize::MAX)
 }
 
 /// Parses and extracts all payloads from a script with multiple envelopes.
@@ -43,7 +67,7 @@ pub fn parse_multi_envelope_payloads(
     let mut payloads = Vec::new();
 
     while enter_envelope(&mut instructions).is_ok() {
-        let payload = extract_until_op_endif(&mut instructions)?;
+        let payload = read_payload_until_endif(&mut instructions, usize::MAX)?;
         payloads.push(payload);
     }
 
@@ -54,109 +78,215 @@ pub fn parse_multi_envelope_payloads(
     Ok(payloads)
 }
 
-/// Parses an envelope container and extracts the pubkey and all payloads.
+/// A tuple-returning view of [`parse_signed_envelope_leaf`], kept for callers
+/// that predate that type.
 ///
-/// Parses a script with the structure:
-/// ```text
-/// <pubkey>
-/// CHECKSIGVERIFY
-/// <envelope_0>
-/// ...
-/// <envelope_n>
-/// ```
-///
-/// Returns a tuple containing the pubkey and a vector of all envelope payloads.
+/// Enforces the same strict grammar and always returns exactly one payload; see
+/// that function for the shape and the strictness rationale.
 ///
 /// # Errors
 ///
-/// Returns [`EnvelopeParseError`] if the container structure is invalid, if no valid
-/// envelopes are found, or if any payload data is malformed.
+/// Returns [`EnvelopeParseError`] if the script is not exactly one signed
+/// envelope leaf.
 pub fn parse_envelope_container(
     script: &ScriptBuf,
 ) -> Result<(Vec<u8>, Vec<Vec<u8>>), EnvelopeParseError> {
+    let leaf = parse_signed_envelope_leaf(script)?;
+    Ok((leaf.pubkey().to_vec(), vec![leaf.into_payload()]))
+}
+
+/// Parses a tapscript leaf that must be exactly one signed envelope:
+///
+/// ```text
+/// <x-only pubkey> OP_CHECKSIG OP_FALSE OP_IF <data pushes> OP_ENDIF
+/// ```
+///
+/// with no leading, interleaved, or trailing instructions (`OP_FALSE`, `OP_0`,
+/// and an empty push are equivalent openers).
+///
+/// The strict shape authenticates only for a
+/// [`LeafVersion::TapScript`](bitcoin::taproot::LeafVersion) leaf. This parses a script, not a
+/// leaf, so the caller must confirm the leaf version itself.
+///
+/// The pubkey must be exactly [`SIGNED_LEAF_PUBKEY_LEN`] bytes — see
+/// [`EnvelopeParseError::InvalidPubkeyLength`] for why a laxer rule breaks
+/// authentication.
+///
+/// # Errors
+///
+/// [`EnvelopeParseError`] if the script deviates from the shape in any way, or
+/// if the payload exceeds [`MAX_ENVELOPE_PAYLOAD_SIZE`].
+pub fn parse_signed_envelope_leaf(
+    script: &ScriptBuf,
+) -> Result<SignedEnvelopeLeaf, EnvelopeParseError> {
     let mut instructions = script.instructions();
 
-    // Extract pubkey
-    let pubkey = match instructions.next() {
-        Some(Ok(Instruction::PushBytes(bytes))) => bytes.as_bytes().to_vec(),
-        _ => return Err(EnvelopeParseError::MissingPubkey),
-    };
+    // Length is checked before OP_CHECKSIG so a bare envelope, whose OP_FALSE
+    // decodes as an empty push, is reported as an invalid pubkey rather than a
+    // missing OP_CHECKSIG.
+    let pubkey_bytes = read_pubkey_push(&mut instructions)?;
+    let pubkey = <[u8; SIGNED_LEAF_PUBKEY_LEN]>::try_from(pubkey_bytes).map_err(|_| {
+        EnvelopeParseError::InvalidPubkeyLength {
+            expected: SIGNED_LEAF_PUBKEY_LEN,
+            found: pubkey_bytes.len(),
+        }
+    })?;
+    expect_checksig(&mut instructions)?;
 
-    // Verify CHECKSIGVERIFY
-    if next_op(&mut instructions) != Some(OP_CHECKSIG) {
-        return Err(EnvelopeParseError::MissingChecksigverify);
+    // The opener must be the very next instruction; unlike the lenient
+    // parsers, nothing may be skipped to reach it.
+    match next_instruction(&mut instructions)? {
+        Some(instruction) if is_envelope_opener(&instruction) => {}
+        _ => return Err(EnvelopeParseError::MissingOpFalse),
     }
 
-    // Extract all envelopes
-    let mut payloads = Vec::new();
-    while enter_envelope(&mut instructions).is_ok() {
-        let payload = extract_until_op_endif(&mut instructions)?;
-        payloads.push(payload);
+    expect_op_if(&mut instructions)?;
+
+    let payload = read_payload_until_endif(&mut instructions, MAX_ENVELOPE_PAYLOAD_SIZE)?;
+
+    if next_instruction(&mut instructions)?.is_some() {
+        return Err(EnvelopeParseError::UnexpectedTrailingInstructions);
     }
 
-    if payloads.is_empty() {
-        return Err(EnvelopeParseError::NoEnvelopesFound);
-    }
+    Ok(SignedEnvelopeLeaf { pubkey, payload })
+}
 
-    Ok((pubkey, payloads))
+/// Reads the next instruction, mapping a decode failure to
+/// [`EnvelopeParseError::MalformedScript`].
+///
+/// Every strict read and the shared payload loop go through here, so an
+/// undecodable instruction errors rather than being silently skipped. The one
+/// place that skips it is [`enter_envelope`]'s forward scan for the opener.
+fn next_instruction<'a>(
+    instructions: &mut Instructions<'a>,
+) -> Result<Option<Instruction<'a>>, EnvelopeParseError> {
+    match instructions.next() {
+        None => Ok(None),
+        Some(Ok(instruction)) => Ok(Some(instruction)),
+        Some(Err(_)) => Err(EnvelopeParseError::MalformedScript),
+    }
 }
 
 /// Locates and validates the envelope start sequence (`OP_FALSE OP_IF`).
 fn enter_envelope(instructions: &mut Instructions<'_>) -> Result<(), EnvelopeParseError> {
-    // Search for OP_FALSE, which can appear in multiple equivalent forms:
-    // - Instruction::Op(OP_FALSE) - the OP_FALSE opcode constant
-    // - Instruction::Op(OP_0) - OP_0 is an alias for OP_FALSE
-    // - Instruction::PushBytes(empty) - OP_FALSE is encoded as OP_PUSHBYTES_0
-    //
-    // Note: OP_FALSE pushes an empty byte array to the stack. When a script is parsed,
-    // it typically appears as Instruction::PushBytes with empty bytes, but we check all
-    // forms for maximum compatibility.
+    // Scan forward for the opener, skipping anything else. Undecodable
+    // instructions are skipped too.
     loop {
         match instructions.next() {
             None => return Err(EnvelopeParseError::MissingOpFalse),
-            Some(Ok(Instruction::Op(op))) if op == OP_FALSE => break,
-            Some(Ok(Instruction::Op(op))) if op == OP_0 => break,
-            Some(Ok(Instruction::PushBytes(bytes))) if bytes.as_bytes().is_empty() => break,
+            Some(Ok(instruction)) if is_envelope_opener(&instruction) => break,
             _ => continue,
         }
     }
 
     // Verify OP_FALSE is followed by OP_IF
-    if next_op(instructions) != Some(OP_IF) {
-        return Err(EnvelopeParseError::MissingOpIf);
-    }
+    expect_op_if(instructions)?;
     Ok(())
 }
 
-/// Extracts payload data from push instructions until `OP_ENDIF`.
-fn extract_until_op_endif(
-    instructions: &mut Instructions<'_>,
-) -> Result<Vec<u8>, EnvelopeParseError> {
-    let mut payload_data = Vec::new();
-    let mut found_endif = false;
+/// Whether an instruction opens an envelope.
+///
+/// `OP_FALSE` pushes an empty byte array, so a decoded script usually presents
+/// the opener as an empty push; the `OP_FALSE` and `OP_0` opcode forms are
+/// accepted too. Shared by the lenient and strict parsers.
+fn is_envelope_opener(instruction: &Instruction<'_>) -> bool {
+    match instruction {
+        Instruction::Op(op) => *op == OP_FALSE || *op == OP_0,
+        Instruction::PushBytes(bytes) => bytes.as_bytes().is_empty(),
+    }
+}
 
-    for instruction_result in instructions {
-        match instruction_result {
-            Ok(Instruction::Op(op)) if op == OP_ENDIF => {
-                found_endif = true;
-                break;
+/// Reads the pubkey push opening a signed leaf, unvalidated — length is the
+/// caller's policy ([`SIGNED_LEAF_PUBKEY_LEN`] for a signed leaf).
+///
+/// Kept separate from [`expect_checksig`] so the length check falls between the
+/// two: a bare envelope's `OP_FALSE` arrives here as a zero-length push, so the
+/// strict parser reports an invalid pubkey rather than a missing checksig.
+///
+/// # Errors
+///
+/// [`EnvelopeParseError::MissingPubkey`] if the next instruction is not a push.
+fn read_pubkey_push<'a>(
+    instructions: &mut Instructions<'a>,
+) -> Result<&'a [u8], EnvelopeParseError> {
+    match next_instruction(instructions)? {
+        Some(Instruction::PushBytes(bytes)) => Ok(bytes.as_bytes()),
+        _ => Err(EnvelopeParseError::MissingPubkey),
+    }
+}
+
+/// Consumes the `OP_CHECKSIG` guarding a container's pubkey.
+///
+/// # Errors
+///
+/// Returns [`EnvelopeParseError::MissingChecksig`] if the next instruction is
+/// anything else.
+fn expect_checksig(instructions: &mut Instructions<'_>) -> Result<(), EnvelopeParseError> {
+    match next_instruction(instructions)? {
+        Some(Instruction::Op(op)) if op == OP_CHECKSIG => Ok(()),
+        _ => Err(EnvelopeParseError::MissingChecksig),
+    }
+}
+
+/// Consumes the `OP_IF` that must follow an envelope opener.
+///
+/// # Errors
+///
+/// Returns [`EnvelopeParseError::MissingOpIf`] if the next instruction is
+/// anything else.
+fn expect_op_if(instructions: &mut Instructions<'_>) -> Result<(), EnvelopeParseError> {
+    match next_instruction(instructions)? {
+        Some(Instruction::Op(op)) if op == OP_IF => Ok(()),
+        _ => Err(EnvelopeParseError::MissingOpIf),
+    }
+}
+
+/// Concatenates payload pushes until `OP_ENDIF`.
+///
+/// `max` bounds the accumulated payload. Callers with no bound of their own
+/// pass [`usize::MAX`].
+///
+/// # Errors
+///
+/// Returns [`EnvelopeParseError::UnexpectedOpcodeInPayload`] for a non-push
+/// instruction before `OP_ENDIF`, [`EnvelopeParseError::MissingOpEndif`] if the
+/// script ends first, or [`EnvelopeParseError::PayloadTooLarge`] if the payload
+/// exceeds `max`.
+fn read_payload_until_endif(
+    instructions: &mut Instructions<'_>,
+    max: usize,
+) -> Result<Vec<u8>, EnvelopeParseError> {
+    let mut payload = Vec::new();
+
+    loop {
+        match next_instruction(instructions)? {
+            Some(Instruction::Op(op)) if op == OP_ENDIF => return Ok(payload),
+            Some(Instruction::PushBytes(bytes)) => {
+                payload.extend_from_slice(bytes.as_bytes());
+                if payload.len() > max {
+                    return Err(EnvelopeParseError::PayloadTooLarge {
+                        total_size: payload.len(),
+                        max,
+                    });
+                }
             }
-            Ok(Instruction::PushBytes(bytes)) => {
-                payload_data.extend_from_slice(bytes.as_bytes());
+            Some(Instruction::Op(_)) => {
+                return Err(EnvelopeParseError::UnexpectedOpcodeInPayload);
             }
-            _ => return Err(EnvelopeParseError::UnexpectedOpcodeInPayload),
+            None => return Err(EnvelopeParseError::MissingOpEndif),
         }
     }
-
-    if !found_endif {
-        return Err(EnvelopeParseError::MissingOpEndif);
-    }
-
-    Ok(payload_data)
 }
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::Opcode;
+    use bitcoin::blockdata::script::Builder;
+    use bitcoin::constants::MAX_SCRIPT_ELEMENT_SIZE;
+    use bitcoin::opcodes::OP_TRUE;
+    use bitcoin::opcodes::all::{OP_ADD, OP_DROP, OP_NOT};
+    use bitcoin::script::PushBytesBuf;
+
     use super::*;
     use crate::builder::{EnvelopeScriptBuilder, MIN_ENVELOPE_PAYLOAD_SIZE, build_envelope_script};
 
@@ -177,31 +307,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_envelope_container() {
-        let pubkey = vec![0x02; 33];
-        let payload1 = vec![1; MIN_ENVELOPE_PAYLOAD_SIZE / 2];
-        let payload2 = vec![2; MIN_ENVELOPE_PAYLOAD_SIZE / 2];
-        let payloads = vec![payload1.clone(), payload2.clone()];
-
-        let script = EnvelopeScriptBuilder::with_pubkey(&pubkey)
-            .unwrap()
-            .add_envelope(&payload1)
-            .unwrap()
-            .add_envelope(&payload2)
-            .unwrap()
-            .build()
-            .unwrap();
-        let (extracted_pubkey, extracted_payloads) = parse_envelope_container(&script).unwrap();
-
-        assert_eq!(extracted_pubkey, pubkey);
-        assert_eq!(extracted_payloads, payloads);
-    }
-
-    #[test]
-    fn test_parse_single_envelope_in_container() {
-        let pubkey = vec![0x03; 33];
+    fn test_parse_envelope_container_accepts_one_signed_leaf() {
+        let pubkey = vec![0x02; SIGNED_LEAF_PUBKEY_LEN];
         let payload = vec![9; MIN_ENVELOPE_PAYLOAD_SIZE];
-        let payloads = vec![payload.clone()];
 
         let script = EnvelopeScriptBuilder::with_pubkey(&pubkey)
             .unwrap()
@@ -212,7 +320,46 @@ mod tests {
         let (extracted_pubkey, extracted_payloads) = parse_envelope_container(&script).unwrap();
 
         assert_eq!(extracted_pubkey, pubkey);
-        assert_eq!(extracted_payloads, payloads);
+        assert_eq!(extracted_payloads, vec![payload]);
+    }
+
+    /// The container delegates the pubkey-length check to the strict leaf
+    /// parser, so a non-32-byte key is rejected.
+    #[test]
+    fn test_parse_envelope_container_rejects_non_32_byte_pubkey() {
+        let long_key = vec![0x03; 33];
+        let payload = vec![9; MIN_ENVELOPE_PAYLOAD_SIZE];
+        let script = EnvelopeScriptBuilder::with_pubkey(&long_key)
+            .unwrap()
+            .add_envelope(&payload)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            parse_envelope_container(&script),
+            Err(EnvelopeParseError::InvalidPubkeyLength { found: 33, .. })
+        ));
+    }
+
+    /// The container adapter must reject the checksig bypass class on a valid
+    /// 32-byte key — an `OP_NOT` that inverts the result, or a trailing
+    /// `OP_DROP OP_TRUE` that discards it — since ASM checkpoint extraction calls
+    /// this API.
+    #[test]
+    fn test_parse_envelope_container_rejects_checksig_bypass() {
+        let inverted = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_NOT, OP_FALSE, OP_IF, OP_ENDIF]);
+        assert!(matches!(
+            parse_envelope_container(&inverted),
+            Err(EnvelopeParseError::MissingOpFalse)
+        ));
+
+        let overridden =
+            build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF, OP_ENDIF, OP_DROP, OP_TRUE]);
+        assert!(matches!(
+            parse_envelope_container(&overridden),
+            Err(EnvelopeParseError::UnexpectedTrailingInstructions)
+        ));
     }
 
     #[test]
@@ -288,12 +435,15 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_envelope_accepts_all_op_false_forms() {
+    fn test_parse_envelope_accepts_op_false_as_empty_push() {
         use bitcoin::blockdata::script;
         use bitcoin::opcodes::OP_FALSE;
         use bitcoin::opcodes::all::{OP_ENDIF, OP_IF};
 
         let payload_data = [1u8, 2, 3, 4, 5];
+
+        // OP_FALSE, OP_0, and OP_PUSHBYTES_0 all encode to 0x00 and decode as an
+        // empty push, so both these constructions produce the same opener.
 
         // Test 1: OP_FALSE from builder (encoded as OP_PUSHBYTES_0)
         let script1 = script::Builder::new()
@@ -317,7 +467,347 @@ mod tests {
         let result2 = parse_envelope_payload(&script2).unwrap();
         assert_eq!(result2, payload_data);
 
-        // All forms should produce the same result
+        // Both encodings decode to the same empty-push opener.
         assert_eq!(result1, result2);
+    }
+
+    // Strict signed envelope leaf parser.
+
+    const TEST_PUBKEY: [u8; SIGNED_LEAF_PUBKEY_LEN] = [7u8; SIGNED_LEAF_PUBKEY_LEN];
+
+    /// Builds the canonical signed leaf shape the production writer emits.
+    fn build_signed_leaf(payload: &[u8]) -> ScriptBuf {
+        EnvelopeScriptBuilder::with_pubkey(&TEST_PUBKEY)
+            .expect("pubkey accepted")
+            .add_envelope(payload)
+            .expect("payload accepted")
+            .build_without_min_check()
+            .expect("build succeeds")
+    }
+
+    /// Builds `<pubkey> OP_CHECKSIG` followed by the given opcodes, for leaves
+    /// that deviate from the strict shape after the signature prefix.
+    fn build_leaf_with_opcodes(pubkey: &[u8], opcodes: &[Opcode]) -> ScriptBuf {
+        let mut builder = Builder::new()
+            .push_slice(PushBytesBuf::try_from(pubkey.to_vec()).expect("pubkey push"))
+            .push_opcode(OP_CHECKSIG);
+        for opcode in opcodes {
+            builder = builder.push_opcode(*opcode);
+        }
+        builder.into_script()
+    }
+
+    #[test]
+    fn test_strict_leaf_round_trips() {
+        let payload = vec![9u8; 300];
+
+        let leaf = parse_signed_envelope_leaf(&build_signed_leaf(&payload)).expect("valid leaf");
+
+        assert_eq!(leaf.pubkey(), &TEST_PUBKEY);
+        assert_eq!(leaf.payload(), payload);
+    }
+
+    #[test]
+    fn test_strict_leaf_concatenates_multi_push_payload() {
+        // 1200 bytes spans three pushes at the 520-byte element limit.
+        let payload: Vec<u8> = (0..1200).map(|i| (i % 251) as u8).collect();
+
+        let leaf = parse_signed_envelope_leaf(&build_signed_leaf(&payload)).expect("valid leaf");
+
+        assert_eq!(leaf.payload(), payload);
+    }
+
+    /// The builder's 126-byte minimum is a writer-side efficiency rule. The
+    /// read path must not inherit it: DA reveals intentionally carry smaller
+    /// chunks through builders that bypass the minimum.
+    #[test]
+    fn test_strict_leaf_accepts_payload_below_builder_minimum() {
+        let payload = vec![1u8; 5];
+        assert!(payload.len() < MIN_ENVELOPE_PAYLOAD_SIZE);
+
+        let leaf = parse_signed_envelope_leaf(&build_signed_leaf(&payload)).expect("valid leaf");
+
+        assert_eq!(leaf.payload(), payload);
+    }
+
+    #[test]
+    fn test_strict_leaf_accepts_empty_payload() {
+        let leaf = parse_signed_envelope_leaf(&build_signed_leaf(&[])).expect("valid leaf");
+
+        assert!(leaf.payload().is_empty());
+    }
+
+    /// Under BIP342 a pubkey that is neither empty nor 32 bytes is an unknown
+    /// key type, for which `OP_CHECKSIG` succeeds without verifying any
+    /// signature. Accepting one would void the leaf's authentication.
+    #[test]
+    fn test_strict_leaf_rejects_non_32_byte_pubkey() {
+        for len in [0usize, 1, 31, 33, 65] {
+            let script = build_leaf_with_opcodes(&vec![2u8; len], &[OP_FALSE, OP_IF, OP_ENDIF]);
+
+            let error = parse_signed_envelope_leaf(&script)
+                .expect_err("non-32-byte pubkey must be rejected");
+
+            assert!(
+                matches!(
+                    error,
+                    EnvelopeParseError::InvalidPubkeyLength {
+                        expected: SIGNED_LEAF_PUBKEY_LEN,
+                        found: got
+                    } if got == len
+                ),
+                "pubkey length {len} produced {error:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_strict_leaf_accepts_exactly_32_byte_pubkey() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF, OP_ENDIF]);
+
+        let leaf = parse_signed_envelope_leaf(&script).expect("32-byte pubkey accepted");
+
+        assert_eq!(leaf.pubkey(), &TEST_PUBKEY);
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_leading_opcode() {
+        let script = bitcoin::blockdata::script::Builder::new()
+            .push_opcode(OP_TRUE)
+            .push_slice(TEST_PUBKEY)
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_opcode(OP_ENDIF)
+            .into_script();
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("leading opcode must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingPubkey));
+    }
+
+    /// A bare `OP_FALSE OP_IF ... OP_ENDIF` leaf, which the lenient parsers
+    /// accept and which carries no signature commitment at all.
+    #[test]
+    fn test_strict_leaf_rejects_bare_envelope() {
+        let script = bitcoin::blockdata::script::Builder::new()
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_slice([1u8, 2, 3])
+            .push_opcode(OP_ENDIF)
+            .into_script();
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("bare envelope must be rejected");
+
+        // The empty push standing in for OP_FALSE reads as a 0-byte pubkey.
+        assert!(matches!(
+            error,
+            EnvelopeParseError::InvalidPubkeyLength { found: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_missing_checksig() {
+        let script = bitcoin::blockdata::script::Builder::new()
+            .push_slice(TEST_PUBKEY)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .push_opcode(OP_ENDIF)
+            .into_script();
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("missing checksig must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingChecksig));
+    }
+
+    /// `OP_CHECKSIG OP_NOT` inverts the check, making the leaf spendable
+    /// precisely when the signature is invalid.
+    #[test]
+    fn test_strict_leaf_rejects_checksig_inversion() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_NOT, OP_FALSE, OP_IF, OP_ENDIF]);
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("checksig inversion must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingOpFalse));
+    }
+
+    /// `OP_ENDIF OP_DROP OP_TRUE` discards the signature check result.
+    #[test]
+    fn test_strict_leaf_rejects_checksig_override() {
+        let script =
+            build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF, OP_ENDIF, OP_DROP, OP_TRUE]);
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("checksig override must be rejected");
+
+        assert!(matches!(
+            error,
+            EnvelopeParseError::UnexpectedTrailingInstructions
+        ));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_junk_before_op_false() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_DROP, OP_FALSE, OP_IF, OP_ENDIF]);
+
+        let error = parse_signed_envelope_leaf(&script).expect_err("junk must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingOpFalse));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_missing_op_if() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_ENDIF]);
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("missing OP_IF must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingOpIf));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_missing_op_endif() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF]);
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("missing OP_ENDIF must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingOpEndif));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_non_push_in_body() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF, OP_ADD, OP_ENDIF]);
+
+        let error = parse_signed_envelope_leaf(&script).expect_err("body opcode must be rejected");
+
+        assert!(matches!(
+            error,
+            EnvelopeParseError::UnexpectedOpcodeInPayload
+        ));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_trailing_opcode() {
+        let script = build_leaf_with_opcodes(&TEST_PUBKEY, &[OP_FALSE, OP_IF, OP_ENDIF, OP_TRUE]);
+
+        let error = parse_signed_envelope_leaf(&script).expect_err("trailing op must be rejected");
+
+        assert!(matches!(
+            error,
+            EnvelopeParseError::UnexpectedTrailingInstructions
+        ));
+    }
+
+    /// SPS-53 allows exactly one chunk per reveal. The lenient parser returns
+    /// the first envelope and silently drops the second.
+    #[test]
+    fn test_strict_leaf_rejects_second_envelope() {
+        let script = EnvelopeScriptBuilder::with_pubkey(&TEST_PUBKEY)
+            .expect("pubkey accepted")
+            .add_envelope(&[1u8; 10])
+            .expect("first payload accepted")
+            .add_envelope(&[2u8; 10])
+            .expect("second payload accepted")
+            .build_without_min_check()
+            .expect("build succeeds");
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("second envelope must be rejected");
+
+        assert!(matches!(
+            error,
+            EnvelopeParseError::UnexpectedTrailingInstructions
+        ));
+    }
+
+    /// The parser's own allocation bound on untrusted L1 input. It cannot be
+    /// reached through `EnvelopeScriptBuilder`, which rejects an oversized
+    /// payload at build time, so the script is assembled by hand.
+    #[test]
+    fn test_strict_leaf_rejects_payload_over_maximum() {
+        let oversized = MAX_ENVELOPE_PAYLOAD_SIZE + 1;
+
+        let mut builder = Builder::new()
+            .push_slice(TEST_PUBKEY)
+            .push_opcode(OP_CHECKSIG)
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF);
+        let mut remaining = oversized;
+        while remaining > 0 {
+            let chunk = remaining.min(MAX_SCRIPT_ELEMENT_SIZE);
+            builder = builder.push_slice(
+                PushBytesBuf::try_from(vec![0u8; chunk]).expect("chunk within push limit"),
+            );
+            remaining -= chunk;
+        }
+        let script = builder.push_opcode(OP_ENDIF).into_script();
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("oversized payload must be rejected");
+
+        assert!(
+            matches!(
+                error,
+                EnvelopeParseError::PayloadTooLarge {
+                    total_size,
+                    max: MAX_ENVELOPE_PAYLOAD_SIZE
+                } if total_size > MAX_ENVELOPE_PAYLOAD_SIZE
+            ),
+            "got {error:?}"
+        );
+    }
+
+    /// The bound is inclusive: a payload of exactly the maximum is valid.
+    #[test]
+    fn test_strict_leaf_accepts_payload_at_maximum() {
+        let leaf =
+            parse_signed_envelope_leaf(&build_signed_leaf(&vec![0u8; MAX_ENVELOPE_PAYLOAD_SIZE]))
+                .expect("payload at maximum is valid");
+
+        assert_eq!(leaf.payload().len(), MAX_ENVELOPE_PAYLOAD_SIZE);
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_empty_script() {
+        let error = parse_signed_envelope_leaf(&ScriptBuf::new())
+            .expect_err("empty script must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MissingPubkey));
+    }
+
+    #[test]
+    fn test_strict_leaf_rejects_undecodable_script() {
+        // PUSHBYTES_5 with only one byte of data following it.
+        let script = ScriptBuf::from_bytes(vec![0x05, 0x01]);
+
+        let error =
+            parse_signed_envelope_leaf(&script).expect_err("undecodable script must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MalformedScript));
+    }
+
+    /// Sharing the payload loop routes the lenient parsers through
+    /// `next_instruction`, so a truncated push inside an envelope is reported
+    /// as a malformed script rather than as an unexpected opcode, which it is
+    /// not. Still a rejection either way.
+    #[test]
+    fn test_lenient_payload_reports_undecodable_push_as_malformed() {
+        let mut bytes = Builder::new()
+            .push_opcode(OP_FALSE)
+            .push_opcode(OP_IF)
+            .into_script()
+            .to_bytes();
+        // PUSHBYTES_5 announcing more data than the script carries.
+        bytes.extend_from_slice(&[0x05, 0x01]);
+        let script = ScriptBuf::from_bytes(bytes);
+
+        let error = parse_envelope_payload(&script).expect_err("truncated push must be rejected");
+
+        assert!(matches!(error, EnvelopeParseError::MalformedScript));
     }
 }


### PR DESCRIPTION
## Description

Adds shared SPS-53 commit/reveal format support to `strata-common`.

- **`strata-l1-envelope-fmt`**: adds a strict signed-envelope leaf parser (`parse_signed_envelope_leaf` → `SignedEnvelopeLeaf`) and a matching builder. The lenient parsers (`parse_envelope_payload`, `parse_multi_envelope_payloads`) remain for scan-forward, data-carrying scripts.
- **`strata-l1-commit-reveal-fmt`** (new crate): SPS-53 commit/reveal script building (`OP_RETURN` marker + one signed reveal leaf per chunk) and reading — single-set payload extraction for the closed-witness (guest) path, plus stateless, consumer-neutral **grouping helpers** for host scanners: classify a commit candidate, assign a reveal to the commit whose slot it spends, and extract a grouped commit's payload. The caller owns block iteration, accumulation, reorg, and telemetry; marker-tail (version) and key checks stay with the caller.
- **`test-utils`**: optional fixtures for downstream crates that need commit/reveal transaction shapes in tests.

The strict parser accepts only `<pubkey> OP_CHECKSIG OP_FALSE OP_IF <payload pushes> OP_ENDIF`, so a confirmed reveal spend is evidence the pubkey holder signed — no later opcode can invert the `OP_CHECKSIG` result.

### Breaking changes (`strata-l1-envelope-fmt`)

- `EnvelopeParseError::MissingChecksigverify` renamed to `MissingChecksig`.
- `parse_envelope_container` now enforces the strict single-leaf grammar (delegates to `parse_signed_envelope_leaf`); callers needing lenient extraction should use `parse_envelope_payload` / `parse_multi_envelope_payloads`.

This PR was created with help from Claude and Codex.

### Testing
Tested the use of the shared crate in `alpen`: `alpen-ee/da/l1-extraction` (WIP), `btcio/src/writer/chunked_envelope/builder` and `alpen-ee/da/runtime/src/verification/`. WIP in `STR-4059` branch of `alpen`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers
The commit-reveal builder keeps two entry points on purpose: `build_commit_reveal_scripts` (splits a payload into chunks at build time) and `build_commit_reveal_scripts_from_chunks` (one reveal leaf per supplied chunk, no re-split). The EE DA provider in `alpen` persists `ChunkedEnvelopeEntry`, which the L1 writer reads. It must build reveal leaves using the stored chunks.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

[STR-4058](https://alpenlabs.atlassian.net/browse/STR-4058)

[STR-4058]: https://alpenlabs.atlassian.net/browse/STR-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ