### PR TITLE
feat(ssz): add delegate ref view for generated schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,8 +2938,8 @@ dependencies = [
 
 [[package]]
 name = "sizzle-parser"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "thiserror 2.0.19",
 ]
@@ -3575,8 +3575,8 @@ dependencies = [
 
 [[package]]
 name = "ssz"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "hex",
  "itertools 0.15.0",
@@ -3588,8 +3588,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_codegen"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -3608,8 +3608,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_derive"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "darling",
  "quote",
@@ -3618,8 +3618,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_primitives"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "hex",
  "rand 0.8.7",
@@ -3628,8 +3628,8 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "itertools 0.15.0",
  "serde",
@@ -3959,7 +3959,13 @@ version = "0.1.0"
 dependencies = [
  "proptest",
  "ssz",
+ "ssz_codegen",
+ "ssz_derive",
+ "ssz_primitives",
+ "ssz_types",
+ "strata-identifiers",
  "tree_hash",
+ "tree_hash_derive",
 ]
 
 [[package]]
@@ -4561,8 +4567,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "digest",
  "sha2",
@@ -4574,8 +4580,8 @@ dependencies = [
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.17.0"
-source = "git+https://github.com/alpenlabs/ssz-gen?tag=v0.17.0#9e33fe8a5cafea88058c0e28dd7ef8b6716352bf"
+version = "0.17.1"
+source = "git+https://github.com/alpenlabs/ssz-gen?branch=feat%2Fsupport-delegates#092550dca946af20e2deb822dbef2b493f78901d"
 dependencies = [
  "darling",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,13 @@ strata-ssz-tests = { path = "crates/ssz-tests" }
 strata-tasks = { path = "crates/tasks" }
 
 # SSZ dependencies
-ssz = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-ssz_codegen = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-ssz_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-ssz_primitives = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-ssz_types = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-tree_hash = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
-tree_hash_derive = { git = "https://github.com/alpenlabs/ssz-gen", tag = "v0.17.0" }
+ssz = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+ssz_codegen = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+ssz_derive = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+ssz_primitives = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+ssz_types = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+tree_hash = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
+tree_hash_derive = { git = "https://github.com/alpenlabs/ssz-gen", branch = "feat/support-delegates" }
 
 # External dependencies
 anyhow = "1"

--- a/crates/btc-types/src/btc.rs
+++ b/crates/btc-types/src/btc.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
 use ssz_derive::{Decode, Encode};
 use strata_codec::{Codec, CodecError, Decoder, Encoder};
-use strata_identifiers::{Buf32, SszDelegate, impl_ssz_transparent_wrapper, impl_ssz_via_delegate};
+use strata_identifiers::{
+    Buf32, SszDelegate, SszDelegateRef, impl_ssz_transparent_wrapper, impl_ssz_via_delegate,
+};
 
 use crate::ParseError;
 use crate::ssz_generated::ssz::btc::{
@@ -71,6 +73,9 @@ impl SszDelegate for BitcoinOutPoint {
 }
 
 impl_ssz_via_delegate!(BitcoinOutPoint);
+
+/// SSZ view naming `BitcoinOutPoint` for an `external_kind: container` field.
+pub type BitcoinOutPointRef<'a> = SszDelegateRef<'a, BitcoinOutPoint>;
 
 impl From<OutPoint> for BitcoinOutPoint {
     fn from(value: OutPoint) -> Self {
@@ -272,6 +277,9 @@ impl SszDelegate for BitcoinAmount {
 
 impl_ssz_via_delegate!(BitcoinAmount);
 
+/// SSZ view naming [`BitcoinAmount`] for an `external_kind: container` field.
+pub type BitcoinAmountRef<'a> = SszDelegateRef<'a, BitcoinAmount>;
+
 /// [Borsh](borsh)-friendly Bitcoin [`Txid`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BitcoinTxid(Txid);
@@ -291,6 +299,9 @@ impl SszDelegate for BitcoinTxid {
 }
 
 impl_ssz_via_delegate!(BitcoinTxid);
+
+/// SSZ view naming `BitcoinTxid` for an `external_kind: container` field.
+pub type BitcoinTxidRef<'a> = SszDelegateRef<'a, BitcoinTxid>;
 
 impl From<Txid> for BitcoinTxid {
     fn from(value: Txid) -> Self {
@@ -420,6 +431,9 @@ impl SszDelegate for BitcoinTxOut {
 }
 
 impl_ssz_via_delegate!(BitcoinTxOut);
+
+/// SSZ view naming [`BitcoinTxOut`] for an `external_kind: container` field.
+pub type BitcoinTxOutRef<'a> = SszDelegateRef<'a, BitcoinTxOut>;
 
 impl BitcoinTxOut {
     /// Returns a reference to the inner [`TxOut`].
@@ -730,6 +744,9 @@ impl SszDelegate for BitcoinScriptBuf {
 }
 
 impl_ssz_via_delegate!(BitcoinScriptBuf);
+
+/// SSZ view naming `BitcoinScriptBuf` for an `external_kind: container` field.
+pub type BitcoinScriptBufRef<'a> = SszDelegateRef<'a, BitcoinScriptBuf>;
 
 impl BitcoinScriptBuf {
     /// Returns a reference to the inner [`ScriptBuf`].

--- a/crates/btc-types/src/params.rs
+++ b/crates/btc-types/src/params.rs
@@ -4,7 +4,7 @@ use bitcoin::params::{MAINNET, Params};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
-use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
+use strata_identifiers::{SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
 
 /// Wrapper around Bitcoin consensus [`Params`] with serialization support.
 #[derive(Debug, Clone)]
@@ -58,6 +58,9 @@ impl SszDelegate for BtcParams {
 }
 
 impl_ssz_via_delegate!(BtcParams);
+
+/// SSZ view naming [`BtcParams`] for an `external_kind: container` field.
+pub type BtcParamsRef<'a> = SszDelegateRef<'a, BtcParams>;
 
 impl PartialEq for BtcParams {
     fn eq(&self, other: &Self) -> bool {

--- a/crates/crypto/src/keys/compressed.rs
+++ b/crates/crypto/src/keys/compressed.rs
@@ -8,7 +8,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use secp256k1::{Error, PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
-use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
+use strata_identifiers::{SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
 
 /// A compressed secp256k1 public key (33 bytes).
 ///
@@ -41,6 +41,9 @@ impl SszDelegate for CompressedPublicKey {
 }
 
 impl_ssz_via_delegate!(CompressedPublicKey);
+
+/// SSZ view naming [`CompressedPublicKey`] for an `external_kind: container` field.
+pub type CompressedPublicKeyRef<'a> = SszDelegateRef<'a, CompressedPublicKey>;
 
 impl CompressedPublicKey {
     /// Create a new `CompressedPublicKey` from a byte slice.

--- a/crates/crypto/src/keys/even.rs
+++ b/crates/crypto/src/keys/even.rs
@@ -13,7 +13,7 @@ use secp256k1::{Parity, PublicKey, SECP256K1, SecretKey, XOnlyPublicKey};
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
-use strata_identifiers::{Buf32, SszDelegate, impl_ssz_via_delegate};
+use strata_identifiers::{Buf32, SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
 
 /// Represents a secret key whose x-only public key has even parity.
 ///
@@ -75,6 +75,9 @@ impl SszDelegate for EvenPublicKey {
 }
 
 impl_ssz_via_delegate!(EvenPublicKey);
+
+/// SSZ view naming [`EvenPublicKey`] for an `external_kind: container` field.
+pub type EvenPublicKeyRef<'a> = SszDelegateRef<'a, EvenPublicKey>;
 
 impl Deref for EvenPublicKey {
     type Target = PublicKey;

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -28,10 +28,12 @@ pub mod test_utils;
 pub mod threshold_signature;
 
 // Re-export even parity key types
-pub use keys::even::{EvenPublicKey, EvenSecretKey, even_kp};
+pub use keys::compressed::{CompressedPublicKey, CompressedPublicKeyRef};
+pub use keys::even::{EvenPublicKey, EvenPublicKeyRef, EvenSecretKey, even_kp};
 // Re-export MuSig2 key aggregation
 pub use musig2::{Musig2Error, aggregate_schnorr_keys};
 pub use schnorr::*;
+pub use threshold_signature::*;
 
 #[cfg(test)]
 mod test_helpers;

--- a/crates/crypto/src/threshold_signature/indexed/config.rs
+++ b/crates/crypto/src/threshold_signature/indexed/config.rs
@@ -9,7 +9,7 @@ use serde::de::Error;
 use serde::{Deserialize, Serialize};
 use ssz::DecodeError;
 use ssz_primitives::FixedBytes;
-use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
+use strata_identifiers::{SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
 
 use super::ThresholdSignatureError;
 use crate::keys::compressed::CompressedPublicKey;
@@ -119,6 +119,9 @@ impl SszDelegate for ThresholdConfig {
 }
 
 impl_ssz_via_delegate!(ThresholdConfig);
+
+/// SSZ view naming [`ThresholdConfig`] for an `external_kind: container` field.
+pub type ThresholdConfigRef<'a> = SszDelegateRef<'a, ThresholdConfig>;
 
 impl ThresholdConfig {
     /// Create a new threshold configuration.
@@ -382,6 +385,9 @@ impl SszDelegate for ThresholdConfigUpdate {
 }
 
 impl_ssz_via_delegate!(ThresholdConfigUpdate);
+
+/// SSZ view naming [`ThresholdConfigUpdate`] for an `external_kind: container` field.
+pub type ThresholdConfigUpdateRef<'a> = SszDelegateRef<'a, ThresholdConfigUpdate>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/crypto/src/threshold_signature/indexed/mod.rs
+++ b/crates/crypto/src/threshold_signature/indexed/mod.rs
@@ -9,7 +9,10 @@ mod errors;
 mod signature;
 mod verification;
 
-pub use config::{MAX_SIGNERS, ThresholdConfig, ThresholdConfigUpdate};
+pub use config::{
+    MAX_SIGNERS, ThresholdConfig, ThresholdConfigRef, ThresholdConfigUpdate,
+    ThresholdConfigUpdateRef,
+};
 pub use errors::ThresholdSignatureError;
-pub use signature::{IndexedSignature, SignatureSet};
+pub use signature::{IndexedSignature, IndexedSignatureRef, SignatureSet, SignatureSetRef};
 pub use verification::verify_threshold_signatures;

--- a/crates/crypto/src/threshold_signature/indexed/signature.rs
+++ b/crates/crypto/src/threshold_signature/indexed/signature.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ssz::DecodeError;
 use ssz_primitives::FixedBytes;
-use strata_identifiers::{SszDelegate, impl_ssz_via_delegate};
+use strata_identifiers::{SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
 
 use super::ThresholdSignatureError;
 use crate::ssz_generated::ssz::threshold::{IndexedSignatureSsz, SignatureSetSsz};
@@ -108,6 +108,9 @@ impl SszDelegate for IndexedSignature {
 
 impl_ssz_via_delegate!(IndexedSignature);
 
+/// SSZ view naming [`IndexedSignature`] for an `external_kind: container` field.
+pub type IndexedSignatureRef<'a> = SszDelegateRef<'a, IndexedSignature>;
+
 /// A set of indexed ECDSA signatures for threshold verification.
 ///
 /// Signatures are guaranteed duplicate-free.
@@ -146,6 +149,9 @@ impl SszDelegate for SignatureSet {
 }
 
 impl_ssz_via_delegate!(SignatureSet);
+
+/// SSZ view naming [`SignatureSet`] for an `external_kind: container` field.
+pub type SignatureSetRef<'a> = SszDelegateRef<'a, SignatureSet>;
 
 impl SignatureSet {
     /// Create a new signature set from a vector of indexed signatures.

--- a/crates/crypto/src/threshold_signature/mod.rs
+++ b/crates/crypto/src/threshold_signature/mod.rs
@@ -8,6 +8,7 @@ pub mod indexed;
 
 // Re-export commonly used types from indexed
 pub use indexed::{
-    IndexedSignature, SignatureSet, ThresholdConfig, ThresholdConfigUpdate,
-    ThresholdSignatureError, verify_threshold_signatures,
+    IndexedSignature, IndexedSignatureRef, SignatureSet, SignatureSetRef, ThresholdConfig,
+    ThresholdConfigRef, ThresholdConfigUpdate, ThresholdConfigUpdateRef, ThresholdSignatureError,
+    verify_threshold_signatures,
 };

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -46,7 +46,7 @@ pub use exec::{EVMExtraPayload, EvmEeBlockCommitment, ExecBlockCommitment, Hash}
 pub use l1::L1BlockCommitmentRef;
 pub use l1::{L1BlockCommitment, L1BlockId, L1Height, WtxidsRoot};
 #[cfg(feature = "ssz")]
-pub use macros::ssz::SszDelegate;
+pub use macros::ssz::{SszDelegate, SszDelegateRef};
 #[cfg(feature = "ssz")]
 pub use ol::OLBlockCommitmentRef;
 pub use ol::{Epoch, L2BlockCommitment, L2BlockId, OLBlockCommitment, OLBlockId, OLTxId, Slot};

--- a/crates/identifiers/src/macros/ssz.rs
+++ b/crates/identifiers/src/macros/ssz.rs
@@ -1,26 +1,19 @@
-//! SSZ view trait macros for identifier and wrapper types.
+//! SSZ implementations for hand-written types used in ssz-gen schemas.
 //!
-//! These macros generate the boilerplate trait implementations (`DecodeView`,
-//! `SszTypeInfo`, `TreeHash`, `ToOwnedSsz`) that the SSZ view layer requires.
-//! Three macros are provided, each targeting a different structural pattern:
+//! ssz-gen emits `Encode`/`Decode`/`TreeHash` and a byte-backed `{Type}Ref` view
+//! only for types a schema declares. Types written in Rust get theirs from here.
 //!
-//! | Macro | Use when… |
-//! |---|---|
-//! | [`impl_ssz_fixed_container!`] | Multi-field struct with `#[ssz(struct_behaviour = "container")]` |
-//! | [`impl_ssz_transparent_wrapper!`] | Newtype whose inner type already implements `DecodeView` |
-//! | [`impl_ssz_transparent_byte_array_wrapper!`] | Newtype wrapping a raw `[u8; N]` (which lacks `DecodeView`) |
+//! ## Giving a type its SSZ impls
 //!
-//! ## Choosing the right macro
+//! - [`impl_ssz_fixed_container!`] — multi-field struct with `#[ssz(struct_behaviour =
+//!   "container")]`, all fields fixed-size.
+//! - [`impl_ssz_transparent_wrapper!`] — newtype whose inner type already implements `DecodeView`.
+//! - [`impl_ssz_transparent_byte_array_wrapper!`] — newtype wrapping a raw `[u8; N]`.
+//! - [`impl_ssz_via_delegate!`] — wrapper whose encoding is another SSZ type's, declared with
+//!   [`SszDelegate`].
 //!
-//! ```text
-//!  Is the type a multi-field container?
-//!    ├─ Yes → impl_ssz_fixed_container!
-//!    └─ No (newtype / transparent wrapper)
-//!         ├─ Inner type has DecodeView? (Buf32, RBuf32, u64, …)
-//!         │    └─ Yes → impl_ssz_transparent_wrapper!
-//!         └─ Inner type is [u8; N]?
-//!              └─ Yes → impl_ssz_transparent_byte_array_wrapper!
-//! ```
+//! Exactly one applies to a given type: they all emit `SszTypeInfo`/`TreeHash`,
+//! so combining two is a coherence error.
 //!
 //! The split between the two transparent-wrapper macros exists because `[u8; N]`
 //! does **not** implement `DecodeView` in the `ssz` crate — only
@@ -28,6 +21,12 @@
 //! the orphan rule prevents adding that impl locally, so
 //! `impl_ssz_transparent_byte_array_wrapper!` provides a manual `DecodeView`
 //! via `TryInto` plus `From` conversions with `FixedBytes<N>`.
+//!
+//! ## Naming a view for `external_kind: container`
+//!
+//! Such a field resolves to a `{Type}Ref<'a>` path. A delegate wrapper
+//! referenced that way aliases [`SszDelegateRef`]; the view comes from the
+//! delegate's own `SszHasView` link.
 
 /// Generates SSZ view trait implementations for a fixed-size container type.
 ///
@@ -35,7 +34,8 @@
 /// whose fields are all fixed-size. Generates:
 /// - `TreeHash` implementation
 /// - `SszTypeInfo` implementation (computes fixed size from field types)
-/// - A `{Type}Ref` view type with `DecodeView`, `SszTypeInfo`, `TreeHash`, and `ToOwnedSsz`
+/// - A `{Type}Ref` type with `DecodeView`, `SszTypeInfo`, `TreeHash`, and `ToOwnedSsz`, which
+///   decodes rather than borrowing
 ///
 /// The `{Type}Ref` name is auto-generated via [`paste`].
 ///
@@ -100,7 +100,12 @@ macro_rules! impl_ssz_fixed_container {
             }
 
             // Ref view type
-            /// SSZ zero-copy view reference for the parent type.
+            /// Adapts the parent type to the SSZ view interface.
+            ///
+            /// Decodes during `DecodeView::from_ssz_bytes` and holds the value;
+            /// it does not borrow the input. `'a` is present only because
+            /// ssz-gen resolves an `external_kind: container` field to a
+            /// `{Type}Ref<'a>` path.
             #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Default)]
             pub struct [<$type Ref>]<'a> {
                 inner: $type,
@@ -269,17 +274,128 @@ pub trait SszDelegate: Sized {
     fn from_delegate(delegate: Self::Delegate) -> Result<Self, ::ssz::DecodeError>;
 }
 
+/// The delegate's canonical view, as ssz-gen declares it.
+type DelegateView<'a, T> = <<T as SszDelegate>::Delegate as ::ssz_types::view::SszHasView>::Ref<'a>;
+
+/// Borrowed SSZ view over a delegate wrapper.
+///
+/// Holds the delegate's view and converts only on `ToOwnedSsz::try_to_owned`.
+// Not `Copy`: it would overlap `ssz_types`' `impl<T: Copy> ToOwnedSsz<T> for T`.
+pub struct SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    delegate: DelegateView<'a, T>,
+}
+
+impl<'a, T> SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    /// Returns the borrowed delegate view.
+    pub fn delegate_ref(&self) -> &DelegateView<'a, T> {
+        &self.delegate
+    }
+}
+
+impl<'a, T> ::core::clone::Clone for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+    DelegateView<'a, T>: ::core::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            delegate: ::core::clone::Clone::clone(&self.delegate),
+        }
+    }
+}
+
+impl<'a, T> ::core::fmt::Debug for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+    DelegateView<'a, T>: ::core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("SszDelegateRef")
+            .field("delegate", &self.delegate)
+            .finish()
+    }
+}
+
+impl<'a, T> ::ssz::view::DecodeView<'a> for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    fn from_ssz_bytes(bytes: &'a [u8]) -> Result<Self, ::ssz::DecodeError> {
+        Ok(Self {
+            delegate: <DelegateView<'a, T> as ::ssz::view::DecodeView<'a>>::from_ssz_bytes(bytes)?,
+        })
+    }
+}
+
+impl<'a, T> ::ssz::view::SszTypeInfo for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    fn is_ssz_fixed_len() -> bool {
+        <DelegateView<'a, T> as ::ssz::view::SszTypeInfo>::is_ssz_fixed_len()
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <DelegateView<'a, T> as ::ssz::view::SszTypeInfo>::ssz_fixed_len()
+    }
+}
+
+impl<'a, T> ::tree_hash::TreeHash for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    fn tree_hash_type() -> ::tree_hash::TreeHashType {
+        <DelegateView<'a, T> as ::tree_hash::TreeHash>::tree_hash_type()
+    }
+
+    fn tree_hash_packed_encoding(&self) -> ::tree_hash::PackedEncoding {
+        <DelegateView<'a, T> as ::tree_hash::TreeHash>::tree_hash_packed_encoding(&self.delegate)
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        <DelegateView<'a, T> as ::tree_hash::TreeHash>::tree_hash_packing_factor()
+    }
+
+    fn tree_hash_root<H: ::tree_hash::TreeHashDigest>(&self) -> H::Output {
+        <DelegateView<'a, T> as ::tree_hash::TreeHash>::tree_hash_root::<H>(&self.delegate)
+    }
+}
+
+impl<'a, T> ::ssz_types::view::ToOwnedSsz<T> for SszDelegateRef<'a, T>
+where
+    T: SszDelegate + 'a,
+    T::Delegate: ::ssz_types::view::SszHasView,
+{
+    fn to_owned(&self) -> T {
+        <Self as ::ssz_types::view::ToOwnedSsz<T>>::try_to_owned(self).expect("valid view")
+    }
+
+    fn try_to_owned(&self) -> Result<T, ::ssz::DecodeError> {
+        let delegate =
+            <DelegateView<'a, T> as ::ssz_types::view::ToOwnedSsz<T::Delegate>>::try_to_owned(
+                &self.delegate,
+            )?;
+        <T as SszDelegate>::from_delegate(delegate)
+    }
+}
+
 /// Generates [`ssz::Encode`], [`ssz::Decode`], and [`tree_hash::TreeHash`]
 /// implementations for a type that implements [`SszDelegate`], delegating the
 /// entire byte layout and merkleization to its
 /// [`Delegate`](SszDelegate::Delegate) type.
-///
-/// This is the "correct by construction" replacement for hand-written
-/// `Encode`/`Decode` impls: the wrapper supplies only the value-level conversion
-/// to/from a well-defined SSZ type via [`SszDelegate`], and this macro wires up
-/// the trait methods so the wrapper inherits the delegate's (spec-compliant)
-/// layout and tree-hash root verbatim. Because the tree hash is delegated too,
-/// the wrapper can be used as a field inside other SSZ containers.
 ///
 /// # Requirements
 ///

--- a/crates/ssz-tests/Cargo.toml
+++ b/crates/ssz-tests/Cargo.toml
@@ -2,12 +2,22 @@
 name = "strata-ssz-tests"
 version = "0.1.0"
 edition = "2024"
-description = "Property testing macros for SSZ-serializable types"
+description = "SSZ test support: property-testing macros, and codegen integration tests for delegate views"
 
 [dependencies]
 proptest.workspace = true
 ssz.workspace = true
 tree_hash.workspace = true
+
+# Used by the delegate codegen fixtures in `tests/`.
+ssz_derive.workspace = true
+ssz_primitives.workspace = true
+ssz_types.workspace = true
+strata-identifiers.workspace = true
+tree_hash_derive.workspace = true
+
+[build-dependencies]
+ssz_codegen.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ssz-tests/build.rs
+++ b/crates/ssz-tests/build.rs
@@ -1,0 +1,27 @@
+//! Build script generating the SSZ containers in `tests/ssz/delegate.ssz`.
+
+use std::path::Path;
+
+use ssz_codegen::{ModuleGeneration, build_ssz_files};
+
+fn main() {
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set by cargo");
+    let output_path = Path::new(&out_dir).join("generated_delegate_ssz.rs");
+
+    let entry_points = ["delegate.ssz"];
+    // No external crates: the schema's `import consumer` resolves to the
+    // integration test's own `consumer` module, which declares the wrappers and
+    // their view aliases.
+    let crates: [&str; 0] = [];
+
+    build_ssz_files(
+        &entry_points,
+        "tests/ssz/",
+        &crates,
+        output_path.to_str().expect("utf8 path"),
+        ModuleGeneration::NestedModules,
+    )
+    .expect("failed to generate delegate SSZ test types");
+
+    println!("cargo:rerun-if-changed=tests/ssz/delegate.ssz");
+}

--- a/crates/ssz-tests/src/lib.rs
+++ b/crates/ssz-tests/src/lib.rs
@@ -1,6 +1,8 @@
 //! Test utilities for SSZ types.
 //!
-//! This crate provides macros for property-based testing of SSZ-serializable types.
+//! [`ssz_proptest!`] covers encode/decode round-trips and tree-hash determinism.
+//! The delegate-view codegen fixtures live in `tests/`, which needs a
+//! compilation unit separate from the crates it exercises.
 
 #![allow(
     unused_crate_dependencies,

--- a/crates/ssz-tests/tests/delegate.rs
+++ b/crates/ssz-tests/tests/delegate.rs
@@ -1,0 +1,577 @@
+//! Stands in for a consumer crate that references delegate wrappers as external
+//! containers in an ssz-gen schema.
+//!
+//! The `consumer` module declares what such a crate writes: the wrappers, and
+//! the aliases naming their views. The view type is chosen by generated code, so
+//! this contract cannot be covered by a unit test inside `strata-identifiers`.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "dependencies are referenced by generated code"
+)]
+
+/// The declarations an adopting crate provides for its schema's external types.
+mod consumer {
+    use ssz::DecodeError;
+    use ssz_types::{BitList, FixedVector, Optional};
+    use strata_identifiers::{SszDelegate, SszDelegateRef, impl_ssz_via_delegate};
+
+    pub(crate) use crate::ssz_generated::tests::ssz::delegate::Choice;
+    use crate::ssz_generated::tests::ssz::delegate::{
+        BoundedListSsz, PairSsz, StableDelegateSsz, WideDelegateSsz,
+    };
+
+    /// Wrapper whose conversion happens to always succeed.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) struct Pair {
+        pub(crate) a: u64,
+        pub(crate) b: u32,
+    }
+
+    impl SszDelegate for Pair {
+        type Delegate = PairSsz;
+
+        fn into_delegate(self) -> Self::Delegate {
+            let Self { a, b } = self;
+            PairSsz { a, b }
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            let PairSsz { a, b } = delegate;
+            Ok(Self { a, b })
+        }
+    }
+
+    impl_ssz_via_delegate!(Pair);
+
+    pub(crate) type PairRef<'a> = SszDelegateRef<'a, Pair>;
+
+    /// Wrapper whose delegate is a raw `[u8; N]`, viewed as `FixedBytesRef`.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) struct Tag(pub(crate) [u8; 32]);
+
+    impl SszDelegate for Tag {
+        type Delegate = [u8; 32];
+
+        fn into_delegate(self) -> Self::Delegate {
+            self.0
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            Ok(Self(delegate))
+        }
+    }
+
+    impl_ssz_via_delegate!(Tag);
+
+    pub(crate) type TagRef<'a> = SszDelegateRef<'a, Tag>;
+
+    /// Refinement wrapper: only some `u64`s are valid amounts.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) struct CheckedAmount(u64);
+
+    impl CheckedAmount {
+        /// Largest accepted value.
+        pub(crate) const MAX: u64 = 100;
+
+        /// Builds a value, rejecting anything above [`MAX`](Self::MAX).
+        pub(crate) fn new(value: u64) -> Result<Self, DecodeError> {
+            if value <= Self::MAX {
+                Ok(Self(value))
+            } else {
+                Err(DecodeError::BytesInvalid(format!(
+                    "amount {value} exceeds {}",
+                    Self::MAX
+                )))
+            }
+        }
+    }
+
+    impl SszDelegate for CheckedAmount {
+        type Delegate = u64;
+
+        fn into_delegate(self) -> Self::Delegate {
+            self.0
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            Self::new(delegate)
+        }
+    }
+
+    impl_ssz_via_delegate!(CheckedAmount);
+
+    pub(crate) type CheckedAmountRef<'a> = SszDelegateRef<'a, CheckedAmount>;
+
+    /// Wrapper whose delegate is a container holding a bounded list, whose bound
+    /// the delegate's view checks only on field access.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub(crate) struct BoundedList(pub(crate) Vec<u8>);
+
+    impl SszDelegate for BoundedList {
+        type Delegate = BoundedListSsz;
+
+        fn into_delegate(self) -> Self::Delegate {
+            BoundedListSsz {
+                data: self.0.try_into().expect("within the list bound"),
+            }
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            Ok(Self(delegate.data.to_vec()))
+        }
+    }
+
+    impl_ssz_via_delegate!(BoundedList);
+
+    pub(crate) type BoundedListRef<'a> = SszDelegateRef<'a, BoundedList>;
+
+    /// Wrapper whose delegate is a `StableContainer` with `Optional` fields.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub(crate) struct StableDelegate {
+        pub(crate) a: Option<u64>,
+        pub(crate) bits: Option<Vec<bool>>,
+    }
+
+    impl SszDelegate for StableDelegate {
+        type Delegate = StableDelegateSsz;
+
+        fn into_delegate(self) -> Self::Delegate {
+            let bits = match self.bits {
+                Some(bits) => {
+                    let mut list =
+                        BitList::<32>::with_capacity(bits.len()).expect("within the bitlist bound");
+                    for (i, bit) in bits.iter().enumerate() {
+                        list.set(i, *bit).expect("index within capacity");
+                    }
+                    Optional::Some(list)
+                }
+                None => Optional::None,
+            };
+            StableDelegateSsz {
+                a: match self.a {
+                    Some(a) => Optional::Some(a),
+                    None => Optional::None,
+                },
+                b: bits,
+            }
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            Ok(Self {
+                a: match delegate.a {
+                    Optional::Some(a) => Some(a),
+                    Optional::None => None,
+                },
+                bits: match delegate.b {
+                    Optional::Some(list) => Some(list.iter().collect()),
+                    Optional::None => None,
+                },
+            })
+        }
+    }
+
+    impl_ssz_via_delegate!(StableDelegate);
+
+    pub(crate) type StableDelegateRef<'a> = SszDelegateRef<'a, StableDelegate>;
+
+    /// Wrapper whose delegate mixes a bitvector, a vector of containers, and a
+    /// union with a null arm.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub(crate) struct WideDelegate {
+        pub(crate) pairs: [Pair; 2],
+        pub(crate) marks: Vec<bool>,
+        pub(crate) tag: Choice,
+        pub(crate) choice: Option<u64>,
+    }
+
+    impl SszDelegate for WideDelegate {
+        type Delegate = WideDelegateSsz;
+
+        fn into_delegate(self) -> Self::Delegate {
+            WideDelegateSsz {
+                pairs: FixedVector::new(
+                    self.pairs
+                        .into_iter()
+                        .map(SszDelegate::into_delegate)
+                        .collect::<Vec<_>>(),
+                )
+                .expect("exactly two pairs"),
+                marks: {
+                    let mut list = BitList::<16>::with_capacity(self.marks.len())
+                        .expect("within the bitlist bound");
+                    for (i, mark) in self.marks.iter().enumerate() {
+                        list.set(i, *mark).expect("index within capacity");
+                    }
+                    list
+                },
+                tag: self.tag,
+                choice: self.choice,
+            }
+        }
+
+        fn from_delegate(delegate: Self::Delegate) -> Result<Self, DecodeError> {
+            let pairs = delegate
+                .pairs
+                .iter()
+                .cloned()
+                .map(Pair::from_delegate)
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Self {
+                pairs: pairs.try_into().expect("exactly two pairs"),
+                marks: delegate.marks.iter().collect(),
+                tag: delegate.tag,
+                choice: delegate.choice,
+            })
+        }
+    }
+
+    impl_ssz_via_delegate!(WideDelegate);
+
+    pub(crate) type WideDelegateRef<'a> = SszDelegateRef<'a, WideDelegate>;
+}
+
+/// SSZ containers generated from `tests/ssz/delegate.ssz`.
+#[allow(unreachable_pub, missing_docs, reason = "generated code")]
+mod ssz_generated {
+    include!(concat!(env!("OUT_DIR"), "/generated_delegate_ssz.rs"));
+}
+
+use ssz::Encode;
+use ssz::view::{DecodeView, SszTypeInfo};
+use ssz_types::view::ToOwnedSsz;
+use tree_hash::{Sha256Hasher, TreeHash};
+
+use crate::consumer::{
+    BoundedList, BoundedListRef, CheckedAmount, CheckedAmountRef, Choice, Pair, PairRef,
+    StableDelegate, StableDelegateRef, Tag, TagRef, WideDelegate, WideDelegateRef,
+};
+use crate::ssz_generated::tests::ssz::delegate::{
+    BoundedListContainer, BoundedListContainerRef, ByteArrayContainer, ByteArrayContainerRef,
+    RefinementContainer, RefinementContainerRef, RepresentationContainer,
+    RepresentationContainerRef, RepresentationListContainer, RepresentationListContainerRef,
+    StableDelegateContainer, StableDelegateContainerRef, WideDelegateContainer,
+    WideDelegateContainerRef,
+};
+
+fn make_pair() -> Pair {
+    Pair {
+        a: 0x0102_0304,
+        b: 0x0506,
+    }
+}
+
+fn make_representation_container() -> RepresentationContainer {
+    RepresentationContainer {
+        pair: make_pair(),
+        n: 9,
+    }
+}
+
+fn make_refinement_container() -> RefinementContainer {
+    RefinementContainer {
+        amount: CheckedAmount::new(42).expect("within bound"),
+        n: 7,
+    }
+}
+
+/// The borrowing view resolves from the pragma and recovers the wrapper.
+#[test]
+fn representation_wrapper_field_resolves_to_borrowing_view() {
+    let owned = make_representation_container();
+    let bytes = owned.as_ssz_bytes();
+
+    let view = RepresentationContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+    let field: PairRef<'_> = view.pair().expect("field view decodes");
+
+    assert_eq!(ToOwnedSsz::to_owned(&field), owned.pair);
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// The decoding adapter resolves from the pragma and recovers the wrapper.
+#[test]
+fn refinement_wrapper_field_resolves_to_decoding_view() {
+    let owned = make_refinement_container();
+    let bytes = owned.as_ssz_bytes();
+
+    let view = RefinementContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+    let field: CheckedAmountRef<'_> = view.amount().expect("field view decodes");
+
+    assert_eq!(ToOwnedSsz::to_owned(&field), owned.amount);
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// A refinement wrapper rejects a valid delegate that is an invalid wrapper, as
+/// an error rather than a panic — the case that forces decoding.
+#[test]
+fn refinement_view_rejects_valid_delegate_invalid_wrapper() {
+    let over_bound = (CheckedAmount::MAX + 1).as_ssz_bytes();
+
+    // Borrowing the delegate succeeds: the bytes are a valid `u64`.
+    let view = <CheckedAmountRef<'_> as DecodeView>::from_ssz_bytes(&over_bound)
+        .expect("delegate view borrows");
+
+    // The wrapper's invariant is enforced on materialization.
+    assert!(ToOwnedSsz::<CheckedAmount>::try_to_owned(&view).is_err());
+}
+
+/// The rejection propagates out of the enclosing container's `try_to_owned`.
+#[test]
+fn refinement_field_getter_rejects_invalid_wrapper() {
+    let mut bytes = (CheckedAmount::MAX + 1).as_ssz_bytes();
+    bytes.extend_from_slice(&7u64.as_ssz_bytes());
+
+    let view = RefinementContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+
+    let field = view.amount().expect("field view borrows");
+    assert!(ToOwnedSsz::<CheckedAmount>::try_to_owned(&field).is_err());
+
+    // Generated code propagates it with `?` rather than panicking.
+    assert!(view.try_to_owned().is_err());
+}
+
+/// Both views report the wrapper's layout, so field offsets agree.
+#[test]
+fn views_report_wrapper_layout() {
+    assert!(<PairRef<'_> as SszTypeInfo>::is_ssz_fixed_len());
+    assert_eq!(
+        <PairRef<'_> as SszTypeInfo>::ssz_fixed_len(),
+        <Pair as Encode>::ssz_fixed_len(),
+    );
+
+    assert!(<CheckedAmountRef<'_> as SszTypeInfo>::is_ssz_fixed_len());
+    assert_eq!(
+        <CheckedAmountRef<'_> as SszTypeInfo>::ssz_fixed_len(),
+        <CheckedAmount as Encode>::ssz_fixed_len(),
+    );
+}
+
+/// The trailing field still decodes, so the views report the layout the encoder
+/// used.
+#[test]
+fn trailing_fields_stay_aligned() {
+    let rep_bytes = make_representation_container().as_ssz_bytes();
+    let ref_bytes = make_refinement_container().as_ssz_bytes();
+
+    let rep_view = RepresentationContainerRef::from_ssz_bytes(&rep_bytes).expect("decodes");
+    let ref_view = RefinementContainerRef::from_ssz_bytes(&ref_bytes).expect("decodes");
+
+    assert_eq!(rep_view.n().expect("trailing field"), 9);
+    assert_eq!(ref_view.n().expect("trailing field"), 7);
+}
+
+/// Container roots are the same merkleized from the owned value or a view.
+#[test]
+fn container_views_merkleize_identically_to_owned() {
+    let representation = make_representation_container();
+    let refinement = make_refinement_container();
+    let rep_bytes = representation.as_ssz_bytes();
+    let ref_bytes = refinement.as_ssz_bytes();
+
+    let rep_view = RepresentationContainerRef::from_ssz_bytes(&rep_bytes).expect("decodes");
+    let ref_view = RefinementContainerRef::from_ssz_bytes(&ref_bytes).expect("decodes");
+
+    assert_eq!(
+        TreeHash::tree_hash_root::<Sha256Hasher>(&rep_view),
+        TreeHash::tree_hash_root::<Sha256Hasher>(&representation),
+    );
+    assert_eq!(
+        TreeHash::tree_hash_root::<Sha256Hasher>(&ref_view),
+        TreeHash::tree_hash_root::<Sha256Hasher>(&refinement),
+    );
+}
+
+/// A `List` of wrappers round-trips through the same path.
+#[test]
+fn list_of_wrappers_round_trips() {
+    let owned = RepresentationListContainer {
+        pairs: vec![make_pair(), make_pair()]
+            .try_into()
+            .expect("within the list bound"),
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = RepresentationListContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// A wrapper whose delegate is a raw `[u8; N]` borrows through
+/// `FixedBytesRef`, via the delegate's `SszHasView` link.
+#[test]
+fn byte_array_delegate_resolves_to_borrowing_view() {
+    let owned = ByteArrayContainer {
+        tag: Tag([0xAB; 32]),
+        n: 11,
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = ByteArrayContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+    let field: TagRef<'_> = view.tag().expect("field view decodes");
+
+    assert_eq!(ToOwnedSsz::to_owned(&field), owned.tag);
+    assert_eq!(view.n().expect("trailing field"), 11);
+    assert_eq!(view.to_owned(), owned);
+    assert_eq!(
+        TreeHash::tree_hash_root::<Sha256Hasher>(&view),
+        TreeHash::tree_hash_root::<Sha256Hasher>(&owned),
+    );
+}
+
+/// A wrapper whose delegate holds a bounded list rejects an over-long list as
+/// an error.
+///
+/// The delegate's container view checks only the offset table at decode, so a
+/// borrowing adapter would accept these bytes and then panic in `to_owned`
+/// when the list getter enforces the bound. Decoding surfaces it as `Err`.
+#[test]
+fn bounded_list_delegate_rejects_over_long_list() {
+    // BoundedListSsz = { data: List[byte, 4] }: a 4-byte offset, then payload.
+    let mut bytes = 4u32.as_ssz_bytes();
+    bytes.extend_from_slice(&[0xAA; 5]);
+
+    let view =
+        <BoundedListRef<'_> as DecodeView>::from_ssz_bytes(&bytes).expect("delegate view borrows");
+
+    assert!(ToOwnedSsz::<BoundedList>::try_to_owned(&view).is_err());
+}
+
+/// The same wrapper round-trips when the list is within its bound.
+#[test]
+fn bounded_list_delegate_round_trips_within_bound() {
+    let owned = BoundedListContainer {
+        bounded: BoundedList(vec![1, 2, 3]),
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = BoundedListContainerRef::from_ssz_bytes(&bytes).expect("view decodes");
+
+    assert_eq!(view.to_owned(), owned);
+}
+
+/// The same nine bytes that panic upstream's generated `to_owned` today.
+#[test]
+fn generated_try_to_owned_reports_deferred_bound_instead_of_panicking() {
+    use crate::ssz_generated::tests::ssz::delegate::{BoundedListSsz, BoundedListSszRef};
+
+    let mut bytes = 4u32.as_ssz_bytes();
+    bytes.extend_from_slice(&[0xAA; 5]);
+
+    let view = <BoundedListSszRef<'_> as DecodeView>::from_ssz_bytes(&bytes)
+        .expect("offset table validates");
+
+    let err = ToOwnedSsz::<BoundedListSsz>::try_to_owned(&view)
+        .expect_err("over-long list must be reported, not panic");
+    println!("PROBE: {err:?}");
+}
+
+/// A delegate that is a `StableContainer` with `Optional` fields round-trips
+/// through the borrowing view.
+#[test]
+fn stable_container_delegate_round_trips() {
+    let owned = StableDelegateContainer {
+        stable: StableDelegate {
+            a: Some(0x0102_0304),
+            bits: Some(vec![true, false, true, true]),
+        },
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = StableDelegateContainerRef::from_ssz_bytes(&bytes).expect("view borrows");
+    let field: StableDelegateRef<'_> = view.stable().expect("field view borrows");
+
+    assert_eq!(
+        ToOwnedSsz::<StableDelegate>::try_to_owned(&field).expect("materializes"),
+        owned.stable
+    );
+    assert_eq!(view.try_to_owned().expect("materializes"), owned);
+}
+
+/// Absent optionals round-trip too, so the `Optional::None` arm is covered.
+#[test]
+fn stable_container_delegate_round_trips_with_absent_fields() {
+    let owned = StableDelegateContainer {
+        stable: StableDelegate {
+            a: None,
+            bits: None,
+        },
+    };
+    let bytes = owned.as_ssz_bytes();
+
+    let view = StableDelegateContainerRef::from_ssz_bytes(&bytes).expect("view borrows");
+
+    assert_eq!(view.try_to_owned().expect("materializes"), owned);
+}
+
+/// A delegate holding a `Vector` of containers and a `Union[null, T]`.
+#[test]
+fn vector_and_union_delegate_round_trips() {
+    for choice in [Some(7u64), None] {
+        let owned = WideDelegateContainer {
+            wide: WideDelegate {
+                pairs: [make_pair(), Pair { a: 5, b: 6 }],
+                marks: vec![true, false, true],
+                tag: Choice::Selector1(0x0203),
+                choice,
+            },
+        };
+        let bytes = owned.as_ssz_bytes();
+
+        let view = WideDelegateContainerRef::from_ssz_bytes(&bytes).expect("view borrows");
+        let field: WideDelegateRef<'_> = view.wide().expect("field view borrows");
+
+        assert_eq!(
+            ToOwnedSsz::<WideDelegate>::try_to_owned(&field).expect("materializes"),
+            owned.wide
+        );
+        assert_eq!(view.try_to_owned().expect("materializes"), owned);
+    }
+}
+
+/// Both new views merkleize identically to their owned counterparts.
+#[test]
+fn new_delegate_views_merkleize_identically_to_owned() {
+    let stable = StableDelegateContainer {
+        stable: StableDelegate {
+            a: Some(1),
+            bits: Some(vec![true, true]),
+        },
+    };
+    let stable_bytes = stable.as_ssz_bytes();
+    let stable_view =
+        StableDelegateContainerRef::from_ssz_bytes(&stable_bytes).expect("view borrows");
+    assert_eq!(
+        TreeHash::tree_hash_root::<Sha256Hasher>(&stable_view),
+        TreeHash::tree_hash_root::<Sha256Hasher>(&stable),
+    );
+
+    let wide = WideDelegateContainer {
+        wide: WideDelegate {
+            pairs: [make_pair(), make_pair()],
+            marks: vec![false, true],
+            tag: Choice::Selector0(9),
+            choice: Some(3),
+        },
+    };
+    let wide_bytes = wide.as_ssz_bytes();
+    let wide_view = WideDelegateContainerRef::from_ssz_bytes(&wide_bytes).expect("view borrows");
+    assert_eq!(
+        TreeHash::tree_hash_root::<Sha256Hasher>(&wide_view),
+        TreeHash::tree_hash_root::<Sha256Hasher>(&wide),
+    );
+}
+
+/// An out-of-range union selector is reported as an error rather than panicking.
+#[test]
+fn union_rejects_out_of_range_selector() {
+    use crate::ssz_generated::tests::ssz::delegate::{Choice, ChoiceRef};
+
+    // Selector 9 on a two-arm union, then a payload byte.
+    let bytes = [9u8, 0u8];
+
+    let view = <ChoiceRef<'_> as DecodeView>::from_ssz_bytes(&bytes).expect("view borrows");
+
+    let err = ToOwnedSsz::<Choice>::try_to_owned(&view)
+        .expect_err("invalid selector must be reported, not panic");
+    println!("PROBE union: {err:?}");
+}

--- a/crates/ssz-tests/tests/ssz/delegate.ssz
+++ b/crates/ssz-tests/tests/ssz/delegate.ssz
@@ -1,0 +1,121 @@
+# Schema exercising both delegate-wrapper classes as external containers.
+#
+# `consumer` is the integration test's own module, which declares the wrappers
+# and the aliases naming their views. Resolving through a module rather than an
+# external crate keeps the fixtures out of any production crate's API.
+
+import consumer
+
+### Delegate for the representation wrapper.
+class PairSsz(Container):
+    ### Arbitrary payload.
+    a: uint64
+    ### Second field, so the delegate is a multi-field container.
+    b: uint32
+
+### Holds a representation wrapper, whose view borrows.
+class RepresentationContainer(Container):
+    ### Resolves to `crate::consumer::PairRef<'a>`.
+    #~# external_kind: container
+    pair: consumer.Pair
+
+    ### Trailing field: a wrong view layout shifts this and is detected.
+    n: uint64
+
+### Holds a refinement wrapper, whose view decodes.
+class RefinementContainer(Container):
+    ### Resolves to `crate::consumer::CheckedAmountRef<'a>`.
+    #~# external_kind: container
+    amount: consumer.CheckedAmount
+
+    ### Trailing field: a wrong view layout shifts this and is detected.
+    n: uint64
+
+### Representation wrappers inside a List, via the same path.
+class RepresentationListContainer(Container):
+    ### Resolves to `ListRef<'a, PairRef<'a>, 4>`.
+    #~# external_kind: container
+    pairs: List[consumer.Pair, 4]
+
+### Holds a wrapper whose delegate is a raw `[u8; N]`, viewed through
+### `SszFixedByteArrayRef`.
+class ByteArrayContainer(Container):
+    ### Resolves to `crate::consumer::TagRef<'a>`.
+    #~# external_kind: container
+    tag: consumer.Tag
+
+    ### Trailing field: a wrong view layout shifts this and is detected.
+    n: uint64
+
+### Delegate whose bound is checked lazily: a container view validates only the
+### offset table, deferring the list bound to field access.
+class BoundedListSsz(Container):
+    ### Payload bounded at 4 bytes.
+    data: List[byte, 4]
+
+### Holds a wrapper over that delegate.
+class BoundedListContainer(Container):
+    ### Resolves to `crate::consumer::BoundedListRef<'a>`.
+    #~# external_kind: container
+    bounded: consumer.BoundedList
+
+### Delegate that is a `StableContainer` with `Optional` fields, one of them a
+### `Bitlist`. Exercises the stable-container and optional conversion paths.
+class StableDelegateSsz(StableContainer[4]):
+    ### Optional primitive.
+    a: Optional[uint64]
+
+    ### Optional bitlist, so the optional-complex path is covered too.
+    b: Optional[Bitlist[32]]
+
+### Holds a wrapper over that delegate.
+class StableDelegateContainer(Container):
+    ### Resolves to `crate::consumer::StableDelegateRef<'a>`.
+    #~# external_kind: container
+    stable: consumer.StableDelegate
+
+### `Union[null, T]` resolves to a Rust `Option`, a distinct conversion branch.
+MaybeAmount = Union[null, uint64]
+
+### Delegate exercising a vector of containers and a union.
+###
+### A `Bitvector` field belongs here too, but the generated getter returns
+### `BitVectorRef<'a, N>` without carrying that type's
+### `where [(); bytes_for_bits(N)]:` bound, so it does not compile. Pre-existing
+### upstream; unrelated to `try_to_owned`.
+Choice = Union[uint8, uint16]
+
+class WideDelegateSsz(Container):
+    ### Vector of a non-byte element type.
+    pairs: Vector[PairSsz, 2]
+
+    ### Bare bitlist, distinct from the `Optional[Bitlist]` path above.
+    marks: Bitlist[16]
+
+    ### Union with no null arm, which generates an enum rather than an `Option`.
+    tag: Choice
+
+    ### Union carrying a null arm.
+    choice: MaybeAmount
+
+### Holds a wrapper over that delegate.
+class WideDelegateContainer(Container):
+    ### Resolves to `crate::consumer::WideDelegateRef<'a>`.
+    #~# external_kind: container
+    wide: consumer.WideDelegate
+
+### Union whose variant is a `List`, and one whose variant is itself a
+### `Union[null, List[...]]` (an `Option<List<...>>` after resolution).
+ListChoice = Union[uint8, List[uint64, 4]]
+
+### Three-arm union with a leading null: the flat spelling of "nothing, or a
+### uint8, or a list". `null` becomes a unit variant of the enum.
+FlatChoice = Union[null, uint8, List[uint64, 4]]
+
+### Container holding both, to force their views to materialize.
+class UnionVariantContainer(Container):
+    ### Union with a list arm.
+    listy: ListChoice
+
+    ### Union with a leading null arm.
+    flat: FlatChoice


### PR DESCRIPTION
## Description

Types using `impl_ssz_via_delegate!` can't be referenced as external containers in `ssz-gen` schemas — `external_kind: container` resolves to a `{Type}Ref<'a>` they don't have, so consumers hand-write one. See [`asm`](https://github.com/alpenlabs/asm/blob/main/crates/btc-verification/src/ssz_delegate.rs) for `HeaderVerificationState`.

Adds `SszDelegateRef<'a, T>` to `strata-identifiers`. It borrows the delegate's own view — named through the delegate's `SszHasView` link, so it can't be named wrongly — and converts on materialization, letting `from_delegate`'s error surface as a `DecodeError` instead of a panic.

A wrapper declares `SszDelegate` and one alias:

```rust
pub type HeaderVerificationStateRef<'a> = SszDelegateRef<'a, HeaderVerificationState>;
```

This PR was created with help from Claude and Codex.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers
Need to update the `ssz-gen` deps after [`ssz-gen#101`](https://github.com/alpenlabs/ssz-gen/pull/101) goes in.

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

[STR-3948](https://alpenlabs.atlassian.net/browse/STR-3948)


[STR-3948]: https://alpenlabs.atlassian.net/browse/STR-3948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ