### PR TITLE
feat: derive Clone on CodecError, MerkleError and ServiceError

### DIFF
--- a/crates/codec/src/errors.rs
+++ b/crates/codec/src/errors.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// Errors from strata-codec.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum CodecError {
     /// For use when we read a container length field that implies a container
     /// of a larger size than allowed in the context.

--- a/crates/merkle/src/error.rs
+++ b/crates/merkle/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for the Merkle Mountain Range (MMR) crate.
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 /// Errors that can occur when operating on the MMR.
 pub enum MerkleError {
     /// The MMR has no elements.

--- a/crates/service/src/errors.rs
+++ b/crates/service/src/errors.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// Errors originating in the service framework.
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum ServiceError {
     /// We cancelled the wait for input, somehow.
     #[error("wait for input cancelled")]


### PR DESCRIPTION
## Description

Derives `Clone` on `CodecError`, `MerkleError` and `ServiceError`.

A consumer that needs to both hand an error back to a caller and keep a copy for itself currently cannot, because these three are not `Clone`. The workaround is to render one of the two copies to a string, which loses the source chain.

The concrete case is in `asm`: when the ASM worker hits a fatal sync failure it must send the typed error to the caller through a completion channel *and* return it so its critical task fails and the runner shuts down (alpenlabs/asm#229). Only one side can own the value, so the other gets a rendered string.

All three types carry only unit variants plus a `String` or a `&'static str`, so `Clone` is free here — no allocation beyond what the variants already hold, and no constraint on future variants beyond what the existing `Debug` bound implies. Five of the fifteen error types in this workspace already derive it, including `strata-btc-types`' with the same `Debug, Clone, Error` ordering used here.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Adding a derive is additive for downstream code, so nothing here should break consumers.

Worth knowing what this does and does not unblock. It clears the three upstream links in a longer chain — the downstream goal is `Clone` on `asm`'s `WorkerError`, and that also needs `std::io::Error` (in `AsmManifestError`) and three `anyhow::Error` fields, neither of which can ever be `Clone`. Those remaining blockers are `asm`'s problem and will need `Arc` wrapping there. So please review this on its own merits — consistency with the error types that already derive `Clone`, and removing a needless restriction on consumers — rather than as the fix for that specific downstream want.

I picked `Clone` rather than `Copy` for `CodecError` (whose payloads are all `&'static str` and would allow it) to stay consistent with the other error types and to avoid locking out a future variant with an owned payload.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

No tests added: a derive has no behaviour to test beyond the compiler accepting it, and downstream use is what exercises it. Full workspace `cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` all pass.

## Related Issues

Unblocks part of alpenlabs/asm#229.
