### PR TITLE
fix(predicate): stop panicking on untrusted predicate key input

### DIFF
--- a/crates/predicate/src/arbitrary.rs
+++ b/crates/predicate/src/arbitrary.rs
@@ -18,6 +18,6 @@ impl<'a> Arbitrary<'a> for PredicateKey {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let id = PredicateTypeId::arbitrary(u)?;
         let condition = Vec::<u8>::arbitrary(u)?;
-        Ok(PredicateKey::new(id, condition))
+        PredicateKey::try_new(id, condition).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }

--- a/crates/predicate/src/borsh.rs
+++ b/crates/predicate/src/borsh.rs
@@ -48,7 +48,7 @@ mod tests {
                 id in predicate_type_id_strategy(),
                 condition in bounded_condition_strategy(256)
             ) {
-                let predkey = PredicateKey::new(id, condition.clone());
+                let predkey = PredicateKey::try_new(id, condition.clone()).unwrap();
                 let serialized = borsh::to_vec(&predkey).unwrap();
 
                 // The borsh format serializes to_bytes() output as Vec<u8>

--- a/crates/predicate/src/errors.rs
+++ b/crates/predicate/src/errors.rs
@@ -21,6 +21,15 @@ pub enum PredicateError {
     #[error("missing predicate type")]
     MissingPredicateType,
 
+    /// Predicate condition bytes exceed the maximum allowed length.
+    #[error("condition length {len} exceeds maximum of {max} bytes")]
+    ConditionTooLong {
+        /// The length of the provided condition bytes.
+        len: usize,
+        /// The maximum allowed condition length.
+        max: usize,
+    },
+
     /// Unknown predicate type name in string parsing.
     #[error("unknown predicate type name: {0}")]
     UnknownPredicateTypeName(String),

--- a/crates/predicate/src/errors.rs
+++ b/crates/predicate/src/errors.rs
@@ -7,6 +7,7 @@
 
 use thiserror::Error;
 
+use crate::MAX_CONDITION_LEN;
 use crate::type_ids::PredicateTypeId;
 
 /// Errors that can occur when working with predicates, claims, and witnesses.
@@ -22,12 +23,10 @@ pub enum PredicateError {
     MissingPredicateType,
 
     /// Predicate condition bytes exceed the maximum allowed length.
-    #[error("condition length {len} exceeds maximum of {max} bytes")]
+    #[error("condition length {len} exceeds maximum of {MAX_CONDITION_LEN} bytes")]
     ConditionTooLong {
         /// The length of the provided condition bytes.
         len: usize,
-        /// The maximum allowed condition length.
-        max: usize,
     },
 
     /// Unknown predicate type name in string parsing.

--- a/crates/predicate/src/key.rs
+++ b/crates/predicate/src/key.rs
@@ -69,21 +69,13 @@ impl PredicateKey {
             .expect("empty condition is always within the length limit")
     }
 
-    /// Returns a borrowed view of this predicate key as a `PredicateKeyBuf`.
+    /// Attempts to borrow this predicate key as a `PredicateKeyBuf`.
     ///
-    /// This provides zero-copy access to the predicate key condition bytes.
-    ///
-    /// # Panics
-    /// Panics if the raw type identifier doesn't map to a known [`PredicateTypeId`]. This can't
-    /// happen for a key built through [`PredicateKey::try_new`], but the SSZ-decoded `id` field is
-    /// an unvalidated raw byte, so a key decoded from untrusted bytes (e.g. `from_ssz_bytes`) can
-    /// carry an unregistered type. Use [`Self::try_as_buf_ref`] for keys of unknown provenance.
-    pub fn as_buf_ref(&self) -> PredicateKeyBuf<'_> {
-        self.try_as_buf_ref()
-            .expect("predicate type should be validated at construction")
-    }
-
-    /// Attempts to borrow this predicate key as a `PredicateKeyBuf` without panicking.
+    /// # Errors
+    /// Returns an error if the raw type identifier doesn't map to a known [`PredicateTypeId`].
+    /// This can't happen for a key built through [`PredicateKey::try_new`], but the SSZ-decoded
+    /// `id` field is an unvalidated raw byte, so a key decoded from untrusted bytes (e.g.
+    /// `from_ssz_bytes`) can carry an unregistered type.
     pub fn try_as_buf_ref(&self) -> PredicateResult<PredicateKeyBuf<'_>> {
         Ok(PredicateKeyBuf {
             id: self.id.try_into()?,
@@ -201,7 +193,7 @@ mod tests {
             let condition = predkey.condition().to_vec();
             let id: PredicateTypeId = predkey.id().try_into().unwrap();
             let predkey = PredicateKey::try_new(id, condition.clone()).unwrap();
-            let buf = predkey.as_buf_ref();
+            let buf = predkey.try_as_buf_ref().unwrap();
 
             prop_assert_eq!(buf.id(), id);
             prop_assert_eq!(buf.condition(), condition.as_slice());

--- a/crates/predicate/src/key.rs
+++ b/crates/predicate/src/key.rs
@@ -32,10 +32,7 @@ impl PredicateKey {
         let len = condition.len();
         let condition = condition
             .try_into()
-            .map_err(|_| PredicateError::ConditionTooLong {
-                len,
-                max: MAX_CONDITION_LEN as usize,
-            })?;
+            .map_err(|_| PredicateError::ConditionTooLong { len })?;
         Ok(Self {
             id: id.as_u8(),
             condition,
@@ -112,11 +109,9 @@ impl<'b> TryFrom<&'b [u8]> for PredicateKeyBuf<'b> {
 
         let id = PredicateTypeId::try_from(bytes[0])?;
         let condition = &bytes[1..];
-        let max = MAX_CONDITION_LEN as usize;
-        if condition.len() > max {
+        if condition.len() > MAX_CONDITION_LEN as usize {
             return Err(PredicateError::ConditionTooLong {
                 len: condition.len(),
-                max,
             });
         }
 
@@ -258,8 +253,8 @@ mod tests {
         let result = PredicateKey::try_new(PredicateTypeId::AlwaysAccept, oversized);
         assert!(matches!(
             result,
-            Err(PredicateError::ConditionTooLong { len, max })
-            if len == MAX_CONDITION_LEN as usize + 1 && max == MAX_CONDITION_LEN as usize
+            Err(PredicateError::ConditionTooLong { len })
+            if len == MAX_CONDITION_LEN as usize + 1
         ));
     }
 
@@ -271,8 +266,8 @@ mod tests {
         let result = PredicateKeyBuf::try_from(bytes.as_slice());
         assert!(matches!(
             result,
-            Err(PredicateError::ConditionTooLong { len, max })
-            if len == MAX_CONDITION_LEN as usize + 1 && max == MAX_CONDITION_LEN as usize
+            Err(PredicateError::ConditionTooLong { len })
+            if len == MAX_CONDITION_LEN as usize + 1
         ));
     }
 

--- a/crates/predicate/src/key.rs
+++ b/crates/predicate/src/key.rs
@@ -1,9 +1,9 @@
 //! Predicate key implementation and type registry.
 
-use crate::PredicateKey;
 use crate::errors::{PredicateError, PredicateResult};
 use crate::type_ids::PredicateTypeId;
 use crate::verifiers::VerifierType;
+use crate::{MAX_CONDITION_LEN, PredicateKey};
 
 /// A zero-copy predicate key that borrows from a buffer.
 ///
@@ -25,17 +25,21 @@ impl PredicateKey {
     /// * `id` - The predicate type identifier indicating which backend to use
     /// * `condition` - The backend-specific predicate condition bytes
     ///
-    /// # Examples
-    /// ```
-    /// use strata_predicate::{PredicateKey, PredicateTypeId};
-    ///
-    /// let predkey = PredicateKey::new(PredicateTypeId::AlwaysAccept, b"test".to_vec());
-    /// ```
-    pub fn new(id: PredicateTypeId, condition: Vec<u8>) -> Self {
-        Self {
+    /// # Errors
+    /// Returns [`PredicateError::ConditionTooLong`] if `condition` is longer than
+    /// [`MAX_CONDITION_LEN`].
+    pub fn try_new(id: PredicateTypeId, condition: Vec<u8>) -> PredicateResult<Self> {
+        let len = condition.len();
+        let condition = condition
+            .try_into()
+            .map_err(|_| PredicateError::ConditionTooLong {
+                len,
+                max: MAX_CONDITION_LEN as usize,
+            })?;
+        Ok(Self {
             id: id.as_u8(),
-            condition: condition.try_into().expect("valid length"),
-        }
+            condition,
+        })
     }
 
     /// Returns the raw predicate type identifier.
@@ -53,19 +57,27 @@ impl PredicateKey {
     /// This is useful for testing scenarios where you need a predicate that
     /// unconditionally validates any input.
     pub fn always_accept() -> Self {
-        Self::new(PredicateTypeId::AlwaysAccept, Vec::new())
+        Self::try_new(PredicateTypeId::AlwaysAccept, Vec::new())
+            .expect("empty condition is always within the length limit")
     }
 
     /// Creates a predicate key that never accepts any witness for any claim.
     ///
     /// This represents an empty/invalid predicate that will reject all verification attempts.
     pub fn never_accept() -> Self {
-        Self::new(PredicateTypeId::NeverAccept, Vec::new())
+        Self::try_new(PredicateTypeId::NeverAccept, Vec::new())
+            .expect("empty condition is always within the length limit")
     }
 
     /// Returns a borrowed view of this predicate key as a `PredicateKeyBuf`.
     ///
     /// This provides zero-copy access to the predicate key condition bytes.
+    ///
+    /// # Panics
+    /// Panics if the raw type identifier doesn't map to a known [`PredicateTypeId`]. This can't
+    /// happen for a key built through [`PredicateKey::try_new`], but the SSZ-decoded `id` field is
+    /// an unvalidated raw byte, so a key decoded from untrusted bytes (e.g. `from_ssz_bytes`) can
+    /// carry an unregistered type. Use [`Self::try_as_buf_ref`] for keys of unknown provenance.
     pub fn as_buf_ref(&self) -> PredicateKeyBuf<'_> {
         self.try_as_buf_ref()
             .expect("predicate type should be validated at construction")
@@ -107,10 +119,16 @@ impl<'b> TryFrom<&'b [u8]> for PredicateKeyBuf<'b> {
         }
 
         let id = PredicateTypeId::try_from(bytes[0])?;
-        Ok(Self {
-            id,
-            condition: &bytes[1..],
-        })
+        let condition = &bytes[1..];
+        let max = MAX_CONDITION_LEN as usize;
+        if condition.len() > max {
+            return Err(PredicateError::ConditionTooLong {
+                len: condition.len(),
+                max,
+            });
+        }
+
+        Ok(Self { id, condition })
     }
 }
 
@@ -141,7 +159,14 @@ impl<'b> PredicateKeyBuf<'b> {
     pub fn to_owned(&self) -> PredicateKey {
         PredicateKey {
             id: self.id.as_u8(),
-            condition: self.condition.to_vec().try_into().expect("valid length"),
+            // Every `PredicateKeyBuf` is built either from `TryFrom<&[u8]>` (which enforces the
+            // length bound) or from `PredicateKey::try_as_buf_ref` (whose condition is already a
+            // bounded `VariableList`), so this can never exceed `MAX_CONDITION_LEN`.
+            condition: self
+                .condition
+                .to_vec()
+                .try_into()
+                .expect("condition length bounded by construction"),
         }
     }
 
@@ -175,7 +200,7 @@ mod tests {
         proptest!(|(predkey in predicate_key_strategy())| {
             let condition = predkey.condition().to_vec();
             let id: PredicateTypeId = predkey.id().try_into().unwrap();
-            let predkey = PredicateKey::new(id, condition.clone());
+            let predkey = PredicateKey::try_new(id, condition.clone()).unwrap();
             let buf = predkey.as_buf_ref();
 
             prop_assert_eq!(buf.id(), id);
@@ -236,9 +261,33 @@ mod tests {
     }
 
     #[test]
+    fn test_try_new_rejects_oversized_condition() {
+        let oversized = vec![0u8; MAX_CONDITION_LEN as usize + 1];
+        let result = PredicateKey::try_new(PredicateTypeId::AlwaysAccept, oversized);
+        assert!(matches!(
+            result,
+            Err(PredicateError::ConditionTooLong { len, max })
+            if len == MAX_CONDITION_LEN as usize + 1 && max == MAX_CONDITION_LEN as usize
+        ));
+    }
+
+    #[test]
+    fn test_try_from_rejects_oversized_condition() {
+        let mut bytes = vec![PredicateTypeId::AlwaysAccept.as_u8()];
+        bytes.extend(vec![0u8; MAX_CONDITION_LEN as usize + 1]);
+
+        let result = PredicateKeyBuf::try_from(bytes.as_slice());
+        assert!(matches!(
+            result,
+            Err(PredicateError::ConditionTooLong { len, max })
+            if len == MAX_CONDITION_LEN as usize + 1 && max == MAX_CONDITION_LEN as usize
+        ));
+    }
+
+    #[test]
     #[cfg(not(feature = "schnorr"))]
     fn test_unsupported_schnorr_gives_helpful_error() {
-        let predkey = PredicateKey::new(PredicateTypeId::Bip340Schnorr, vec![0u8; 32]);
+        let predkey = PredicateKey::try_new(PredicateTypeId::Bip340Schnorr, vec![0u8; 32]).unwrap();
         let claim = b"test claim";
         let witness = b"test witness";
 
@@ -256,7 +305,7 @@ mod tests {
     #[test]
     #[cfg(not(feature = "sp1-groth16"))]
     fn test_unsupported_sp1_gives_helpful_error() {
-        let predkey = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0u8; 32]);
+        let predkey = PredicateKey::try_new(PredicateTypeId::Sp1Groth16, vec![0u8; 32]).unwrap();
         let claim = b"test claim";
         let witness = b"test witness";
 

--- a/crates/predicate/src/lib.rs
+++ b/crates/predicate/src/lib.rs
@@ -41,7 +41,8 @@
 //! use strata_predicate::{PredicateKey, PredicateTypeId};
 //!
 //! // Create a predicate key (always accept type for testing)
-//! let predkey = PredicateKey::new(PredicateTypeId::AlwaysAccept, b"test_condition".to_vec());
+//! let predkey =
+//!     PredicateKey::try_new(PredicateTypeId::AlwaysAccept, b"test_condition".to_vec()).unwrap();
 //!
 //! // Define claim and witness data
 //! let claim = b"hello world";

--- a/crates/predicate/src/lib.rs
+++ b/crates/predicate/src/lib.rs
@@ -49,7 +49,7 @@
 //! let witness = b"test_signature";
 //!
 //! // Verify using the global function
-//! let predicate_bytes = predkey.as_buf_ref().to_bytes();
+//! let predicate_bytes = predkey.try_as_buf_ref().unwrap().to_bytes();
 //! strata_predicate::verify_claim_witness(&predicate_bytes, claim, witness).unwrap();
 //!
 //! // Or verify using the predicate key method

--- a/crates/predicate/src/serde.rs
+++ b/crates/predicate/src/serde.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for PredicateKey {
                     .map_err(|e| serde::de::Error::custom(format!("Invalid hex encoding: {e}")))?
             };
 
-            Ok(PredicateKey::new(id, condition))
+            PredicateKey::try_new(id, condition).map_err(serde::de::Error::custom)
         } else {
             struct PredicateKeyVisitor;
 
@@ -111,7 +111,7 @@ impl<'de> Deserialize<'de> for PredicateKey {
                         serde::de::Error::custom(format!("Invalid predicate type ID: {e}"))
                     })?;
 
-                    Ok(PredicateKey::new(id, condition))
+                    PredicateKey::try_new(id, condition).map_err(serde::de::Error::custom)
                 }
             }
 
@@ -139,10 +139,11 @@ mod tests {
         assert_eq!(predkey1, deserialized1);
 
         // Test with non-empty condition
-        let predkey2 = PredicateKey::new(
+        let predkey2 = PredicateKey::try_new(
             PredicateTypeId::Bip340Schnorr,
             vec![0x01, 0x02, 0x03, 0x04, 0x05],
-        );
+        )
+        .unwrap();
         let json2 = serde_json::to_string(&predkey2).unwrap();
         assert_eq!(json2, r#""Bip340Schnorr:0102030405""#);
 
@@ -151,7 +152,9 @@ mod tests {
         assert_eq!(predkey2, deserialized2);
 
         // Test with another predicate type
-        let predkey3 = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef]);
+        let predkey3 =
+            PredicateKey::try_new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef])
+                .unwrap();
         let json3 = serde_json::to_string(&predkey3).unwrap();
         assert_eq!(json3, r#""Sp1Groth16:deadbeef""#);
 
@@ -168,16 +171,19 @@ mod tests {
         assert_eq!(predkey1, decoded1);
 
         // Test with non-empty condition
-        let predkey2 = PredicateKey::new(
+        let predkey2 = PredicateKey::try_new(
             PredicateTypeId::Bip340Schnorr,
             vec![0x01, 0x02, 0x03, 0x04, 0x05],
-        );
+        )
+        .unwrap();
         let encoded2 = bincode::serialize(&predkey2).unwrap();
         let decoded2: PredicateKey = bincode::deserialize(&encoded2).unwrap();
         assert_eq!(predkey2, decoded2);
 
         // Test with another predicate type
-        let predkey3 = PredicateKey::new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef]);
+        let predkey3 =
+            PredicateKey::try_new(PredicateTypeId::Sp1Groth16, vec![0xde, 0xad, 0xbe, 0xef])
+                .unwrap();
         let encoded3 = bincode::serialize(&predkey3).unwrap();
         let decoded3: PredicateKey = bincode::deserialize(&encoded3).unwrap();
         assert_eq!(predkey3, decoded3);

--- a/crates/predicate/src/test_utils.rs
+++ b/crates/predicate/src/test_utils.rs
@@ -74,5 +74,5 @@ pub(crate) fn bounded_condition_strategy(max_len: usize) -> impl Strategy<Value 
 
 pub(crate) fn predicate_key_strategy() -> impl Strategy<Value = PredicateKey> {
     (predicate_type_id_strategy(), condition_strategy())
-        .prop_map(|(id, condition)| PredicateKey::new(id, condition))
+        .prop_map(|(id, condition)| PredicateKey::try_new(id, condition).unwrap())
 }


### PR DESCRIPTION
## Description

`strata-predicate` panicked instead of returning an error in two places reachable from untrusted input:

- `PredicateKey::new` converted the caller-supplied condition bytes into a length-bounded SSZ list with `.expect("valid length")`, and `PredicateKeyBuf`'s `TryFrom<&[u8]>` never checked the condition length at all. Both are reachable from deserialization (serde JSON/bincode, `arbitrary`, and borsh via `PredicateKeyBuf::try_from` + `to_owned`), so an oversized condition in externally supplied bytes crashed the process instead of failing to decode.
- `PredicateKey::as_buf_ref` panicked whenever the raw SSZ-decoded type id wasn't a registered `PredicateTypeId`. That's not a can't-happen case: the id is stored as an unvalidated raw byte specifically so the format can round-trip predicate types a given build doesn't know about. `try_as_buf_ref` already existed to handle this gracefully.

The constructor is renamed `try_new` and returns `Result`; `as_buf_ref` is removed in favor of the existing `try_as_buf_ref`.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] New or updated tests

## Notes to Reviewers

This is a public API break for `PredicateKey::new` (now `try_new`, returns `Result`) and removes `PredicateKey::as_buf_ref`. Downstream repos (alpen, alpen-ee, asm, strata-bridge) pin this crate via git tag/rev, so nothing breaks until they bump the dependency; call sites there will need updating separately when that happens.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

N/A