### PR TITLE
fix(service): wake a sync worker on shutdown instead of only on input

### DIFF
--- a/crates/service/src/adapters/mpsc.rs
+++ b/crates/service/src/adapters/mpsc.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
 
+use futures::FutureExt;
 use tokio::sync::mpsc;
 
-use crate::{AsyncServiceInput, ServiceInput, ServiceMsg, SyncServiceInput};
+use crate::{AsyncGuard, AsyncServiceInput, ServiceInput, ServiceMsg, SyncServiceInput};
 
 /// Adapter for using a mpsc receiver as a input.
 ///
@@ -52,6 +53,46 @@ impl<T: ServiceMsg> SyncServiceInput for TokioMpscInput<T> {
         let item = self.rx.blocking_recv();
         self.closed |= item.is_none();
         Ok(item)
+    }
+
+    fn recv_next_until_shutdown(
+        &mut self,
+        shutdown: &(impl AsyncGuard + Sync),
+    ) -> anyhow::Result<Option<Self::Msg>> {
+        if self.closed {
+            return Ok(None);
+        }
+
+        // A command channel is held open by its senders for the life of the
+        // process, so the plain `blocking_recv` above parks until the next
+        // message no matter what else is going on.  Wait on the shutdown signal
+        // alongside it instead.
+        //
+        // `futures::executor::block_on` rather than a tokio runtime: both halves
+        // here are driven purely by wakers (an mpsc channel and, for
+        // `strata-tasks`, an `AtomicBool` plus a `Notify`), so neither needs the
+        // timer or the IO driver.  A sync worker gets its own plain thread with
+        // no runtime entered, so there may not be one to borrow.
+        let recv = async {
+            futures::select_biased! {
+                // Biased so a shutdown already in flight wins over a queued
+                // message.  The loop below discards that message anyway once it
+                // sees the guard, so this only makes the exit prompter.
+                _ = shutdown.wait_for_shutdown().fuse() => None,
+                item = self.rx.recv().fuse() => Some(item),
+            }
+        };
+
+        match futures::executor::block_on(recv) {
+            // Channel produced something, or closed on its own.
+            Some(item) => {
+                self.closed |= item.is_none();
+                Ok(item)
+            }
+            // Shutdown won the race. The channel itself is untouched, so this
+            // does not mark the input closed.
+            None => Ok(None),
+        }
     }
 }
 

--- a/crates/service/src/adapters/sync_async.rs
+++ b/crates/service/src/adapters/sync_async.rs
@@ -1,4 +1,6 @@
-use crate::{AsyncServiceInput, ServiceInput, ServiceMsg, SyncServiceInput};
+use futures::FutureExt;
+
+use crate::{AsyncGuard, AsyncServiceInput, ServiceInput, ServiceMsg, SyncServiceInput};
 
 /// Adapter for using an async service input as a sync one.
 pub struct SyncAsyncInput<I> {
@@ -23,5 +25,19 @@ where
 impl<I: AsyncServiceInput> SyncServiceInput for SyncAsyncInput<I> {
     fn recv_next(&mut self) -> anyhow::Result<Option<Self::Msg>> {
         self.handle.block_on(self.inner.recv_next())
+    }
+
+    fn recv_next_until_shutdown(
+        &mut self,
+        shutdown: &(impl AsyncGuard + Sync),
+    ) -> anyhow::Result<Option<Self::Msg>> {
+        // The wrapped input may park indefinitely, so race it against shutdown
+        // rather than blocking on it alone.
+        self.handle.block_on(async {
+            futures::select_biased! {
+                _ = shutdown.wait_for_shutdown().fuse() => Ok(None),
+                item = self.inner.recv_next().fuse() => item,
+            }
+        })
     }
 }

--- a/crates/service/src/executor.rs
+++ b/crates/service/src/executor.rs
@@ -4,7 +4,13 @@ use std::future::Future;
 /// Executor for synchronous workers.
 pub trait SyncExecutor {
     /// To get shutdown signal notification.
-    type ShutdownGuard: SyncGuard + Send + 'static;
+    ///
+    /// This is also an [`AsyncGuard`] so a sync worker can wait on the shutdown
+    /// signal alongside its input instead of parking on the input alone.  See
+    /// [`SyncServiceInput::recv_next_until_shutdown`].
+    ///
+    /// [`SyncServiceInput::recv_next_until_shutdown`]: crate::SyncServiceInput::recv_next_until_shutdown
+    type ShutdownGuard: SyncGuard + AsyncGuard + Send + Sync + 'static;
 
     /// Spawn a sync worker task.
     fn spawn_sync(

--- a/crates/service/src/sync_worker.rs
+++ b/crates/service/src/sync_worker.rs
@@ -8,13 +8,13 @@ use tracing::*;
 use crate::instrumentation::{
     record_shutdown_result, OperationResult, ServiceInstrumentation, ShutdownReason,
 };
-use crate::{Response, ServiceState, SyncGuard, SyncService, SyncServiceInput};
+use crate::{AsyncGuard, Response, ServiceState, SyncGuard, SyncService, SyncServiceInput};
 
 pub(crate) fn worker_task<S: SyncService, I>(
     mut state: S::State,
     mut inp: I,
     status_tx: watch::Sender<S::Status>,
-    shutdown_guard: impl SyncGuard,
+    shutdown_guard: impl SyncGuard + AsyncGuard + Sync,
 ) -> anyhow::Result<()>
 where
     I: SyncServiceInput<Msg = S::Msg>,
@@ -52,8 +52,13 @@ where
 
     // Process each message in a loop.  We do a shutdown check after each
     // possibly long-running call.
+    //
+    // The wait for input is itself shutdown-aware: this worker owns a plain
+    // thread that nothing can cancel from outside, so a plain blocking receive
+    // would sit through a shutdown until the next message arrived (for a command
+    // channel, possibly never).
     let mut err = None;
-    while let Some(input) = inp.recv_next()? {
+    while let Some(input) = inp.recv_next_until_shutdown(&shutdown_guard)? {
         // Check after getting a new input.
         if shutdown_guard.should_shutdown() {
             info!(service.name = %service_name, "shutdown signal received");
@@ -167,11 +172,16 @@ fn handle_shutdown<S: SyncService>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
     use serde::Serialize;
-    use tokio::sync::watch;
+    use tokio::sync::{mpsc, watch, Notify};
 
     use super::*;
-    use crate::{SyncGuard, VecInput};
+    use crate::{SyncGuard, TokioMpscInput, VecInput};
 
     /// Guard that never signals shutdown.
     struct NeverShutdown;
@@ -179,6 +189,12 @@ mod tests {
     impl SyncGuard for NeverShutdown {
         fn should_shutdown(&self) -> bool {
             false
+        }
+    }
+
+    impl AsyncGuard for NeverShutdown {
+        async fn wait_for_shutdown(&self) {
+            std::future::pending().await
         }
     }
 
@@ -251,5 +267,77 @@ mod tests {
         let result = worker_task::<OkService, _>(TestState, inp, status_tx, NeverShutdown);
 
         result.expect("worker_task should return Ok when all inputs succeed");
+    }
+
+    /// Guard whose shutdown is driven by a flag we flip from the test.
+    #[derive(Clone, Default)]
+    struct FlagShutdown {
+        flag: Arc<AtomicBool>,
+        notify: Arc<Notify>,
+    }
+
+    impl FlagShutdown {
+        fn trigger(&self) {
+            self.flag.store(true, Ordering::SeqCst);
+            self.notify.notify_waiters();
+        }
+    }
+
+    impl SyncGuard for FlagShutdown {
+        fn should_shutdown(&self) -> bool {
+            self.flag.load(Ordering::SeqCst)
+        }
+    }
+
+    impl AsyncGuard for FlagShutdown {
+        async fn wait_for_shutdown(&self) {
+            while !self.should_shutdown() {
+                self.notify.notified().await;
+            }
+        }
+    }
+
+    /// A worker parked on an idle command channel must stop when shutdown is
+    /// signalled. Nothing can cancel the worker's thread from outside, so if the
+    /// wait for input ignored the guard the worker would sit here until the next
+    /// message — which, on a command channel whose senders are held for the life
+    /// of the process, may be never.
+    #[test]
+    fn worker_task_exits_while_parked_on_idle_input() {
+        // Sender stays alive for the whole test, so the channel never closes on
+        // its own and only the shutdown signal can end the wait.
+        let (_tx, rx) = mpsc::channel::<u32>(4);
+        let inp = TokioMpscInput::new(rx);
+        let (status_tx, _status_rx) = watch::channel(TestStatus);
+        let shutdown = FlagShutdown::default();
+
+        let worker_shutdown = shutdown.clone();
+        let worker = thread::spawn(move || {
+            worker_task::<OkService, _>(TestState, inp, status_tx, worker_shutdown)
+        });
+
+        // Let the worker reach the parked state before signalling, so we are
+        // testing the wait rather than the pre-loop check.
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            !worker.is_finished(),
+            "worker should be parked on the input"
+        );
+
+        shutdown.trigger();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "worker did not wake on the shutdown signal",
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        worker
+            .join()
+            .expect("worker thread panicked")
+            .expect("a shutdown is a normal exit, not an error");
     }
 }

--- a/crates/service/src/types.rs
+++ b/crates/service/src/types.rs
@@ -6,6 +6,8 @@ use std::future::Future;
 
 use serde::Serialize;
 
+use crate::AsyncGuard;
+
 /// Response from handling an input.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Response {
@@ -145,4 +147,23 @@ pub trait SyncServiceInput: ServiceInput {
     ///
     /// This is like a specialized `TryIterator`.
     fn recv_next(&mut self) -> anyhow::Result<Option<Self::Msg>>;
+
+    /// Receives the "next input", giving up and returning `Ok(None)` if
+    /// `shutdown` fires while we are waiting.
+    ///
+    /// A sync worker runs on its own thread and cannot be cancelled from
+    /// outside, so an input that parks indefinitely in [`recv_next`] would sit
+    /// through a shutdown until the next message happens to arrive.  Any input
+    /// that can block without bound should override this so the worker stops
+    /// when asked.
+    ///
+    /// The default ignores `shutdown` and defers to [`recv_next`], which is
+    /// correct for inputs that never block indefinitely (an in-memory queue, a
+    /// finite iterator).
+    fn recv_next_until_shutdown(
+        &mut self,
+        _shutdown: &(impl AsyncGuard + Sync),
+    ) -> anyhow::Result<Option<Self::Msg>> {
+        self.recv_next()
+    }
 }


### PR DESCRIPTION
## Description

A sync service worker could ignore a shutdown signal indefinitely.

The loop in `sync_worker::worker_task` only checks its shutdown guard *after* `recv_next()` returns:

```rust
while let Some(input) = inp.recv_next()? {
    if shutdown_guard.should_shutdown() { break; }
    ...
```

`recv_next()` on a command channel calls `blocking_recv()`, which parks until the next message. The channel's senders are held by a `CommandHandle` that normally lives as long as the process, so the channel never closes on its own. A worker that is idle when shutdown fires therefore stays parked until the next message happens to arrive — which for a quiet service may be never. The process then hangs until the task manager's graceful-shutdown timeout expires and it is torn down the hard way.

The async worker does not have this problem: it already `select!`s the whole loop against `wait_for_shutdown()`. This brings the sync worker to parity. A sync worker runs on a plain thread that nothing can cancel from outside, so the wait itself has to be shutdown-aware.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

Found while fixing a related shutdown bug downstream in `asm` (alpenlabs/asm#229), where the ASM worker is a sync service driven by a command channel. Independent of that fix — it is why a fatal ASM worker exit was slow to take the process down even once it was raised properly. This PR is also independent of #169; they touch different files and can land in either order.

**The design choice worth your attention.** `SyncServiceInput` gains `recv_next_until_shutdown`, with a default that delegates to the existing `recv_next`. That keeps the change non-breaking for input implementations and is correct for inputs that cannot block indefinitely — `VecInput` and `IterInput` are finite and in-memory. The two adapters that *can* park forever, `TokioMpscInput` and `SyncAsyncInput`, override it. The downside of a permissive default is that a future blocking input silently inherits the old behaviour; the alternative was a required method, which breaks every implementor for no gain in the four in-tree cases. I went with the default and documented the expectation on the trait method. Say the word if you would rather have it required.

**Why `futures::executor::block_on` in the mpsc adapter** rather than a tokio runtime: both halves of the race are purely waker-driven — a tokio mpsc channel on one side, and on the other `strata-tasks`' `ShutdownGuard`, which is an `AtomicBool` plus a `Notify`. Neither needs the timer or the IO driver. A sync worker gets a plain `std::thread` from `spawn_critical` with no runtime entered, so there may not be one to borrow. `SyncAsyncInput` already holds an explicit `Handle` and keeps using it.

I used a biased select so a shutdown already in flight beats a queued message. The loop discarded that message anyway on the next guard check, so this only makes the exit prompter — no behaviour change.

**The breaking part.** `SyncExecutor::ShutdownGuard` now additionally requires `AsyncGuard + Sync`. This only breaks an out-of-tree `SyncExecutor` whose guard cannot await a shutdown. `strata_tasks::ShutdownGuard`, the only in-tree impl, already satisfies both.

**On the test.** `worker_task_exits_while_parked_on_idle_input` holds the sender open for the whole test, so nothing but the shutdown signal can end the wait, and it sleeps first to make sure the worker is genuinely parked rather than catching the pre-loop check. I confirmed it fails against the old loop — reverting just the `recv_next_until_shutdown` call makes it fail with "worker did not wake on the shutdown signal" after its 5s deadline, and pass again with the fix.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

Full workspace `cargo test`, `cargo clippy --all-targets` and `cargo fmt --check` all pass.

## Related Issues

Unblocks prompt shutdown for alpenlabs/asm#229.
