### PR TITLE
fix(deps): stop pulling full tokio via workspace feature inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,15 +1577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,29 +2140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,15 +2525,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,12 +2755,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdd"
@@ -4300,7 +4253,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.94"
 sha2 = "0.10"
 thiserror = "2"
-tokio = { version = "1.37", features = ["full"] }
+tokio = { version = "1.37", default-features = false }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-opentelemetry = "0.32"

--- a/crates/db-macros/Cargo.toml
+++ b/crates/db-macros/Cargo.toml
@@ -13,7 +13,7 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full", "derive"] }
 
 [dev-dependencies]
-tokio = { version = "1.37", features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -26,6 +26,6 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -12,7 +12,7 @@ metrics.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tracing.workspace = true
 
 [lints]

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -10,7 +10,14 @@ workspace = true
 anyhow.workspace = true
 futures-util.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = [
+  "macros",
+  "rt",
+  "signal",
+  "sync",
+  "time",
+] }
 tracing.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread"] }


### PR DESCRIPTION
## Description

Workspace-inherited features are additive only, so a member crate declaring `tokio = { workspace = true, features = [...] }` can never opt out of whatever the root dependency enables. With the root pinned to `full`, every crate in the workspace pulled in all of tokio (net, fs, process, signal, ...) regardless of what it actually used — unwanted footprint for downstream consumers (alpen, asm) that don't already pull full tokio elsewhere.

This drops `full` from the root `tokio` dependency and has each crate (`db-macros`, `metrics`, `service`, `tasks`) declare only the features it actually calls. `crates/retry` already followed this pattern (see #145, which this PR is stacked on top of since `strata-retry` doesn't exist on `main` yet).

Split out of #145 per review discussion, since the fix legitimately spans crates beyond retry and doesn't belong bundled into that PR.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency update
- [ ] Security fix

## Notes to Reviewers

Base branch is `feat/retry-crate`, not `main` — this needs to land after/alongside #145. `cargo check --workspace --all-targets` passes with the split features.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

Split from #145.