### PR TITLE
Array-based identifier trait

### DIFF
--- a/crates/identifiers/src/acct.rs
+++ b/crates/identifiers/src/acct.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ssz")]
 use ssz_derive::{Decode, Encode};
 
+use crate::key_types::decl_array_key_wrapper_impl;
+
 const ACCT_ID_LEN: usize = 32;
 /// Length in bytes of a subject identifier.
 pub const SUBJ_ID_LEN: usize = 32;
@@ -32,6 +34,7 @@ type RawAccountId = [u8; ACCT_ID_LEN];
 pub struct AccountId(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] RawAccountId);
 
 impl_opaque_thin_wrapper!(AccountId => RawAccountId);
+decl_array_key_wrapper_impl!(AccountId => RawAccountId);
 
 impl AccountId {
     /// The "zero" account ID.
@@ -94,6 +97,7 @@ type RawAccountSerial = u32;
 pub struct AccountSerial(RawAccountSerial);
 
 impl_opaque_thin_wrapper!(AccountSerial => RawAccountSerial);
+decl_array_key_wrapper_impl!(AccountSerial => RawAccountSerial);
 
 impl AccountSerial {
     /// Returns the zero serial.
@@ -168,6 +172,7 @@ type RawSubjectId = [u8; SUBJ_ID_LEN];
 pub struct SubjectId(#[cfg_attr(feature = "serde", serde(with = "hex::serde"))] RawSubjectId);
 
 impl_opaque_thin_wrapper!(SubjectId => RawSubjectId);
+decl_array_key_wrapper_impl!(SubjectId => RawSubjectId);
 
 impl fmt::Display for SubjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/identifiers/src/acct.rs
+++ b/crates/identifiers/src/acct.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "ssz")]
 use ssz_derive::{Decode, Encode};
 
-use crate::key_types::decl_array_key_wrapper_impl;
+use crate::array_keys::decl_array_key_wrapper_impl;
 
 const ACCT_ID_LEN: usize = 32;
 /// Length in bytes of a subject identifier.

--- a/crates/identifiers/src/array_keys/macros.rs
+++ b/crates/identifiers/src/array_keys/macros.rs
@@ -1,108 +1,7 @@
-//! Utilities for working with identifiers as database keys.
+//! Macros for declaring [`ArrayKey`] impls, along with the impls we declare
+//! with them for the primitive types.
 
-/// Used for types that can be represented as a flat array of bytes, as would be
-/// used for binary database keys.
-///
-/// Unfortunately, `generic_const_exprs` is not stable, so we can't make this
-/// interface *really* nice, we just have to hope that LLVM realizes that it can
-/// eliminate all these bounds checks.
-pub trait ArrayKey {
-    /// The size of an array that contains this key byte.
-    const BYTES: usize;
-
-    /// Copies the key bytes into the array.
-    ///
-    /// This must be big-endian.
-    ///
-    /// # Panics
-    ///
-    /// If called with a slice that is not [`Self::BYTES`] bytes.
-    fn copy_into(&self, buf: &mut [u8]);
-
-    /// Constructs an instance of the key by decoding from bytes.
-    ///
-    /// # Panics
-    ///
-    /// If called with a slice that is not [`Self::BYTES`] bytes.
-    fn copy_from(buf: &[u8]) -> Self;
-}
-
-/// General impl for all bytebufs since they're already of the right format.
-impl<const N: usize> ArrayKey for [u8; N] {
-    const BYTES: usize = N;
-
-    fn copy_into(&self, buf: &mut [u8]) {
-        assert_buf_len_eq::<Self>(buf);
-        buf.copy_from_slice(self);
-    }
-
-    fn copy_from(buf: &[u8]) -> Self {
-        assert_buf_len_eq::<Self>(buf);
-        buf.try_into().unwrap()
-    }
-}
-
-/// Extension trait for "buffer types" that we might want to decode as an [`ArrayKey`].
-pub trait ArrayKeyBuf {
-    /// Attempts to decode the buf into an [`ArrayKey`] type.
-    ///
-    /// Returns `None` if the array is not the right size.
-    fn try_into_key<K: ArrayKey>(&self) -> Option<K>;
-}
-
-impl<T: AsRef<[u8]>> ArrayKeyBuf for T {
-    fn try_into_key<K: ArrayKey>(&self) -> Option<K> {
-        let buf = <Self as AsRef<[u8]>>::as_ref(self);
-        if buf.len() == K::BYTES {
-            Some(K::copy_from(buf))
-        } else {
-            None
-        }
-    }
-}
-
-/// Extension trait for array types that we might want to decode as an [`ArrayKey`].
-///
-/// Unlike [`ArrayKeyBuf`], this is infallible, since the array length is known
-/// statically and MUST be checked at compile time.
-///
-/// You shouldn't have to implement this on your own types, it's just so we can
-/// add trait member fn to `[u8; N]`.
-pub trait ArrayKeyArr<const N: usize> {
-    /// Decodes the array into an [`ArrayKey`] type of exactly the same width.
-    ///
-    /// Instantiating this with a key type whose width isn't `N` MUST fail to
-    /// compile.
-    fn into_key<K: ArrayKey>(self) -> K;
-}
-
-/// Impl for `[u8; N]` arrays that provides the guarantees we expect.
-impl<const N: usize> ArrayKeyArr<N> for [u8; N] {
-    fn into_key<K: ArrayKey>(self) -> K {
-        // Ideally this would be a bound like `K: ArrayKey<BYTES = { N }>`, but
-        // that needs `associated_const_equality`, which isn't stable.  An
-        // inline const inherits the generics of the fn it's in, so we can check
-        // the same thing here, just at monomorphization time instead of when
-        // typechecking the call.
-        assert_key_width_eq::<N, K>();
-        K::copy_from(&self)
-    }
-}
-
-/// Fails to compile if `K` is not exactly `N` bytes wide.
-///
-/// This is a post-monomorphization error, so it only fires where this is
-/// actually instantiated.  That's every real call, but it does mean a bad
-/// instantiation sitting in generic code that's never called goes unreported.
-#[inline(always)]
-fn assert_key_width_eq<const N: usize, K: ArrayKey>() {
-    const {
-        assert!(
-            N == K::BYTES,
-            "arraykey: array length does not match key width"
-        )
-    };
-}
+use super::traits::{ArrayKey, assert_buf_len_eq};
 
 /// Declares an [`ArrayKey`] impl for a tuple of the arity implied by the number
 /// of type parameter names passed to it.
@@ -214,7 +113,7 @@ macro_rules! decl_array_key_struct_impl {
             const BYTES: usize = 0 $(+ <$field_ty as $crate::ArrayKey>::BYTES)+;
 
             fn copy_into(&self, buf: &mut [u8]) {
-                $crate::key_types::assert_buf_len_eq::<Self>(buf);
+                $crate::array_keys::assert_buf_len_eq::<Self>(buf);
                 let mut rest = buf;
                 $(
                     let (cur, next) = core::mem::take(&mut rest)
@@ -226,7 +125,7 @@ macro_rules! decl_array_key_struct_impl {
             }
 
             fn copy_from(buf: &[u8]) -> Self {
-                $crate::key_types::assert_buf_len_eq::<Self>(buf);
+                $crate::array_keys::assert_buf_len_eq::<Self>(buf);
                 let mut rest = buf;
                 $(
                     let (cur, next) = rest.split_at(<$field_ty as $crate::ArrayKey>::BYTES);
@@ -243,22 +142,12 @@ macro_rules! decl_array_key_struct_impl {
 pub(crate) use decl_array_key_struct_impl;
 pub(crate) use decl_array_key_wrapper_impl;
 
-#[inline(always)]
-pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
-    let len = arr.len();
-    assert_eq!(
-        arr.len(),
-        K::BYTES,
-        "arraykey: passed invalid array (exp {}, got {len})",
-        K::BYTES
-    );
-}
-
 #[cfg(all(test, feature = "arbitrary"))]
 mod tests {
     use arbitrary::{Arbitrary, Unstructured};
 
     use super::*;
+    use crate::array_keys::traits::ArrayKeyArr;
 
     /// Number of instances we check per type.
     const ROUNDS: usize = 64;

--- a/crates/identifiers/src/array_keys/macros.rs
+++ b/crates/identifiers/src/array_keys/macros.rs
@@ -75,12 +75,6 @@ decl_array_key_int_impl!(u32);
 decl_array_key_int_impl!(u64);
 decl_array_key_int_impl!(u128);
 
-decl_array_key_int_impl!(i8);
-decl_array_key_int_impl!(i16);
-decl_array_key_int_impl!(i32);
-decl_array_key_int_impl!(i64);
-decl_array_key_int_impl!(i128);
-
 /// Declares an [`ArrayKey`] impl for a newtype wrapping another key type,
 /// giving it exactly the same encoding as the type it wraps.
 ///
@@ -197,12 +191,6 @@ mod tests {
         check_roundtrips_arb::<u32>(u);
         check_roundtrips_arb::<u64>(u);
         check_roundtrips_arb::<u128>(u);
-
-        check_roundtrips_arb::<i8>(u);
-        check_roundtrips_arb::<i16>(u);
-        check_roundtrips_arb::<i32>(u);
-        check_roundtrips_arb::<i64>(u);
-        check_roundtrips_arb::<i128>(u);
     }
 
     #[test]
@@ -226,14 +214,14 @@ mod tests {
         check_roundtrips_arb::<(u32, [u8; 32])>(u);
         check_roundtrips_arb::<(u64, u32, [u8; 20])>(u);
         check_roundtrips_arb::<(u8, u16, u32, u64)>(u);
-        check_roundtrips_arb::<(i8, u16, [u8; 3], u64, u128)>(u);
+        check_roundtrips_arb::<(u8, u16, [u8; 3], u64, u128)>(u);
         check_roundtrips_arb::<(u8, u16, u32, u64, u128, [u8; 7])>(u);
 
         // Weirder cases, mostly to make sure composition and zero-width members
         // behave.
         check_roundtrips_arb::<([u8; 0], u32, [u8; 0])>(u);
         check_roundtrips_arb::<((u8, u16), (u32, u64))>(u);
-        check_roundtrips_arb::<(u64, ([u8; 4], (i16, [u8; 0])), [u8; 1])>(u);
+        check_roundtrips_arb::<(u64, ([u8; 4], (u16, [u8; 0])), [u8; 1])>(u);
         check_roundtrips_arb::<((((u8, u8), u8), u8), u8)>(u);
     }
 
@@ -306,7 +294,7 @@ mod tests {
 
         // Ints decode big-endian, matching `copy_from`.
         assert_eq!([0x01u8, 0x02, 0x03, 0x04].into_key::<u32>(), 0x01020304);
-        assert_eq!([0xffu8].into_key::<i8>(), -1);
+        assert_eq!([0xffu8].into_key::<u8>(), 0xff);
 
         // Composites work too, which is the case a length marker trait
         // couldn't have covered.
@@ -326,7 +314,7 @@ mod tests {
         assert_eq!(<(u32, [u8; 32])>::BYTES, 36);
         assert_eq!(<([u8; 0], u32, [u8; 0])>::BYTES, 4);
         assert_eq!(<(u8, u16, u32, u64, u128, [u8; 7])>::BYTES, 38);
-        assert_eq!(<(u64, ([u8; 4], (i16, [u8; 0])), [u8; 1])>::BYTES, 15);
+        assert_eq!(<(u64, ([u8; 4], (u16, [u8; 0])), [u8; 1])>::BYTES, 15);
     }
 
     #[test]

--- a/crates/identifiers/src/array_keys/macros.rs
+++ b/crates/identifiers/src/array_keys/macros.rs
@@ -136,15 +136,12 @@ macro_rules! decl_array_key_struct_impl {
 pub(crate) use decl_array_key_struct_impl;
 pub(crate) use decl_array_key_wrapper_impl;
 
-#[cfg(all(test, feature = "arbitrary"))]
+#[cfg(test)]
 mod tests {
-    use arbitrary::{Arbitrary, Unstructured};
+    use proptest::prelude::*;
 
     use super::*;
     use crate::array_keys::traits::ArrayKeyArr;
-
-    /// Number of instances we check per type.
-    const ROUNDS: usize = 64;
 
     /// Encodes a key and decodes it again, checking we get the same value back
     /// and that we used exactly the number of bytes we said we would.
@@ -156,84 +153,19 @@ mod tests {
         buf
     }
 
-    /// Generates a bunch of arbitrary instances of a key type and roundtrips
-    /// each of them.
-    fn check_roundtrips_arb<'a, K>(u: &mut Unstructured<'a>)
-    where
-        K: ArrayKey + Arbitrary<'a> + Eq + core::fmt::Debug,
-    {
-        for _ in 0..ROUNDS {
-            let k = K::arbitrary(u).expect("test: generate key");
-            check_roundtrip(k);
-        }
-    }
-
-    /// Deterministic pseudorandom byte source so that failures are reproducible.
-    fn gen_entropy(seed: u64, len: usize) -> Vec<u8> {
-        let mut state = seed | 1;
-        (0..len)
-            .map(|_| {
-                state ^= state << 13;
-                state ^= state >> 7;
-                state ^= state << 17;
-                (state >> 24) as u8
-            })
-            .collect()
-    }
-
-    #[test]
-    fn test_roundtrip_ints() {
-        let ent = gen_entropy(0x1234, 16 * 1024);
-        let u = &mut Unstructured::new(&ent);
-
-        check_roundtrips_arb::<u8>(u);
-        check_roundtrips_arb::<u16>(u);
-        check_roundtrips_arb::<u32>(u);
-        check_roundtrips_arb::<u64>(u);
-        check_roundtrips_arb::<u128>(u);
-    }
-
-    #[test]
-    fn test_roundtrip_arrays() {
-        let ent = gen_entropy(0x5678, 16 * 1024);
-        let u = &mut Unstructured::new(&ent);
-
-        check_roundtrips_arb::<[u8; 0]>(u);
-        check_roundtrips_arb::<[u8; 1]>(u);
-        check_roundtrips_arb::<[u8; 4]>(u);
-        check_roundtrips_arb::<[u8; 20]>(u);
-        check_roundtrips_arb::<[u8; 32]>(u);
-    }
-
-    #[test]
-    fn test_roundtrip_tuples() {
-        let ent = gen_entropy(0x9abc, 64 * 1024);
-        let u = &mut Unstructured::new(&ent);
-
-        // Simple cases for each arity we declared impls for.
-        check_roundtrips_arb::<(u32, [u8; 32])>(u);
-        check_roundtrips_arb::<(u64, u32, [u8; 20])>(u);
-        check_roundtrips_arb::<(u8, u16, u32, u64)>(u);
-        check_roundtrips_arb::<(u8, u16, [u8; 3], u64, u128)>(u);
-        check_roundtrips_arb::<(u8, u16, u32, u64, u128, [u8; 7])>(u);
-
-        // Weirder cases, mostly to make sure composition and zero-width members
-        // behave.
-        check_roundtrips_arb::<([u8; 0], u32, [u8; 0])>(u);
-        check_roundtrips_arb::<((u8, u16), (u32, u64))>(u);
-        check_roundtrips_arb::<(u64, ([u8; 4], (u16, [u8; 0])), [u8; 1])>(u);
-        check_roundtrips_arb::<((((u8, u8), u8), u8), u8)>(u);
-    }
-
     /// Newtype to exercise `decl_array_key_wrapper_impl`.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     struct TestWrapper([u8; 12]);
 
     decl_array_key_wrapper_impl!(TestWrapper => [u8; 12]);
 
+    fn arb_test_wrapper() -> impl Strategy<Value = TestWrapper> {
+        any::<[u8; 12]>().prop_map(TestWrapper)
+    }
+
     /// Struct to exercise `decl_array_key_struct_impl`, mixing widths and
     /// including a wrapper member.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     struct TestStruct {
         idx: u32,
         pad: [u8; 0],
@@ -246,17 +178,74 @@ mod tests {
         [idx: u32, pad: [u8; 0], id: TestWrapper, flag: u8]
     );
 
-    #[test]
-    fn test_roundtrip_wrapper_and_struct() {
-        let ent = gen_entropy(0xdef0, 16 * 1024);
-        let u = &mut Unstructured::new(&ent);
+    fn arb_test_struct() -> impl Strategy<Value = TestStruct> {
+        (
+            any::<u32>(),
+            any::<[u8; 0]>(),
+            arb_test_wrapper(),
+            any::<u8>(),
+        )
+            .prop_map(|(idx, pad, id, flag)| TestStruct { idx, pad, id, flag })
+    }
 
-        check_roundtrips_arb::<TestWrapper>(u);
-        check_roundtrips_arb::<TestStruct>(u);
+    proptest! {
+        #[test]
+        fn test_roundtrip_ints(a in any::<u8>(), b in any::<u16>(), c in any::<u32>(), d in any::<u64>(), e in any::<u128>()) {
+            check_roundtrip(a);
+            check_roundtrip(b);
+            check_roundtrip(c);
+            check_roundtrip(d);
+            check_roundtrip(e);
+        }
 
-        // They compose with the other impls like anything else.
-        check_roundtrips_arb::<(TestWrapper, u64)>(u);
-        check_roundtrips_arb::<(TestStruct, [u8; 3])>(u);
+        #[test]
+        fn test_roundtrip_arrays(a0 in any::<[u8; 0]>(), a1 in any::<[u8; 1]>(), a4 in any::<[u8; 4]>(), a20 in any::<[u8; 20]>(), a32 in any::<[u8; 32]>()) {
+            check_roundtrip(a0);
+            check_roundtrip(a1);
+            check_roundtrip(a4);
+            check_roundtrip(a20);
+            check_roundtrip(a32);
+        }
+
+        #[test]
+        fn test_roundtrip_tuples(
+            t1 in any::<(u32, [u8; 32])>(),
+            t2 in any::<(u64, u32, [u8; 20])>(),
+            t3 in any::<(u8, u16, u32, u64)>(),
+            t4 in any::<(u8, u16, [u8; 3], u64, u128)>(),
+            t5 in any::<(u8, u16, u32, u64, u128, [u8; 7])>(),
+            // Weirder cases, mostly to make sure composition and zero-width
+            // members behave.
+            t6 in any::<([u8; 0], u32, [u8; 0])>(),
+            t7 in any::<((u8, u16), (u32, u64))>(),
+            t8 in any::<(u64, ([u8; 4], (u16, [u8; 0])), [u8; 1])>(),
+            t9 in any::<((((u8, u8), u8), u8), u8)>(),
+        ) {
+            check_roundtrip(t1);
+            check_roundtrip(t2);
+            check_roundtrip(t3);
+            check_roundtrip(t4);
+            check_roundtrip(t5);
+            check_roundtrip(t6);
+            check_roundtrip(t7);
+            check_roundtrip(t8);
+            check_roundtrip(t9);
+        }
+
+        #[test]
+        fn test_roundtrip_wrapper_and_struct(
+            w in arb_test_wrapper(),
+            s in arb_test_struct(),
+            wt in (arb_test_wrapper(), any::<u64>()),
+            st in (arb_test_struct(), any::<[u8; 3]>()),
+        ) {
+            check_roundtrip(w);
+            check_roundtrip(s);
+
+            // They compose with the other impls like anything else.
+            check_roundtrip(wt);
+            check_roundtrip(st);
+        }
     }
 
     #[test]

--- a/crates/identifiers/src/array_keys/mod.rs
+++ b/crates/identifiers/src/array_keys/mod.rs
@@ -1,0 +1,5 @@
+mod macros;
+mod traits;
+
+pub(crate) use macros::*;
+pub use traits::*;

--- a/crates/identifiers/src/array_keys/traits.rs
+++ b/crates/identifiers/src/array_keys/traits.rs
@@ -1,0 +1,124 @@
+//! Utilities for working with identifiers as database keys.
+
+/// Used for types that can be represented as a flat array of bytes, as would be
+/// used for binary database keys.
+///
+/// Unfortunately, `generic_const_exprs` is not stable, so we can't make this
+/// interface *really* nice, we just have to hope that LLVM realizes that it can
+/// eliminate all these bounds checks.
+pub trait ArrayKey {
+    /// The size of an array that contains this key byte.
+    const BYTES: usize;
+
+    /// Copies the key bytes into the array.
+    ///
+    /// This must be big-endian.
+    ///
+    /// # Panics
+    ///
+    /// If called with a slice that is not [`Self::BYTES`] bytes.
+    fn copy_into(&self, buf: &mut [u8]);
+
+    /// Constructs an instance of the key by decoding from bytes.
+    ///
+    /// # Panics
+    ///
+    /// If called with a slice that is not [`Self::BYTES`] bytes.
+    fn copy_from(buf: &[u8]) -> Self;
+}
+
+/// General impl for all bytebufs since they're already of the right format.
+impl<const N: usize> ArrayKey for [u8; N] {
+    const BYTES: usize = N;
+
+    fn copy_into(&self, buf: &mut [u8]) {
+        assert_buf_len_eq::<Self>(buf);
+        buf.copy_from_slice(self);
+    }
+
+    fn copy_from(buf: &[u8]) -> Self {
+        assert_buf_len_eq::<Self>(buf);
+        buf.try_into().unwrap()
+    }
+}
+
+/// Extension trait for "buffer types" that we might want to decode as an [`ArrayKey`].
+pub trait ArrayKeyBuf {
+    /// Attempts to decode the buf into an [`ArrayKey`] type.
+    ///
+    /// Returns `None` if the array is not the right size.
+    fn try_into_key<K: ArrayKey>(&self) -> Option<K>;
+}
+
+impl<T: AsRef<[u8]>> ArrayKeyBuf for T {
+    fn try_into_key<K: ArrayKey>(&self) -> Option<K> {
+        let buf = <Self as AsRef<[u8]>>::as_ref(self);
+        if buf.len() == K::BYTES {
+            Some(K::copy_from(buf))
+        } else {
+            None
+        }
+    }
+}
+
+/// Extension trait for array types that we might want to decode as an [`ArrayKey`].
+///
+/// Unlike [`ArrayKeyBuf`], this is infallible, since the array length is known
+/// statically and MUST be checked at compile time.
+///
+/// You shouldn't have to implement this on your own types, it's just so we can
+/// add trait member fn to `[u8; N]`.
+pub trait ArrayKeyArr<const N: usize> {
+    /// Decodes the array into an [`ArrayKey`] type of exactly the same width.
+    ///
+    /// Instantiating this with a key type whose width isn't `N` MUST fail to
+    /// compile.
+    fn into_key<K: ArrayKey>(self) -> K;
+}
+
+/// Impl for `[u8; N]` arrays that provides the guarantees we expect.
+impl<const N: usize> ArrayKeyArr<N> for [u8; N] {
+    fn into_key<K: ArrayKey>(self) -> K {
+        // Ideally this would be a bound like `K: ArrayKey<BYTES = { N }>`, but
+        // that needs `associated_const_equality`, which isn't stable.  An
+        // inline const inherits the generics of the fn it's in, so we can check
+        // the same thing here, just at monomorphization time instead of when
+        // typechecking the call.
+        assert_arraykey_bytes::<N, K>();
+        K::copy_from(&self)
+    }
+}
+
+/// Fails to compile if `K` is not exactly `N` bytes wide.  Does nothing at
+/// run-time.
+///
+/// This triggers an error during constant propagation (rather than at type
+/// checking), so it only fires where this is actually instantiated.  That's
+/// every real call, but it does mean a bad instantiation sitting in generic
+/// code that's never called goes unreported.
+#[inline(always)]
+fn assert_arraykey_bytes<const N: usize, K: ArrayKey>() {
+    const {
+        // Can't be `assert_eq!` because of const eval issues.
+        assert!(
+            N == K::BYTES,
+            "arraykey: array length does not match key width"
+        )
+    };
+}
+
+/// Asserts that a buffer is exactly as wide as the key type `K` expects.
+///
+/// # Panics
+///
+/// If the buffer length doesn't match [`ArrayKey::BYTES`].
+#[inline(always)]
+pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
+    let len = arr.len();
+    assert_eq!(
+        arr.len(),
+        K::BYTES,
+        "arraykey: passed invalid array (exp {}, got {len})",
+        K::BYTES
+    );
+}

--- a/crates/identifiers/src/array_keys/traits.rs
+++ b/crates/identifiers/src/array_keys/traits.rs
@@ -12,7 +12,7 @@ pub trait ArrayKey {
 
     /// Copies the key bytes into the array.
     ///
-    /// This must be big-endian.
+    /// This MUST be big-endian for integer-like types.
     ///
     /// # Panics
     ///
@@ -27,7 +27,7 @@ pub trait ArrayKey {
     fn copy_from(buf: &[u8]) -> Self;
 }
 
-/// General impl for all bytebufs since they're already of the right format.
+/// General impl for all bytebufs since they're already of the right structure.
 impl<const N: usize> ArrayKey for [u8; N] {
     const BYTES: usize = N;
 
@@ -69,11 +69,18 @@ impl<T: AsRef<[u8]>> ArrayKeyBuf for T {
 /// You shouldn't have to implement this on your own types, it's just so we can
 /// add trait member fn to `[u8; N]`.
 pub trait ArrayKeyArr<const N: usize> {
-    /// Decodes the array into an [`ArrayKey`] type of exactly the same width.
+    /// Decodes the array into an [`ArrayKey`] type of exactly the same size.
     ///
     /// Instantiating this with a key type whose width isn't `N` MUST fail to
     /// compile.
     fn into_key<K: ArrayKey>(self) -> K;
+
+    /// Constructs a new instance of the array from an [`ArrayKey`] type of
+    /// exactly the same size.
+    ///
+    /// Instantiating this with a key type whose width isn't `N` MUST fail to
+    /// compile.
+    fn from_key<K: ArrayKey>(k: &K) -> Self;
 }
 
 /// Impl for `[u8; N]` arrays that provides the guarantees we expect.
@@ -86,6 +93,13 @@ impl<const N: usize> ArrayKeyArr<N> for [u8; N] {
         // typechecking the call.
         assert_arraykey_bytes::<N, K>();
         K::copy_from(&self)
+    }
+
+    fn from_key<K: ArrayKey>(k: &K) -> Self {
+        assert_arraykey_bytes::<N, K>();
+        let mut buf = [0; N];
+        k.copy_into(&mut buf[..]);
+        buf
     }
 }
 
@@ -121,4 +135,58 @@ pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
         "arraykey: passed invalid array (exp {}, got {len})",
         K::BYTES
     );
+}
+
+/// Extension trait for [`ArrayKey`] with convenience fns.
+pub trait ArrayKeyExt: ArrayKey {
+    /// Encodes the key into a `Vec<u8>`.
+    fn to_vec(&self) -> Vec<u8>;
+}
+
+impl<T: ArrayKey> ArrayKeyExt for T {
+    fn to_vec(&self) -> Vec<u8> {
+        let mut vec = vec![0; Self::BYTES];
+        self.copy_into(&mut vec[..]);
+        vec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_key_arr() {
+        // Arrays are their own key type, so this is just a passthrough.
+        assert_eq!(<[u8; 4]>::from_key(&[1u8, 2, 3, 4]), [1, 2, 3, 4]);
+        assert_eq!(<[u8; 0]>::from_key(&[]), [0u8; 0]);
+
+        // Ints encode big-endian, matching `copy_into`.
+        assert_eq!(
+            <[u8; 4]>::from_key(&0x01020304u32),
+            [0x01, 0x02, 0x03, 0x04]
+        );
+        assert_eq!(<[u8; 1]>::from_key(&0xffu8), [0xff]);
+    }
+
+    #[test]
+    fn test_from_key_is_inverse_of_into_key() {
+        let arr = [0x11u8, 0x22, 0x33, 0x44];
+        let k = arr.into_key::<u32>();
+        assert_eq!(<[u8; 4]>::from_key(&k), arr);
+    }
+
+    #[test]
+    fn test_to_vec_matches_copy_into() {
+        let k = 0x01020304u32;
+        let mut buf = [0u8; 4];
+        k.copy_into(&mut buf);
+        assert_eq!(k.to_vec(), buf.to_vec());
+
+        let arr = [0xaa, 0xbb, 0xcc];
+        assert_eq!(arr.to_vec(), vec![0xaa, 0xbb, 0xcc]);
+
+        let empty: [u8; 0] = [];
+        assert_eq!(empty.to_vec(), Vec::<u8>::new());
+    }
 }

--- a/crates/identifiers/src/epoch.rs
+++ b/crates/identifiers/src/epoch.rs
@@ -24,8 +24,8 @@ use ssz_derive::{Decode, Encode};
 #[cfg(feature = "codec")]
 use strata_codec::Codec;
 
+use crate::array_keys::decl_array_key_struct_impl;
 use crate::buf::Buf32;
-use crate::key_types::decl_array_key_struct_impl;
 use crate::ol::{OLBlockCommitment, OLBlockId};
 use crate::{Epoch, Slot};
 

--- a/crates/identifiers/src/epoch.rs
+++ b/crates/identifiers/src/epoch.rs
@@ -25,6 +25,7 @@ use ssz_derive::{Decode, Encode};
 use strata_codec::Codec;
 
 use crate::buf::Buf32;
+use crate::key_types::decl_array_key_struct_impl;
 use crate::ol::{OLBlockCommitment, OLBlockId};
 use crate::{Epoch, Slot};
 
@@ -47,6 +48,11 @@ pub struct EpochCommitment {
 
 #[cfg(feature = "ssz")]
 crate::impl_ssz_fixed_container!(EpochCommitment, [epoch: Epoch, last_slot: Slot, last_blkid: OLBlockId]);
+
+decl_array_key_struct_impl!(
+    EpochCommitment,
+    [epoch: Epoch, last_slot: Slot, last_blkid: OLBlockId]
+);
 
 impl EpochCommitment {
     /// Creates a new epoch commitment from its components.

--- a/crates/identifiers/src/exec.rs
+++ b/crates/identifiers/src/exec.rs
@@ -6,6 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::buf::Buf32;
+use crate::key_types::decl_array_key_struct_impl;
 
 /// Alias to [`Buf32`] used as a universal hash type in EE.
 pub type Hash = Buf32;
@@ -47,6 +48,8 @@ pub struct ExecBlockCommitment {
     slot: u64,
     blkid: Buf32,
 }
+
+decl_array_key_struct_impl!(ExecBlockCommitment, [slot: u64, blkid: Buf32]);
 
 impl ExecBlockCommitment {
     /// Creates a new execution block commitment.

--- a/crates/identifiers/src/exec.rs
+++ b/crates/identifiers/src/exec.rs
@@ -5,8 +5,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::array_keys::decl_array_key_struct_impl;
 use crate::buf::Buf32;
-use crate::key_types::decl_array_key_struct_impl;
 
 /// Alias to [`Buf32`] used as a universal hash type in EE.
 pub type Hash = Buf32;

--- a/crates/identifiers/src/key_types.rs
+++ b/crates/identifiers/src/key_types.rs
@@ -120,8 +120,69 @@ decl_array_key_int_impl!(i32);
 decl_array_key_int_impl!(i64);
 decl_array_key_int_impl!(i128);
 
+/// Declares an [`ArrayKey`] impl for a newtype wrapping another key type,
+/// giving it exactly the same encoding as the type it wraps.
+///
+/// This must be a newtype a la `struct Foo(Bar);`.
+macro_rules! decl_array_key_wrapper_impl {
+    ($ty:ty => $inner:ty) => {
+        impl $crate::ArrayKey for $ty {
+            const BYTES: usize = <$inner as $crate::ArrayKey>::BYTES;
+
+            fn copy_into(&self, buf: &mut [u8]) {
+                <$inner as $crate::ArrayKey>::copy_into(&self.0, buf);
+            }
+
+            fn copy_from(buf: &[u8]) -> Self {
+                Self(<$inner as $crate::ArrayKey>::copy_from(buf))
+            }
+        }
+    };
+}
+
+/// Declares an [`ArrayKey`] impl for a struct with named fields, encoding the
+/// fields in the order they're listed in.
+///
+/// Since each field is encoded big-endian with no padding, the byte ordering of
+/// the key matches the ordering of the fields as listed, which is usually what
+/// we want out of a composite database key.
+macro_rules! decl_array_key_struct_impl {
+    ($ty:ty, [$($field:ident: $field_ty:ty),+ $(,)?]) => {
+        impl $crate::ArrayKey for $ty {
+            const BYTES: usize = 0 $(+ <$field_ty as $crate::ArrayKey>::BYTES)+;
+
+            fn copy_into(&self, buf: &mut [u8]) {
+                $crate::key_types::assert_buf_len_eq::<Self>(buf);
+                let mut rest = buf;
+                $(
+                    let (cur, next) = core::mem::take(&mut rest)
+                        .split_at_mut(<$field_ty as $crate::ArrayKey>::BYTES);
+                    <$field_ty as $crate::ArrayKey>::copy_into(&self.$field, cur);
+                    rest = next;
+                )+
+                debug_assert!(rest.is_empty());
+            }
+
+            fn copy_from(buf: &[u8]) -> Self {
+                $crate::key_types::assert_buf_len_eq::<Self>(buf);
+                let mut rest = buf;
+                $(
+                    let (cur, next) = rest.split_at(<$field_ty as $crate::ArrayKey>::BYTES);
+                    let $field = <$field_ty as $crate::ArrayKey>::copy_from(cur);
+                    rest = next;
+                )+
+                debug_assert!(rest.is_empty());
+                Self { $($field,)+ }
+            }
+        }
+    };
+}
+
+pub(crate) use decl_array_key_struct_impl;
+pub(crate) use decl_array_key_wrapper_impl;
+
 #[inline(always)]
-fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
+pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
     #[cfg(debug_assertions)]
     {
         let len = arr.len();
@@ -226,6 +287,67 @@ mod tests {
         check_roundtrips_arb::<((u8, u16), (u32, u64))>(u);
         check_roundtrips_arb::<(u64, ([u8; 4], (i16, [u8; 0])), [u8; 1])>(u);
         check_roundtrips_arb::<((((u8, u8), u8), u8), u8)>(u);
+    }
+
+    /// Newtype to exercise `decl_array_key_wrapper_impl`.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary)]
+    struct TestWrapper([u8; 12]);
+
+    decl_array_key_wrapper_impl!(TestWrapper => [u8; 12]);
+
+    /// Struct to exercise `decl_array_key_struct_impl`, mixing widths and
+    /// including a wrapper member.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary)]
+    struct TestStruct {
+        idx: u32,
+        pad: [u8; 0],
+        id: TestWrapper,
+        flag: u8,
+    }
+
+    decl_array_key_struct_impl!(
+        TestStruct,
+        [idx: u32, pad: [u8; 0], id: TestWrapper, flag: u8]
+    );
+
+    #[test]
+    fn test_roundtrip_wrapper_and_struct() {
+        let ent = gen_entropy(0xdef0, 16 * 1024);
+        let u = &mut Unstructured::new(&ent);
+
+        check_roundtrips_arb::<TestWrapper>(u);
+        check_roundtrips_arb::<TestStruct>(u);
+
+        // They compose with the other impls like anything else.
+        check_roundtrips_arb::<(TestWrapper, u64)>(u);
+        check_roundtrips_arb::<(TestStruct, [u8; 3])>(u);
+    }
+
+    #[test]
+    fn test_wrapper_and_struct_layout() {
+        assert_eq!(TestWrapper::BYTES, 12);
+        assert_eq!(TestStruct::BYTES, 17);
+
+        // A wrapper encodes exactly like the value it wraps.
+        let inner = [0x11u8; 12];
+        assert_eq!(
+            check_roundtrip(TestWrapper(inner)),
+            check_roundtrip(inner),
+            "wrapper should not change the encoding"
+        );
+
+        // A struct encodes exactly like a tuple of its fields, in order.
+        let s = TestStruct {
+            idx: 0x01020304,
+            pad: [],
+            id: TestWrapper(inner),
+            flag: 0xff,
+        };
+        assert_eq!(
+            check_roundtrip(s),
+            check_roundtrip((s.idx, s.pad, s.id, s.flag)),
+            "struct should encode as its fields in order"
+        );
     }
 
     #[test]

--- a/crates/identifiers/src/key_types.rs
+++ b/crates/identifiers/src/key_types.rs
@@ -1,0 +1,249 @@
+//! Utilities for working with identifiers as database keys.
+
+/// Used for types that can be represented as a flat array of bytes, as would be
+/// used for binary database keys.
+///
+/// Unfortunately, `generic_const_exprs` is not stable, so we can't make this
+/// interface *really* nice, we just have to hope that LLVM realizes that it can
+/// eliminate all these bounds checks.
+pub trait ArrayKey {
+    /// The size of an array that contains this key byte.
+    const BYTES: usize;
+
+    /// Copies the key bytes into the array.
+    ///
+    /// This must be big-endian.
+    ///
+    /// # Panics
+    ///
+    /// If called with a slice that is not [`Self::WIDTH`] bytes.
+    fn copy_into(&self, buf: &mut [u8]);
+
+    /// Constructs an instance of the key by decoding from bytes.
+    ///
+    /// # Panics
+    ///
+    /// If called with a slice that is not [`Self::WIDTH`] bytes.
+    fn copy_from(buf: &[u8]) -> Self;
+}
+
+/// General impl for all bytebufs since they're already of the right format.
+impl<const N: usize> ArrayKey for [u8; N] {
+    const BYTES: usize = N;
+
+    fn copy_into(&self, buf: &mut [u8]) {
+        assert_buf_len_eq::<Self>(buf);
+        buf.copy_from_slice(self);
+    }
+
+    fn copy_from(buf: &[u8]) -> Self {
+        assert_buf_len_eq::<Self>(buf);
+        buf.try_into().unwrap()
+    }
+}
+
+/// Declares an [`ArrayKey`] impl for a tuple of the arity implied by the number
+/// of type parameter names passed to it.
+///
+/// The fields are laid out in the buffer in order, each taking up as many bytes
+/// as its own impl says it does.
+macro_rules! decl_array_key_tuple_impl {
+    ($($ty:ident),+ $(,)?) => {
+        // The type param names are also reused as value bindings, which is what
+        // the lint allowance is for.
+        #[allow(non_snake_case)]
+        impl<$($ty: ArrayKey),+> ArrayKey for ($($ty,)+) {
+            const BYTES: usize = 0 $(+ <$ty as ArrayKey>::BYTES)+;
+
+            fn copy_into(&self, buf: &mut [u8]) {
+                assert_buf_len_eq::<Self>(buf);
+                let ($($ty,)+) = self;
+                let mut rest = buf;
+                $(
+                    let (cur, next) = core::mem::take(&mut rest)
+                        .split_at_mut(<$ty as ArrayKey>::BYTES);
+                    $ty.copy_into(cur);
+                    rest = next;
+                )+
+                debug_assert!(rest.is_empty());
+            }
+
+            fn copy_from(buf: &[u8]) -> Self {
+                assert_buf_len_eq::<Self>(buf);
+                let mut rest = buf;
+                $(
+                    let (cur, next) = rest.split_at(<$ty as ArrayKey>::BYTES);
+                    let $ty = <$ty as ArrayKey>::copy_from(cur);
+                    rest = next;
+                )+
+                debug_assert!(rest.is_empty());
+                ($($ty,)+)
+            }
+        }
+    };
+}
+
+decl_array_key_tuple_impl!(A, B);
+decl_array_key_tuple_impl!(A, B, C);
+decl_array_key_tuple_impl!(A, B, C, D);
+decl_array_key_tuple_impl!(A, B, C, D, E);
+decl_array_key_tuple_impl!(A, B, C, D, E, F);
+
+/// Declares an [`ArrayKey`] impl for an integer type, encoding it big-endian.
+macro_rules! decl_array_key_int_impl {
+    ($ty:ty) => {
+        impl ArrayKey for $ty {
+            const BYTES: usize = core::mem::size_of::<$ty>();
+
+            fn copy_into(&self, buf: &mut [u8]) {
+                assert_buf_len_eq::<Self>(buf);
+                buf.copy_from_slice(&<$ty>::to_be_bytes(*self)[..]);
+            }
+
+            fn copy_from(buf: &[u8]) -> Self {
+                assert_buf_len_eq::<Self>(buf);
+                <$ty>::from_be_bytes(buf.try_into().unwrap())
+            }
+        }
+    };
+}
+
+decl_array_key_int_impl!(u8);
+decl_array_key_int_impl!(u16);
+decl_array_key_int_impl!(u32);
+decl_array_key_int_impl!(u64);
+decl_array_key_int_impl!(u128);
+
+decl_array_key_int_impl!(i8);
+decl_array_key_int_impl!(i16);
+decl_array_key_int_impl!(i32);
+decl_array_key_int_impl!(i64);
+decl_array_key_int_impl!(i128);
+
+#[inline(always)]
+fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
+    #[cfg(debug_assertions)]
+    {
+        let len = arr.len();
+        assert_eq!(
+            arr.len(),
+            K::BYTES,
+            "dbkey: passed invalid array (exp {}, got {len})",
+            K::BYTES
+        );
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod tests {
+    use arbitrary::{Arbitrary, Unstructured};
+
+    use super::*;
+
+    /// Number of instances we check per type.
+    const ROUNDS: usize = 64;
+
+    /// Encodes a key and decodes it again, checking we get the same value back
+    /// and that we used exactly the number of bytes we said we would.
+    fn check_roundtrip<K: ArrayKey + Eq + core::fmt::Debug>(k: K) -> Vec<u8> {
+        let mut buf = vec![0u8; K::BYTES];
+        k.copy_into(&mut buf);
+        let dec = K::copy_from(&buf);
+        assert_eq!(dec, k, "dbkey: roundtrip mismatch (buf {buf:?})");
+        buf
+    }
+
+    /// Generates a bunch of arbitrary instances of a key type and roundtrips
+    /// each of them.
+    fn check_roundtrips_arb<'a, K>(u: &mut Unstructured<'a>)
+    where
+        K: ArrayKey + Arbitrary<'a> + Eq + core::fmt::Debug,
+    {
+        for _ in 0..ROUNDS {
+            let k = K::arbitrary(u).expect("test: generate key");
+            check_roundtrip(k);
+        }
+    }
+
+    /// Deterministic pseudorandom byte source so that failures are reproducible.
+    fn gen_entropy(seed: u64, len: usize) -> Vec<u8> {
+        let mut state = seed | 1;
+        (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                (state >> 24) as u8
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_roundtrip_ints() {
+        let ent = gen_entropy(0x1234, 16 * 1024);
+        let u = &mut Unstructured::new(&ent);
+
+        check_roundtrips_arb::<u8>(u);
+        check_roundtrips_arb::<u16>(u);
+        check_roundtrips_arb::<u32>(u);
+        check_roundtrips_arb::<u64>(u);
+        check_roundtrips_arb::<u128>(u);
+
+        check_roundtrips_arb::<i8>(u);
+        check_roundtrips_arb::<i16>(u);
+        check_roundtrips_arb::<i32>(u);
+        check_roundtrips_arb::<i64>(u);
+        check_roundtrips_arb::<i128>(u);
+    }
+
+    #[test]
+    fn test_roundtrip_arrays() {
+        let ent = gen_entropy(0x5678, 16 * 1024);
+        let u = &mut Unstructured::new(&ent);
+
+        check_roundtrips_arb::<[u8; 0]>(u);
+        check_roundtrips_arb::<[u8; 1]>(u);
+        check_roundtrips_arb::<[u8; 4]>(u);
+        check_roundtrips_arb::<[u8; 20]>(u);
+        check_roundtrips_arb::<[u8; 32]>(u);
+    }
+
+    #[test]
+    fn test_roundtrip_tuples() {
+        let ent = gen_entropy(0x9abc, 64 * 1024);
+        let u = &mut Unstructured::new(&ent);
+
+        // Simple cases for each arity we declared impls for.
+        check_roundtrips_arb::<(u32, [u8; 32])>(u);
+        check_roundtrips_arb::<(u64, u32, [u8; 20])>(u);
+        check_roundtrips_arb::<(u8, u16, u32, u64)>(u);
+        check_roundtrips_arb::<(i8, u16, [u8; 3], u64, u128)>(u);
+        check_roundtrips_arb::<(u8, u16, u32, u64, u128, [u8; 7])>(u);
+
+        // Weirder cases, mostly to make sure composition and zero-width members
+        // behave.
+        check_roundtrips_arb::<([u8; 0], u32, [u8; 0])>(u);
+        check_roundtrips_arb::<((u8, u16), (u32, u64))>(u);
+        check_roundtrips_arb::<(u64, ([u8; 4], (i16, [u8; 0])), [u8; 1])>(u);
+        check_roundtrips_arb::<((((u8, u8), u8), u8), u8)>(u);
+    }
+
+    #[test]
+    fn test_bytes_widths() {
+        assert_eq!(<(u32, [u8; 32])>::BYTES, 36);
+        assert_eq!(<([u8; 0], u32, [u8; 0])>::BYTES, 4);
+        assert_eq!(<(u8, u16, u32, u64, u128, [u8; 7])>::BYTES, 38);
+        assert_eq!(<(u64, ([u8; 4], (i16, [u8; 0])), [u8; 1])>::BYTES, 15);
+    }
+
+    #[test]
+    fn test_layout_is_flat_be_concat() {
+        // Members are laid out in order, big-endian, with no padding.
+        let buf = check_roundtrip((0x01u8, 0x0203u16, [0x04u8, 0x05]));
+        assert_eq!(buf, vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+
+        // ...so nesting doesn't change the encoding, only the type.
+        let nested = check_roundtrip((0x01u8, (0x0203u16, [0x04u8, 0x05])));
+        assert_eq!(nested, buf);
+    }
+}

--- a/crates/identifiers/src/key_types.rs
+++ b/crates/identifiers/src/key_types.rs
@@ -245,16 +245,13 @@ pub(crate) use decl_array_key_wrapper_impl;
 
 #[inline(always)]
 pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
-    #[cfg(debug_assertions)]
-    {
-        let len = arr.len();
-        assert_eq!(
-            arr.len(),
-            K::BYTES,
-            "arraykey: passed invalid array (exp {}, got {len})",
-            K::BYTES
-        );
-    }
+    let len = arr.len();
+    assert_eq!(
+        arr.len(),
+        K::BYTES,
+        "arraykey: passed invalid array (exp {}, got {len})",
+        K::BYTES
+    );
 }
 
 #[cfg(all(test, feature = "arbitrary"))]

--- a/crates/identifiers/src/key_types.rs
+++ b/crates/identifiers/src/key_types.rs
@@ -42,6 +42,68 @@ impl<const N: usize> ArrayKey for [u8; N] {
     }
 }
 
+/// Extension trait for "buffer types" that we might want to decode as an [`ArrayKey`].
+pub trait ArrayKeyBuf {
+    /// Attempts to decode the buf into an [`ArrayKey`] type.
+    ///
+    /// Returns `None` if the array is not the right size.
+    fn try_into_key<K: ArrayKey>(&self) -> Option<K>;
+}
+
+impl<T: AsRef<[u8]>> ArrayKeyBuf for T {
+    fn try_into_key<K: ArrayKey>(&self) -> Option<K> {
+        let buf = <Self as AsRef<[u8]>>::as_ref(self);
+        if buf.len() == K::BYTES {
+            Some(K::copy_from(buf))
+        } else {
+            None
+        }
+    }
+}
+
+/// Extension trait for array types that we might want to decode as an [`ArrayKey`].
+///
+/// Unlike [`ArrayKeyBuf`], this is infallible, since the array length is known
+/// statically and MUST be checked at compile time.
+///
+/// You shouldn't have to implement this on your own types, it's just so we can
+/// add trait member fn to `[u8; N]`.
+pub trait ArrayKeyArr<const N: usize> {
+    /// Decodes the array into an [`ArrayKey`] type of exactly the same width.
+    ///
+    /// Instantiating this with a key type whose width isn't `N` MUST fail to
+    /// compile.
+    fn into_key<K: ArrayKey>(self) -> K;
+}
+
+/// Impl for `[u8; N]` arrays that provides the guarantees we expect.
+impl<const N: usize> ArrayKeyArr<N> for [u8; N] {
+    fn into_key<K: ArrayKey>(self) -> K {
+        // Ideally this would be a bound like `K: ArrayKey<BYTES = { N }>`, but
+        // that needs `associated_const_equality`, which isn't stable.  An
+        // inline const inherits the generics of the fn it's in, so we can check
+        // the same thing here, just at monomorphization time instead of when
+        // typechecking the call.
+        assert_key_width_eq::<N, K>();
+        K::copy_from(&self)
+    }
+}
+
+/// Fails to compile if `K` is not exactly `N` bytes wide.
+///
+/// This is a post-monomorphization error, so it only fires where this is
+/// actually instantiated.  That's every real call, but it does mean a bad
+/// instantiation sitting in generic code that's never called goes unreported.
+#[inline(always)]
+fn assert_key_width_eq<const N: usize, K: ArrayKey>() {
+    const {
+        assert!(
+            N == K::BYTES,
+            "arraykey: array length does not match key width"
+        )
+    };
+}
+
 /// Declares an [`ArrayKey`] impl for a tuple of the arity implied by the number
 /// of type parameter names passed to it.
 ///
@@ -189,7 +251,7 @@ pub(crate) fn assert_buf_len_eq<K: ArrayKey>(arr: &[u8]) {
         assert_eq!(
             arr.len(),
             K::BYTES,
-            "dbkey: passed invalid array (exp {}, got {len})",
+            "arraykey: passed invalid array (exp {}, got {len})",
             K::BYTES
         );
     }
@@ -210,7 +272,7 @@ mod tests {
         let mut buf = vec![0u8; K::BYTES];
         k.copy_into(&mut buf);
         let dec = K::copy_from(&buf);
-        assert_eq!(dec, k, "dbkey: roundtrip mismatch (buf {buf:?})");
+        assert_eq!(dec, k, "test: roundtrip mismatch (buf {buf:?})");
         buf
     }
 
@@ -348,6 +410,29 @@ mod tests {
             check_roundtrip((s.idx, s.pad, s.id, s.flag)),
             "struct should encode as its fields in order"
         );
+    }
+
+    #[test]
+    fn test_into_key_from_arr() {
+        // Arrays are their own key type, so this is just a passthrough.
+        assert_eq!([1u8, 2, 3, 4].into_key::<[u8; 4]>(), [1, 2, 3, 4]);
+        assert_eq!([].into_key::<[u8; 0]>(), [0u8; 0]);
+
+        // Ints decode big-endian, matching `copy_from`.
+        assert_eq!([0x01u8, 0x02, 0x03, 0x04].into_key::<u32>(), 0x01020304);
+        assert_eq!([0xffu8].into_key::<i8>(), -1);
+
+        // Composites work too, which is the case a length marker trait
+        // couldn't have covered.
+        let (a, b) = [0x01u8, 0x02, 0x03, 0x04, 0x05].into_key::<(u8, u32)>();
+        assert_eq!((a, b), (0x01, 0x02030405));
+
+        let w = [0x11u8; 12].into_key::<TestWrapper>();
+        assert_eq!(w, TestWrapper([0x11; 12]));
+
+        // ...and it agrees with going through `copy_from` directly.
+        let buf = [0xa5u8; 17];
+        assert_eq!(buf.into_key::<TestStruct>(), TestStruct::copy_from(&buf));
     }
 
     #[test]

--- a/crates/identifiers/src/key_types.rs
+++ b/crates/identifiers/src/key_types.rs
@@ -16,14 +16,14 @@ pub trait ArrayKey {
     ///
     /// # Panics
     ///
-    /// If called with a slice that is not [`Self::WIDTH`] bytes.
+    /// If called with a slice that is not [`Self::BYTES`] bytes.
     fn copy_into(&self, buf: &mut [u8]);
 
     /// Constructs an instance of the key by decoding from bytes.
     ///
     /// # Panics
     ///
-    /// If called with a slice that is not [`Self::WIDTH`] bytes.
+    /// If called with a slice that is not [`Self::BYTES`] bytes.
     fn copy_from(buf: &[u8]) -> Self;
 }
 

--- a/crates/identifiers/src/l1.rs
+++ b/crates/identifiers/src/l1.rs
@@ -12,8 +12,8 @@ use ssz_derive::{Decode, Encode};
 #[cfg(feature = "codec")]
 use strata_codec::Codec;
 
+use crate::array_keys::decl_array_key_struct_impl;
 use crate::buf::{Buf32, RBuf32};
-use crate::key_types::decl_array_key_struct_impl;
 
 /// L1 block height (as a simple u32)
 pub type L1Height = u32;

--- a/crates/identifiers/src/l1.rs
+++ b/crates/identifiers/src/l1.rs
@@ -13,6 +13,7 @@ use ssz_derive::{Decode, Encode};
 use strata_codec::Codec;
 
 use crate::buf::{Buf32, RBuf32};
+use crate::key_types::decl_array_key_struct_impl;
 
 /// L1 block height (as a simple u32)
 pub type L1Height = u32;
@@ -83,6 +84,8 @@ pub struct L1BlockCommitment {
 
 #[cfg(feature = "ssz")]
 crate::impl_ssz_fixed_container!(L1BlockCommitment, [height: L1Height, blkid: L1BlockId]);
+
+decl_array_key_struct_impl!(L1BlockCommitment, [height: L1Height, blkid: L1BlockId]);
 
 impl fmt::Display for L1BlockCommitment {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -36,7 +36,7 @@ pub use acct::{
     AccountId, AccountSerial, AccountTypeId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL,
     RawAccountTypeId, SUBJ_ID_LEN, SYSTEM_RESERVED_ACCTS, SubjectId, SubjectIdBytes,
 };
-pub use array_keys::{ArrayKey, ArrayKeyArr, ArrayKeyBuf};
+pub use array_keys::{ArrayKey, ArrayKeyArr, ArrayKeyBuf, ArrayKeyExt};
 pub use buf::{Buf20, Buf32, Buf64, RBuf32};
 pub use epoch::EpochCommitment;
 #[cfg(feature = "ssz")]

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -43,7 +43,7 @@ pub use epoch::EpochCommitmentRef;
 #[cfg(feature = "borsh")]
 pub use exec::create_evm_extra_payload;
 pub use exec::{EVMExtraPayload, EvmEeBlockCommitment, ExecBlockCommitment, Hash};
-pub use key_types::ArrayKey;
+pub use key_types::{ArrayKey, ArrayKeyArr, ArrayKeyBuf};
 #[cfg(feature = "ssz")]
 pub use l1::L1BlockCommitmentRef;
 pub use l1::{L1BlockCommitment, L1BlockId, L1Height, WtxidsRoot};

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -17,6 +17,7 @@ mod acct;
 mod buf;
 mod epoch;
 mod exec;
+mod key_types;
 mod l1;
 mod ol;
 
@@ -42,6 +43,7 @@ pub use epoch::EpochCommitmentRef;
 #[cfg(feature = "borsh")]
 pub use exec::create_evm_extra_payload;
 pub use exec::{EVMExtraPayload, EvmEeBlockCommitment, ExecBlockCommitment, Hash};
+pub use key_types::ArrayKey;
 #[cfg(feature = "ssz")]
 pub use l1::L1BlockCommitmentRef;
 pub use l1::{L1BlockCommitment, L1BlockId, L1Height, WtxidsRoot};

--- a/crates/identifiers/src/lib.rs
+++ b/crates/identifiers/src/lib.rs
@@ -14,10 +14,10 @@ use strata_ssz_tests as _;
 mod macros;
 
 mod acct;
+mod array_keys;
 mod buf;
 mod epoch;
 mod exec;
-mod key_types;
 mod l1;
 mod ol;
 
@@ -36,6 +36,7 @@ pub use acct::{
     AccountId, AccountSerial, AccountTypeId, BRIDGE_GATEWAY_ACCT_ID, BRIDGE_GATEWAY_ACCT_SERIAL,
     RawAccountTypeId, SUBJ_ID_LEN, SYSTEM_RESERVED_ACCTS, SubjectId, SubjectIdBytes,
 };
+pub use array_keys::{ArrayKey, ArrayKeyArr, ArrayKeyBuf};
 pub use buf::{Buf20, Buf32, Buf64, RBuf32};
 pub use epoch::EpochCommitment;
 #[cfg(feature = "ssz")]
@@ -43,7 +44,6 @@ pub use epoch::EpochCommitmentRef;
 #[cfg(feature = "borsh")]
 pub use exec::create_evm_extra_payload;
 pub use exec::{EVMExtraPayload, EvmEeBlockCommitment, ExecBlockCommitment, Hash};
-pub use key_types::{ArrayKey, ArrayKeyArr, ArrayKeyBuf};
 #[cfg(feature = "ssz")]
 pub use l1::L1BlockCommitmentRef;
 pub use l1::{L1BlockCommitment, L1BlockId, L1Height, WtxidsRoot};

--- a/crates/identifiers/src/macros/buf.rs
+++ b/crates/identifiers/src/macros/buf.rs
@@ -96,6 +96,8 @@ macro_rules! impl_buf_core {
                 Self([0; $len])
             }
         }
+
+        $crate::key_types::decl_array_key_wrapper_impl!($name => [u8; $len]);
     };
 }
 

--- a/crates/identifiers/src/macros/buf.rs
+++ b/crates/identifiers/src/macros/buf.rs
@@ -97,7 +97,7 @@ macro_rules! impl_buf_core {
             }
         }
 
-        $crate::key_types::decl_array_key_wrapper_impl!($name => [u8; $len]);
+        $crate::array_keys::decl_array_key_wrapper_impl!($name => [u8; $len]);
     };
 }
 

--- a/crates/identifiers/src/macros/wrapper.rs
+++ b/crates/identifiers/src/macros/wrapper.rs
@@ -93,5 +93,18 @@ macro_rules! impl_buf_wrapper {
                 ::core::fmt::Display::fmt(&self.0, f)
             }
         }
+
+        // Same encoding as the buffer we wrap.
+        impl $crate::ArrayKey for $wrapper {
+            const BYTES: usize = <$name as $crate::ArrayKey>::BYTES;
+
+            fn copy_into(&self, buf: &mut [u8]) {
+                <$name as $crate::ArrayKey>::copy_into(&self.0, buf);
+            }
+
+            fn copy_from(buf: &[u8]) -> Self {
+                Self(<$name as $crate::ArrayKey>::copy_from(buf))
+            }
+        }
     };
 }

--- a/crates/identifiers/src/ol.rs
+++ b/crates/identifiers/src/ol.rs
@@ -11,8 +11,8 @@ use ssz_derive::{Decode, Encode};
 #[cfg(feature = "codec")]
 use strata_codec::Codec;
 
+use crate::array_keys::decl_array_key_struct_impl;
 use crate::buf::Buf32;
-use crate::key_types::decl_array_key_struct_impl;
 
 /// Sequential slot number within the OL chain.
 pub type Slot = u64;

--- a/crates/identifiers/src/ol.rs
+++ b/crates/identifiers/src/ol.rs
@@ -12,6 +12,7 @@ use ssz_derive::{Decode, Encode};
 use strata_codec::Codec;
 
 use crate::buf::Buf32;
+use crate::key_types::decl_array_key_struct_impl;
 
 /// Sequential slot number within the OL chain.
 pub type Slot = u64;
@@ -63,6 +64,8 @@ pub struct OLBlockCommitment {
 
 #[cfg(feature = "ssz")]
 crate::impl_ssz_fixed_container!(OLBlockCommitment, [slot: Slot, blkid: OLBlockId]);
+
+decl_array_key_struct_impl!(OLBlockCommitment, [slot: Slot, blkid: OLBlockId]);
 
 impl OLBlockCommitment {
     /// Creates a new block commitment from a slot and block ID.


### PR DESCRIPTION
## Description

This PR adds a trait to capture identifiers that are isomorphic to fixed-size byte arrays of some size, and then implements it on several types.  This seems like it'd be useful for making the database layer more generic in the future.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

I wish we had magical future Rust features so this could be a lot cooler!  This is kinda limited as-is, unfortunately.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
